### PR TITLE
Remove some unnecessary sleep invocations & clean up some code.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -11,6 +11,7 @@ import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.posted.game.pbem.PbemMessagePoster;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.util.ArrayList;
@@ -182,12 +183,12 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
       return false;
     }
     // there is an issue with maps using thousands of chance triggers: they are causing the cypted
-    // random source (ie:
-    // live and pbem games) to lock up or error out
-    // so we need to slow them down a bit, until we come up with a better solution (like aggregating
-    // all the chances
-    // together, then getting a ton of random numbers at once instead of one at a time)
-    Interruptibles.sleep(100);
+    // random source (ie: live and pbem games) to lock up or error out so we need to slow them down
+    // a bit, until we come up with a better solution (like aggregating all the chances together,
+    // then getting a ton of random numbers at once instead of one at a time)
+    if (PbemMessagePoster.gameDataHasPlayByEmailOrForumMessengers(getData())) {
+      Interruptibles.sleep(100);
+    }
     final int rollResult =
         bridge.getRandom(
                 diceSides,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -20,6 +20,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.posted.game.pbem.PbemMessagePoster;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
@@ -857,12 +858,12 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         changeChanceDecrementOrIncrementOnSuccessOrFailure(delegateBridge, objectiveMet, false);
       } else {
         // there is an issue with maps using thousands of chance triggers: they are causing the
-        // crypted random source
-        // (i.e.: live and pbem games) to lock up or error out
-        // so we need to slow them down a bit, until we come up with a better solution (like
-        // aggregating all the chances
-        // together, then getting a ton of random numbers at once instead of one at a time)
-        Interruptibles.sleep(100);
+        // cypted random source (ie: live and pbem games) to lock up or error out so we need to slow
+        // them down a bit, until we come up with a better solution (like aggregating all the
+        // chances together, then getting a ton of random numbers at once instead of one at a time)
+        if (PbemMessagePoster.gameDataHasPlayByEmailOrForumMessengers(data)) {
+          Interruptibles.sleep(100);
+        }
         final int rollResult =
             delegateBridge.getRandom(
                     diceSides,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -529,13 +529,13 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
         }
         if (numberOfDice > 0) {
           // there is an issue with maps that have lots of rolls without any pause between them:
-          // they are causing the
-          // crypted random source (ie: live and pbem games) to lock up or error out
-          // so we need to slow them down a bit, until we come up with a better solution (like
-          // aggregating all the
-          // chances together, then getting a ton of random numbers at once instead of one at a
-          // time)
-          Interruptibles.sleep(100);
+          // they are causing the crypted random source (ie: live and pbem games) to lock up or
+          // error out so we need to slow them down a bit, until we come up with a better solution
+          // (like aggregating all the chances together, then getting a ton of random numbers at
+          // once instead of one at a time)
+          if (PbemMessagePoster.gameDataHasPlayByEmailOrForumMessengers(data)) {
+            Interruptibles.sleep(100);
+          }
           final String transcript = "Rolling for Convoy Blockade Damage in " + b.getName();
           final int[] dice =
               bridge.getRandom(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -101,32 +101,14 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           }
         }
         if (!toAdd.isEmpty()) {
-          final String transcriptText =
-              player.getName()
-                  + " creates "
-                  + MyFormatter.unitsToTextNoOwner(toAdd)
-                  + " in "
-                  + t.getName();
-          bridge.getHistoryWriter().startEvent(transcriptText, toAdd);
-          endTurnReport.append(transcriptText).append("<br />");
-          final Change place = ChangeFactory.addUnits(t, toAdd);
-          change.add(place);
+          createUnits(t, toAdd, change, endTurnReport);
         }
         if (!toAddSea.isEmpty()) {
           final Predicate<Territory> myTerrs = Matches.territoryIsWater();
           final Collection<Territory> waterNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (!waterNeighbors.isEmpty()) {
-            final Territory tw = getRandomTerritory(data, waterNeighbors, bridge);
-            final String transcriptText =
-                player.getName()
-                    + " creates "
-                    + MyFormatter.unitsToTextNoOwner(toAddSea)
-                    + " in "
-                    + tw.getName();
-            bridge.getHistoryWriter().startEvent(transcriptText, toAddSea);
-            endTurnReport.append(transcriptText).append("<br />");
-            final Change place = ChangeFactory.addUnits(tw, toAddSea);
-            change.add(place);
+            final Territory location = getRandomTerritory(data, waterNeighbors, bridge);
+            createUnits(location, toAddSea, change, endTurnReport);
           }
         }
         if (!toAddLand.isEmpty()) {
@@ -134,17 +116,8 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
               Matches.isTerritoryOwnedBy(player).and(Matches.territoryIsLand());
           final Collection<Territory> landNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (!landNeighbors.isEmpty()) {
-            final Territory tl = getRandomTerritory(data, landNeighbors, bridge);
-            final String transcriptText =
-                player.getName()
-                    + " creates "
-                    + MyFormatter.unitsToTextNoOwner(toAddLand)
-                    + " in "
-                    + tl.getName();
-            bridge.getHistoryWriter().startEvent(transcriptText, toAddLand);
-            endTurnReport.append(transcriptText).append("<br />");
-            final Change place = ChangeFactory.addUnits(tl, toAddLand);
-            change.add(place);
+            final Territory location = getRandomTerritory(data, landNeighbors, bridge);
+            createUnits(location, toAddLand, change, endTurnReport);
           }
         }
       }
@@ -153,6 +126,23 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
       bridge.addChange(change);
     }
     return endTurnReport.toString();
+  }
+
+  private void createUnits(
+      final Territory location,
+      Collection<Unit> units,
+      CompositeChange change,
+      StringBuilder endTurnReport) {
+    final String transcriptText =
+        player.getName()
+            + " creates "
+            + MyFormatter.unitsToTextNoOwner(units)
+            + " in "
+            + location.getName();
+    bridge.getHistoryWriter().startEvent(transcriptText, units);
+    endTurnReport.append(transcriptText).append("<br />");
+    final Change place = ChangeFactory.addUnits(location, units);
+    change.add(place);
   }
 
   private static Territory getRandomTerritory(

--- a/lib/java-extras/src/main/java/org/triplea/java/Interruptibles.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/Interruptibles.java
@@ -105,6 +105,10 @@ public final class Interruptibles {
    * @throws IllegalArgumentException If {@code millis} is negative.
    */
   public static boolean sleep(final long millis) {
+    if (millis == 0) {
+      return true;
+    }
+    new Exception().printStackTrace();
     return await(() -> Thread.sleep(millis));
   }
 

--- a/lib/java-extras/src/main/java/org/triplea/java/Interruptibles.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/Interruptibles.java
@@ -108,7 +108,6 @@ public final class Interruptibles {
     if (millis == 0) {
       return true;
     }
-    new Exception().printStackTrace();
     return await(() -> Thread.sleep(millis));
   }
 


### PR DESCRIPTION
## Change Summary & Additional Notes

This change removes some unnecessary sleep invocations that exist to work around excessive calls to remote random servers like PBEM by wrapping the logic in a PBEM-check block.

Additionally, cleans up comment formatting and makes sleeps calls with value 0 (which can happen per engine settings) to be no-ops. 

Also cleans up some redundant checks that are always true.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
