### PR TITLE
Add a units bar, showing units inside the territory after its name in the bottom bar.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -160,15 +160,10 @@ public class BottomBar extends JPanel {
       if (production > 0) {
         resources.add(new Resource(Constants.PUS, data), production);
       }
-      final ResourceCollection resourceCollection = ta.getResources();
-      if (resourceCollection != null) {
-        resources.add(resourceCollection.getResourcesCopy());
-      }
+      Optional.ofNullable(ta.getResources()).ifPresent(r -> resources.add(r.getResourcesCopy()));
       for (final Resource resource : resources.keySet()) {
-        final JLabel resourceLabel =
-            uiContext.getResourceImageFactory().getLabel(resource, resources);
         territoryInfo.add(Box.createHorizontalStrut(10));
-        territoryInfo.add(resourceLabel);
+        territoryInfo.add(uiContext.getResourceImageFactory().getLabel(resource, resources));
       }
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -48,7 +48,6 @@ public class BottomBar extends JPanel {
 
     resourceBar = new ResourceBar(data, uiContext);
 
-
     territoryUnitsPanel = new SimpleUnitPanel(uiContext, SimpleUnitPanel.Style.SMALL_ICONS_ROW);
     territoryUnitsPanel.setBorder(new EtchedBorder(EtchedBorder.RAISED));
 
@@ -73,11 +72,9 @@ public class BottomBar extends JPanel {
         territoryInfo,
         gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.CENTER).build());
 
-
     centerPanel.add(
         territoryUnitsPanel,
         gridBuilder.gridX(2).weightX(1).anchor(GridBagConstraintsAnchor.EAST).build());
-
 
     statusMessage.setPreferredSize(new Dimension(0, 0));
     statusMessage.setBorder(new EtchedBorder(EtchedBorder.RAISED));
@@ -174,7 +171,6 @@ public class BottomBar extends JPanel {
       territoryInfo.add(resourceLabel, gridBuilder.gridX(count++).build());
     }
     SwingComponents.redraw(territoryInfo);
-
 
     var cats = UnitSeparator.categorize(territory.getUnits());
     territoryUnitsPanel.setUnitsFromCategories(cats);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.ui;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Resource;
-import games.strategy.engine.data.ResourceCollection;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.triplea.Constants;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -68,12 +68,12 @@ public class BottomBar extends JPanel {
     territoryInfo.setBorder(new EtchedBorder(EtchedBorder.RAISED));
     centerPanel.add(
         territoryInfo,
-        gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.SOUTHWEST).build());
+        gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.CENTER).build());
 
     statusMessage.setPreferredSize(new Dimension(0, 0));
     statusMessage.setBorder(new EtchedBorder(EtchedBorder.RAISED));
     centerPanel.add(
-        statusMessage, gridBuilder.gridX(3).anchor(GridBagConstraintsAnchor.EAST).build());
+        statusMessage, gridBuilder.gridX(2).anchor(GridBagConstraintsAnchor.EAST).build());
     return centerPanel;
   }
 
@@ -122,22 +122,21 @@ public class BottomBar extends JPanel {
     territoryInfo.setLayout(new BoxLayout(territoryInfo, BoxLayout.LINE_AXIS));
     territoryInfo.add(Box.createHorizontalGlue());
 
-    // Display territory effects, territory name, and resources
-    final StringBuilder territoryEffectText = new StringBuilder();
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
-    if (ta != null) {
-      final List<TerritoryEffect> territoryEffects = ta.getTerritoryEffect();
-      for (final TerritoryEffect territoryEffect : territoryEffects) {
-        try {
-          final JLabel territoryEffectLabel = new JLabel();
-          territoryEffectLabel.setToolTipText(territoryEffect.getName());
-          territoryEffectLabel.setIcon(
-              uiContext.getTerritoryEffectImageFactory().getIcon(territoryEffect.getName()));
-          territoryInfo.add(territoryEffectLabel);
-          territoryInfo.add(Box.createHorizontalStrut(10));
-        } catch (final IllegalStateException e) {
-          territoryEffectText.append(territoryEffect.getName()).append(", ");
-        }
+
+    // Display territory effects, territory name, resources and units.
+    final StringBuilder territoryEffectText = new StringBuilder();
+    final List<TerritoryEffect> territoryEffects = ta != null ? ta.getTerritoryEffect() : List.of();
+    for (final TerritoryEffect territoryEffect : territoryEffects) {
+      try {
+        final JLabel territoryEffectLabel = new JLabel();
+        territoryEffectLabel.setToolTipText(territoryEffect.getName());
+        territoryEffectLabel.setIcon(
+            uiContext.getTerritoryEffectImageFactory().getIcon(territoryEffect.getName()));
+        territoryInfo.add(territoryEffectLabel);
+        territoryInfo.add(Box.createHorizontalStrut(10));
+      } catch (final IllegalStateException e) {
+        territoryEffectText.append(territoryEffect.getName()).append(", ");
       }
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -14,11 +14,15 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridBagLayout;
 import java.awt.Image;
+import java.awt.Insets;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
@@ -63,13 +67,12 @@ public class BottomBar extends JPanel {
     centerPanel.add(
         resourceBar, gridBuilder.weightX(0).anchor(GridBagConstraintsAnchor.WEST).build());
 
-    territoryInfo.setLayout(new GridBagLayout());
+    territoryInfo.setLayout(new BoxLayout(territoryInfo, BoxLayout.LINE_AXIS));
     territoryInfo.setBorder(new EtchedBorder(EtchedBorder.RAISED));
-
     territoryInfo.setPreferredSize(new Dimension(0, 0));
     centerPanel.add(
         territoryInfo,
-        gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.WEST).build());
+        gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.SOUTHWEST).build());
 
     statusMessage.setPreferredSize(new Dimension(0, 0));
     statusMessage.setBorder(new EtchedBorder(EtchedBorder.RAISED));
@@ -109,11 +112,9 @@ public class BottomBar extends JPanel {
 
   public void setTerritory(final @Nullable Territory territory) {
     territoryInfo.removeAll();
+    territoryInfo.add(Box.createHorizontalGlue());
 
-    final var gridBuilder = new GridBagConstraintsBuilder(0, 0);
-    int gridX = 0;
     if (territory == null) {
-      territoryInfo.add(new JLabel(), gridBuilder.build());
       SwingComponents.redraw(territoryInfo);
       return;
     }
@@ -130,7 +131,7 @@ public class BottomBar extends JPanel {
           territoryEffectLabel.setIcon(
               uiContext.getTerritoryEffectImageFactory().getIcon(territoryEffect.getName()));
           territoryEffectLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
-          territoryInfo.add(territoryEffectLabel, gridBuilder.gridX(gridX++).build());
+          territoryInfo.add(territoryEffectLabel);
         } catch (final IllegalStateException e) {
           territoryEffectText.append(territoryEffect.getName()).append(", ");
         }
@@ -139,12 +140,12 @@ public class BottomBar extends JPanel {
 
     final JLabel nameLabel = new JLabel(territory.getName());
     nameLabel.setFont(nameLabel.getFont().deriveFont(Font.BOLD));
-    territoryInfo.add(nameLabel, gridBuilder.gridX(gridX++).build());
+    territoryInfo.add(nameLabel);
 
     if (territoryEffectText.length() > 0) {
       territoryEffectText.setLength(territoryEffectText.length() - 2);
       final JLabel territoryEffectTextLabel = new JLabel("(" + territoryEffectText + ")");
-      territoryInfo.add(territoryEffectTextLabel, gridBuilder.gridX(gridX++).build());
+      territoryInfo.add(territoryEffectTextLabel);
     }
 
     if (ta != null) {
@@ -161,7 +162,7 @@ public class BottomBar extends JPanel {
         final JLabel resourceLabel =
             uiContext.getResourceImageFactory().getLabel(resource, resources);
         resourceLabel.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 0));
-        territoryInfo.add(resourceLabel, gridBuilder.gridX(gridX++).build());
+        territoryInfo.add(resourceLabel);
       }
     }
 
@@ -169,9 +170,19 @@ public class BottomBar extends JPanel {
     unitsPanel.setScaleFactor(0.5);
     unitsPanel.setUnitsFromCategories(UnitSeparator.categorize(territory.getUnits()));
     unitsPanel.setBorder(BorderFactory.createEmptyBorder(0, 20, 0, 0));
-    territoryInfo.add(unitsPanel, gridBuilder.gridX(gridX).build());
+    unitsPanel.setPreferredSize(
+        new Dimension(
+            unitsPanel.getPreferredSize().width,
+            getHeight() - getBorderVerticalSpace(territoryInfo)));
+    territoryInfo.add(unitsPanel);
+    territoryInfo.add(Box.createHorizontalGlue());
 
     SwingComponents.redraw(territoryInfo);
+  }
+
+  private int getBorderVerticalSpace(JComponent c) {
+    Insets insets = c.getBorder().getBorderInsets(c);
+    return insets.top + insets.bottom;
   }
 
   public void gameDataChanged() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -131,12 +131,12 @@ public class BottomBar extends JPanel {
     final List<TerritoryEffect> territoryEffects = ta != null ? ta.getTerritoryEffect() : List.of();
     for (final TerritoryEffect territoryEffect : territoryEffects) {
       try {
-        final JLabel territoryEffectLabel = new JLabel();
-        territoryEffectLabel.setToolTipText(territoryEffect.getName());
-        territoryEffectLabel.setIcon(
+        final JLabel label = new JLabel();
+        label.setToolTipText(territoryEffect.getName());
+        label.setIcon(
             uiContext.getTerritoryEffectImageFactory().getIcon(territoryEffect.getName()));
-        territoryInfo.add(territoryEffectLabel);
-        territoryInfo.add(Box.createHorizontalStrut(10));
+        territoryInfo.add(label);
+        territoryInfo.add(Box.createHorizontalStrut(6));
       } catch (final IllegalStateException e) {
         territoryEffectText.append(territoryEffect.getName()).append(", ");
       }
@@ -146,19 +146,21 @@ public class BottomBar extends JPanel {
 
     if (territoryEffectText.length() > 0) {
       territoryEffectText.setLength(territoryEffectText.length() - 2);
-      final JLabel territoryEffectTextLabel = new JLabel("(" + territoryEffectText + ")");
+      final JLabel territoryEffectTextLabel = new JLabel(" (" + territoryEffectText + ")");
       territoryInfo.add(territoryEffectTextLabel);
     }
 
     Optional.ofNullable(ta).ifPresent(this::addTerritoryResourceDetails);
 
-    final Collection<UnitCategory> units = UnitSeparator.categorize(territory.getUnits());
-    if (!units.isEmpty()) {
-      JSeparator separator = new JSeparator(JSeparator.VERTICAL);
-      separator.setMaximumSize(new Dimension(40, getHeight()));
-      separator.setPreferredSize(separator.getMaximumSize());
-      territoryInfo.add(separator);
-      territoryInfo.add(createUnitBar(units));
+    if (uiContext.isShowUnitsInStatusBar()) {
+      final Collection<UnitCategory> units = UnitSeparator.categorize(territory.getUnits());
+      if (!units.isEmpty()) {
+        JSeparator separator = new JSeparator(JSeparator.VERTICAL);
+        separator.setMaximumSize(new Dimension(40, getHeight()));
+        separator.setPreferredSize(separator.getMaximumSize());
+        territoryInfo.add(separator);
+        territoryInfo.add(createUnitBar(units));
+      }
     }
 
     territoryInfo.add(Box.createHorizontalGlue());
@@ -190,7 +192,7 @@ public class BottomBar extends JPanel {
     }
     Optional.ofNullable(ta.getResources()).ifPresent(r -> resources.add(r.getResourcesCopy()));
     for (final Resource resource : resources.keySet()) {
-      territoryInfo.add(Box.createHorizontalStrut(10));
+      territoryInfo.add(Box.createHorizontalStrut(6));
       territoryInfo.add(uiContext.getResourceImageFactory().getLabel(resource, resources));
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -69,12 +69,6 @@ public class BottomBar extends JPanel {
         territoryInfo,
         gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.WEST).build());
 
-
-    centerPanel.add(
-        territoryUnitsPanel,
-        gridBuilder.gridX(2).weightX(1).anchor(GridBagConstraintsAnchor.EAST).build());
-
-
     statusMessage.setPreferredSize(new Dimension(0, 0));
     statusMessage.setBorder(new EtchedBorder(EtchedBorder.RAISED));
     centerPanel.add(
@@ -169,10 +163,11 @@ public class BottomBar extends JPanel {
       territoryInfo.add(resourceLabel, gridBuilder.gridX(count++).build());
     }
 
-    final var unitsPanel = new SimpleUnitPanel(uiContext, SimpleUnitPanel.Style.MINI_ICONS_ROW);
+    final var unitsPanel = new SimpleUnitPanel(uiContext, SimpleUnitPanel.Style.SMALL_ICONS_ROW);
+    unitsPanel.setScaleFactor(0.5);
     unitsPanel.setUnitsFromCategories(UnitSeparator.categorize(territory.getUnits()));
     unitsPanel.setBorder(BorderFactory.createEmptyBorder(0, 20, 0, 0));
-    territoryInfo.add(unitsPanel, gridBuilder.gridX(count++).build());
+    territoryInfo.add(unitsPanel, gridBuilder.gridX(count).build());
 
     SwingComponents.redraw(territoryInfo);
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -34,6 +34,7 @@ public class BottomBar extends JPanel {
 
   private final ResourceBar resourceBar;
   private final JPanel territoryInfo = new JPanel();
+  private final SimpleUnitPanel territoryUnitsPanel;
 
   private final JLabel statusMessage = new JLabel();
 
@@ -68,6 +69,12 @@ public class BottomBar extends JPanel {
     centerPanel.add(
         territoryInfo,
         gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.WEST).build());
+
+
+    centerPanel.add(
+        territoryUnitsPanel,
+        gridBuilder.gridX(2).weightX(1).anchor(GridBagConstraintsAnchor.EAST).build());
+
 
     statusMessage.setPreferredSize(new Dimension(0, 0));
     statusMessage.setBorder(new EtchedBorder(EtchedBorder.RAISED));
@@ -169,6 +176,11 @@ public class BottomBar extends JPanel {
     territoryInfo.add(unitsPanel, gridBuilder.gridX(count++).build());
 
     SwingComponents.redraw(territoryInfo);
+
+
+    var cats = UnitSeparator.categorize(territory.getUnits());
+    territoryUnitsPanel.setUnitsFromCategories(cats);
+    SwingComponents.redraw(territoryUnitsPanel);
   }
 
   public void gameDataChanged() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -48,10 +48,9 @@ public class BottomBar extends JPanel {
   public BottomBar(final UiContext uiContext, final GameData data, final boolean usingDiceServer) {
     this.uiContext = uiContext;
     this.data = data;
+    this.resourceBar = new ResourceBar(data, uiContext);
+
     setLayout(new BorderLayout());
-
-    resourceBar = new ResourceBar(data, uiContext);
-
     add(createCenterPanel(), BorderLayout.CENTER);
     add(createStepPanel(usingDiceServer), BorderLayout.EAST);
   }
@@ -65,9 +64,8 @@ public class BottomBar extends JPanel {
     centerPanel.add(
         resourceBar, gridBuilder.weightX(0).anchor(GridBagConstraintsAnchor.WEST).build());
 
-    territoryInfo.setLayout(new BoxLayout(territoryInfo, BoxLayout.LINE_AXIS));
-    territoryInfo.setBorder(new EtchedBorder(EtchedBorder.RAISED));
     territoryInfo.setPreferredSize(new Dimension(0, 0));
+    territoryInfo.setBorder(new EtchedBorder(EtchedBorder.RAISED));
     centerPanel.add(
         territoryInfo,
         gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.SOUTHWEST).build());
@@ -121,6 +119,7 @@ public class BottomBar extends JPanel {
     //   2. If the content is wider than the available space, then the beginning will be shown,
     //      which is the more important information (territory name, income, etc).
     //   3. Elements are vertically centered.
+    territoryInfo.setLayout(new BoxLayout(territoryInfo, BoxLayout.LINE_AXIS));
     territoryInfo.add(Box.createHorizontalGlue());
 
     // Display territory effects, territory name, and resources

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -15,6 +15,7 @@ import java.awt.GridBagLayout;
 import java.awt.Image;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -33,7 +34,6 @@ public class BottomBar extends JPanel {
 
   private final ResourceBar resourceBar;
   private final JPanel territoryInfo = new JPanel();
-  private final SimpleUnitPanel territoryUnitsPanel;
 
   private final JLabel statusMessage = new JLabel();
 
@@ -47,9 +47,6 @@ public class BottomBar extends JPanel {
     setLayout(new BorderLayout());
 
     resourceBar = new ResourceBar(data, uiContext);
-
-    territoryUnitsPanel = new SimpleUnitPanel(uiContext, SimpleUnitPanel.Style.SMALL_ICONS_ROW);
-    territoryUnitsPanel.setBorder(new EtchedBorder(EtchedBorder.RAISED));
 
     add(createCenterPanel(), BorderLayout.CENTER);
     add(createStepPanel(usingDiceServer), BorderLayout.EAST);
@@ -70,11 +67,7 @@ public class BottomBar extends JPanel {
     territoryInfo.setPreferredSize(new Dimension(0, 0));
     centerPanel.add(
         territoryInfo,
-        gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.CENTER).build());
-
-    centerPanel.add(
-        territoryUnitsPanel,
-        gridBuilder.gridX(2).weightX(1).anchor(GridBagConstraintsAnchor.EAST).build());
+        gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.WEST).build());
 
     statusMessage.setPreferredSize(new Dimension(0, 0));
     statusMessage.setBorder(new EtchedBorder(EtchedBorder.RAISED));
@@ -112,7 +105,7 @@ public class BottomBar extends JPanel {
     }
   }
 
-  public void setTerritory(final Territory territory) {
+  public void setTerritory(final @Nullable Territory territory) {
     territoryInfo.removeAll();
 
     final JLabel nameLabel = new JLabel();
@@ -150,8 +143,7 @@ public class BottomBar extends JPanel {
 
     if (territoryEffectText.length() > 0) {
       territoryEffectText.setLength(territoryEffectText.length() - 2);
-      final JLabel territoryEffectTextLabel = new JLabel();
-      territoryEffectTextLabel.setText(" (" + territoryEffectText + ")");
+      final JLabel territoryEffectTextLabel = new JLabel("(" + territoryEffectText + ")");
       territoryInfo.add(territoryEffectTextLabel, gridBuilder.gridX(count++).build());
     }
 
@@ -170,11 +162,13 @@ public class BottomBar extends JPanel {
       resourceLabel.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 0));
       territoryInfo.add(resourceLabel, gridBuilder.gridX(count++).build());
     }
-    SwingComponents.redraw(territoryInfo);
 
-    var cats = UnitSeparator.categorize(territory.getUnits());
-    territoryUnitsPanel.setUnitsFromCategories(cats);
-    SwingComponents.redraw(territoryUnitsPanel);
+    final var unitsPanel = new SimpleUnitPanel(uiContext, SimpleUnitPanel.Style.MINI_ICONS_ROW);
+    unitsPanel.setUnitsFromCategories(UnitSeparator.categorize(territory.getUnits()));
+    unitsPanel.setBorder(BorderFactory.createEmptyBorder(0, 20, 0, 0));
+    territoryInfo.add(unitsPanel, gridBuilder.gridX(count++).build());
+
+    SwingComponents.redraw(territoryInfo);
   }
 
   public void gameDataChanged() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -34,7 +34,6 @@ public class BottomBar extends JPanel {
 
   private final ResourceBar resourceBar;
   private final JPanel territoryInfo = new JPanel();
-  private final SimpleUnitPanel territoryUnitsPanel;
 
   private final JLabel statusMessage = new JLabel();
 
@@ -176,11 +175,6 @@ public class BottomBar extends JPanel {
     territoryInfo.add(unitsPanel, gridBuilder.gridX(count++).build());
 
     SwingComponents.redraw(territoryInfo);
-
-
-    var cats = UnitSeparator.categorize(territory.getUnits());
-    territoryUnitsPanel.setUnitsFromCategories(cats);
-    SwingComponents.redraw(territoryUnitsPanel);
   }
 
   public void gameDataChanged() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -129,16 +129,15 @@ public class BottomBar extends JPanel {
     // Display territory effects, territory name, resources and units.
     final StringBuilder territoryEffectText = new StringBuilder();
     final List<TerritoryEffect> territoryEffects = ta != null ? ta.getTerritoryEffect() : List.of();
-    for (final TerritoryEffect territoryEffect : territoryEffects) {
+    for (final TerritoryEffect effect : territoryEffects) {
       try {
         final JLabel label = new JLabel();
-        label.setToolTipText(territoryEffect.getName());
-        label.setIcon(
-            uiContext.getTerritoryEffectImageFactory().getIcon(territoryEffect.getName()));
+        label.setToolTipText(effect.getName());
+        label.setIcon(uiContext.getTerritoryEffectImageFactory().getIcon(effect.getName()));
         territoryInfo.add(label);
         territoryInfo.add(Box.createHorizontalStrut(6));
       } catch (final IllegalStateException e) {
-        territoryEffectText.append(territoryEffect.getName()).append(", ");
+        territoryEffectText.append(effect.getName()).append(", ");
       }
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -8,6 +8,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.util.UnitSeparator;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridBagLayout;
@@ -32,6 +33,7 @@ public class BottomBar extends JPanel {
 
   private final ResourceBar resourceBar;
   private final JPanel territoryInfo = new JPanel();
+  private final SimpleUnitPanel territoryUnitsPanel;
 
   private final JLabel statusMessage = new JLabel();
 
@@ -45,6 +47,11 @@ public class BottomBar extends JPanel {
     setLayout(new BorderLayout());
 
     resourceBar = new ResourceBar(data, uiContext);
+
+
+    territoryUnitsPanel = new SimpleUnitPanel(uiContext, SimpleUnitPanel.Style.SMALL_ICONS_ROW);
+    territoryUnitsPanel.setBorder(new EtchedBorder(EtchedBorder.RAISED));
+
     add(createCenterPanel(), BorderLayout.CENTER);
     add(createStepPanel(usingDiceServer), BorderLayout.EAST);
   }
@@ -66,10 +73,16 @@ public class BottomBar extends JPanel {
         territoryInfo,
         gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.CENTER).build());
 
+
+    centerPanel.add(
+        territoryUnitsPanel,
+        gridBuilder.gridX(2).weightX(1).anchor(GridBagConstraintsAnchor.EAST).build());
+
+
     statusMessage.setPreferredSize(new Dimension(0, 0));
     statusMessage.setBorder(new EtchedBorder(EtchedBorder.RAISED));
     centerPanel.add(
-        statusMessage, gridBuilder.gridX(2).anchor(GridBagConstraintsAnchor.EAST).build());
+        statusMessage, gridBuilder.gridX(3).anchor(GridBagConstraintsAnchor.EAST).build());
     return centerPanel;
   }
 
@@ -161,6 +174,11 @@ public class BottomBar extends JPanel {
       territoryInfo.add(resourceLabel, gridBuilder.gridX(count++).build());
     }
     SwingComponents.redraw(territoryInfo);
+
+
+    var cats = UnitSeparator.categorize(territory.getUnits());
+    territoryUnitsPanel.setUnitsFromCategories(cats);
+    SwingComponents.redraw(territoryUnitsPanel);
   }
 
   public void gameDataChanged() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -69,15 +69,12 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
               updateScheduled = false;
               final GamePlayer player;
               final IntegerMap<Resource> resourceIncomes;
-              try {
-                gameData.acquireReadLock();
+              try (GameData.Unlocker ignored = gameData.acquireReadLock()){
                 player = gameData.getSequence().getStep().getPlayerId();
                 if (player == null) {
                   return;
                 }
                 resourceIncomes = AbstractEndTurnDelegate.findEstimatedIncome(player, gameData);
-              } finally {
-                gameData.releaseReadLock();
               }
               SwingUtilities.invokeLater(
                   () -> {
@@ -95,7 +92,7 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
                       text.append(" (").append(income >= 0 ? "+" : "").append(income).append(")");
                       final JLabel label =
                           uiContext.getResourceImageFactory().getLabel(resource, text.toString());
-                      label.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 10));
+                      label.setBorder(BorderFactory.createEmptyBorder(0, 6, 0, 6));
                       add(label, new GridBagConstraintsBuilder(count++, 0).weightY(1).build());
                     }
                   });

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -69,7 +69,7 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
               updateScheduled = false;
               final GamePlayer player;
               final IntegerMap<Resource> resourceIncomes;
-              try (GameData.Unlocker ignored = gameData.acquireReadLock()){
+              try (GameData.Unlocker ignored = gameData.acquireReadLock()) {
                 player = gameData.getSequence().getStep().getPlayerId();
                 if (player == null) {
                   return;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -19,12 +19,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.border.Border;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.WrapLayout;
@@ -155,7 +153,13 @@ public class SimpleUnitPanel extends JPanel {
         log.error("missing unit icon (won't be displayed): " + imageName + ", " + imageKey);
       }
       if (style == Style.SMALL_ICONS_ROW) {
-        Image newimg = icon.get().getImage().getScaledInstance(icon.get().getIconWidth()/2, icon.get().getIconHeight()/2,  java.awt.Image.SCALE_SMOOTH);
+        Image newimg =
+            icon.get()
+                .getImage()
+                .getScaledInstance(
+                    icon.get().getIconWidth() / 2,
+                    icon.get().getIconHeight() / 2,
+                    java.awt.Image.SCALE_SMOOTH);
         icon = Optional.of(new ImageIcon(newimg));
       }
       icon.ifPresent(label::setIcon);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -13,15 +13,18 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.util.UnitCategory;
+import java.awt.Image;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.border.Border;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.WrapLayout;
@@ -35,6 +38,7 @@ public class SimpleUnitPanel extends JPanel {
 
   public enum Style {
     LARGE_ICONS_COLUMN,
+    SMALL_ICONS_ROW,
     SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY
   }
 
@@ -47,6 +51,8 @@ public class SimpleUnitPanel extends JPanel {
     this.style = style;
     if (style == Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY) {
       setLayout(new WrapLayout());
+    } else if (style == Style.SMALL_ICONS_ROW) {
+      setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
     } else {
       setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     }
@@ -132,7 +138,7 @@ public class SimpleUnitPanel extends JPanel {
       final boolean damaged,
       final boolean disabled) {
     final JLabel label = new JLabel();
-    label.setText(" x " + quantity);
+    label.setText(" x " + quantity + " ");
     if (unit instanceof UnitType) {
       final UnitType unitType = (UnitType) unit;
 
@@ -143,10 +149,14 @@ public class SimpleUnitPanel extends JPanel {
               .damaged(damaged)
               .disabled(disabled)
               .build();
-      final Optional<ImageIcon> icon = uiContext.getUnitImageFactory().getIcon(imageKey);
+      Optional<ImageIcon> icon = uiContext.getUnitImageFactory().getIcon(imageKey);
       if (icon.isEmpty() && !uiContext.isShutDown()) {
         final String imageName = imageKey.getFullName();
         log.error("missing unit icon (won't be displayed): " + imageName + ", " + imageKey);
+      }
+      if (style == Style.SMALL_ICONS_ROW) {
+        Image newimg = icon.get().getImage().getScaledInstance(icon.get().getIconWidth()/2, icon.get().getIconHeight()/2,  java.awt.Image.SCALE_SMOOTH);
+        icon = Optional.of(new ImageIcon(newimg));
       }
       icon.ifPresent(label::setIcon);
       MapUnitTooltipManager.setUnitTooltip(label, unitType, player, quantity);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -36,7 +36,7 @@ public class SimpleUnitPanel extends JPanel {
 
   public enum Style {
     LARGE_ICONS_COLUMN,
-    SMALL_ICONS_ROW,
+    MINI_ICONS_ROW,
     SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY
   }
 
@@ -49,7 +49,7 @@ public class SimpleUnitPanel extends JPanel {
     this.style = style;
     if (style == Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY) {
       setLayout(new WrapLayout());
-    } else if (style == Style.SMALL_ICONS_ROW) {
+    } else if (style == Style.MINI_ICONS_ROW) {
       setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
     } else {
       setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
@@ -152,7 +152,7 @@ public class SimpleUnitPanel extends JPanel {
         final String imageName = imageKey.getFullName();
         log.error("missing unit icon (won't be displayed): " + imageName + ", " + imageKey);
       }
-      if (style == Style.SMALL_ICONS_ROW) {
+      if (style == Style.MINI_ICONS_ROW) {
         Image newimg =
             icon.get()
                 .getImage()

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -19,10 +19,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.border.Border;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.WrapLayout;
@@ -36,7 +38,7 @@ public class SimpleUnitPanel extends JPanel {
 
   public enum Style {
     LARGE_ICONS_COLUMN,
-    MINI_ICONS_ROW,
+    SMALL_ICONS_ROW,
     SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY
   }
 
@@ -49,7 +51,7 @@ public class SimpleUnitPanel extends JPanel {
     this.style = style;
     if (style == Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY) {
       setLayout(new WrapLayout());
-    } else if (style == Style.MINI_ICONS_ROW) {
+    } else if (style == Style.SMALL_ICONS_ROW) {
       setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
     } else {
       setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
@@ -152,14 +154,8 @@ public class SimpleUnitPanel extends JPanel {
         final String imageName = imageKey.getFullName();
         log.error("missing unit icon (won't be displayed): " + imageName + ", " + imageKey);
       }
-      if (style == Style.MINI_ICONS_ROW) {
-        Image newimg =
-            icon.get()
-                .getImage()
-                .getScaledInstance(
-                    icon.get().getIconWidth() / 2,
-                    icon.get().getIconHeight() / 2,
-                    java.awt.Image.SCALE_SMOOTH);
+      if (style == Style.SMALL_ICONS_ROW) {
+        Image newimg = icon.get().getImage().getScaledInstance(icon.get().getIconWidth()/2, icon.get().getIconHeight()/2,  java.awt.Image.SCALE_SMOOTH);
         icon = Optional.of(new ImageIcon(newimg));
       }
       icon.ifPresent(label::setIcon);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -35,6 +36,7 @@ public class SimpleUnitPanel extends JPanel {
   private final UiContext uiContext;
   private final Style style;
   @Setter private double scaleFactor = 1.0;
+  @Setter private boolean showCountsForSingleUnits = true;
 
   public enum Style {
     LARGE_ICONS_COLUMN,
@@ -138,10 +140,11 @@ public class SimpleUnitPanel extends JPanel {
       final boolean damaged,
       final boolean disabled) {
     final JLabel label = new JLabel();
-    label.setText(" x " + quantity + " ");
+    if (showCountsForSingleUnits || quantity > 1) {
+      label.setText("x " + quantity);
+    }
     if (unit instanceof UnitType) {
       final UnitType unitType = (UnitType) unit;
-
       final UnitImageFactory.ImageKey imageKey =
           UnitImageFactory.ImageKey.builder()
               .player(player)
@@ -165,6 +168,9 @@ public class SimpleUnitPanel extends JPanel {
       label.setIcon(scaleIcon(icon, scaleFactor));
     }
     add(label);
+    if (style == Style.SMALL_ICONS_ROW) {
+      add(Box.createHorizontalStrut(8));
+    }
   }
 
   private static ImageIcon scaleIcon(ImageIcon icon, double scaleFactor) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -199,7 +199,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   @Getter private final ButtonModel editModeButtonModel;
   @Getter private IEditDelegate editDelegate;
   private final JSplitPane gameCenterPanel;
-  private final BottomBar bottomBar;
+  @Getter private final BottomBar bottomBar;
   private GamePlayer lastStepPlayer;
   private GamePlayer currentStepPlayer;
   private final Map<GamePlayer, Boolean> requiredTurnSeries = new HashMap<>();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -74,6 +74,7 @@ public class UiContext {
   private final DiceImageFactory diceImageFactory;
   private final PuImageFactory puImageFactory = new PuImageFactory();
   private boolean drawUnits = true;
+  @Getter @Setter private boolean showUnitsInStatusBar = true;
   private boolean drawTerritoryEffects;
 
   @Getter private Cursor cursor;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -74,6 +74,7 @@ final class ViewMenu extends JMenu {
     addUnitSizeMenu();
     addLockMap();
     addShowUnitsMenu();
+    addShowUnitsInStatusBarMenu();
     addFlagDisplayModeMenu();
 
     if (uiContext.getMapData().useTerritoryEffectMarkers()) {
@@ -213,7 +214,7 @@ final class ViewMenu extends JMenu {
     unitSizeGroup.add(radioItem56);
     unitSizeGroup.add(radioItem50);
     radioItem100.setSelected(true);
-    // select the closest to to the default size
+    // select the closest to the default size
     final Enumeration<AbstractButton> enum1 = unitSizeGroup.getElements();
     boolean matchFound = false;
     while (enum1.hasMoreElements()) {
@@ -317,11 +318,22 @@ final class ViewMenu extends JMenu {
     showUnitsBox.setSelected(true);
     showUnitsBox.addActionListener(
         e -> {
-          final boolean tfselected = showUnitsBox.isSelected();
-          uiContext.setShowUnits(tfselected);
+          uiContext.setShowUnits(showUnitsBox.isSelected());
           frame.getMapPanel().resetMap();
         });
     add(showUnitsBox);
+  }
+
+  private void addShowUnitsInStatusBarMenu() {
+    JCheckBoxMenuItem checkbox = new JCheckBoxMenuItem("Show Units in Status Bar");
+    checkbox.setSelected(true);
+    checkbox.addActionListener(
+        e -> {
+          uiContext.setShowUnitsInStatusBar(checkbox.isSelected());
+          // Trigger a bottom bar update.
+          frame.getBottomBar().setTerritory(frame.getMapPanel().getCurrentTerritory());
+        });
+    add(checkbox);
   }
 
   private void addMapFontAndColorEditorMenu() {
@@ -423,8 +435,7 @@ final class ViewMenu extends JMenu {
     territoryEffectsBox.setMnemonic(KeyEvent.VK_T);
     territoryEffectsBox.addActionListener(
         e -> {
-          final boolean tfselected = territoryEffectsBox.isSelected();
-          uiContext.setShowTerritoryEffects(tfselected);
+          uiContext.setShowTerritoryEffects(territoryEffectsBox.isSelected());
           frame.getMapPanel().resetMap();
         });
     add(territoryEffectsBox);


### PR DESCRIPTION
## Change Summary & Additional Notes
Add a units bar to the main UI, showing units inside the territory after its name at the bottom of the screen.
This feature makes it easy to see which units exist in the given territory, without having to open the battle calculator or switching to the territory tab (which loses focus on that territory when you move the mouse). This is especially helpful on some maps where there are small territories that can get cluttered with units and it's hard to see exactly what's there.

This change makes it so the units in the territory under the cursor are shown at the bottom of the screen, in the same cell in the bottom bar where the territory name is.

I've taken special care to test that this works well on a variety of maps and results in consistently good looking results.

In particular:
  - The content of the cell continues to be centered.
  - On smaller screens, priority is given to the territory name / resources if not everything can fit.
  - It works well with a variety of image sizes and presence of larger images doesn't cause layout issues.
  - A menu item is added to toggle the display of this bar, so users who don't like it can turn it off.


Tested on maps:
  - Pacific Theatre Solo Challenge
  - Civil War: Eastern Campaigns
    - This map has some units that are slightly taller, so verified they don't cause alignment issues
    - This map has some territories with no resources / units, verified that territory name label has consistent alignment
  - Warcraft
  - Star Trek Dilithium War
  - WW2 Oil and Snow
  - Conquest of the World
  - Another World
  - 1914-COW-Empires
  - Feudal Japan
  - Feudal Japan Warlords
  - 270BC Wars

Tested manually resizing window to smaller and larger sizes to verify layouts on different screen sizes.

Screenshots:

*Pacific Theatre Solo Challenge*, mouse over SZ 46 which has a big fleet:
![units_bar_pacific](https://user-images.githubusercontent.com/17648/170357387-9bdeaffb-9220-4a35-8f59-f39849a2258a.png)

*Civil War: Eastern Campaigns*:
  - Cut off behavior when units don't fully fit the alloted space (I found the territory with most unit types and resized my window down to see this behavior).
  - OK handling of units that may be a bit taller (they just get cut off without causing other layout issues)
![units_bar_civil_war](https://user-images.githubusercontent.com/17648/170357807-6d7fdb0e-46c3-4129-855f-8441d9224841.png)

*Warcraft*:
  - Larger image sizes get cut off in a sensible way
![units_bar_warcraft](https://user-images.githubusercontent.com/17648/170358150-6e6e1165-a213-4b10-8dda-f989fca32984.png)

*Conquest of the World*:
  - This map uses very large unit images. The unit bar doesn't look amazing, but also doesn't break catastrophically either. (Note: This map is not in the repo and must be downloaded manually from github). I've also not seen other maps using such extreme image sizes and every map I've tried otherwise generally looked reasonable.
![unit_bar_conquest_of_the_world](https://user-images.githubusercontent.com/17648/170359498-4c588811-5ec0-4547-b157-4ceb5accc897.png)


## Release Note
<!--

Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->NEW|The selected territory's units will now be shown at the bottom of the screen<!--END_RELEASE_NOTE-->
