### PR TITLE
Improve keyboard shortcuts on Mac.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -100,10 +100,10 @@ final class FileMenu extends JMenu {
         new JMenuItem(SwingAction.of("Leave Game", e -> frame.leaveGame()));
     leaveGameMenuExit.setMnemonic(KeyEvent.VK_L);
     if (isMac) { // On Mac OS X, the command-Q is reserved for the Quit action,
-      // so set the command-L key combo for the Leave Game action
+      // so set the command-W key combo for the Leave Game action
       leaveGameMenuExit.setAccelerator(
           KeyStroke.getKeyStroke(
-              KeyEvent.VK_L, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+              KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
     } else { // On non-Mac operating systems, set the Ctrl-Q key combo for the Leave Game action
       leaveGameMenuExit.setAccelerator(
           KeyStroke.getKeyStroke(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -154,9 +154,10 @@ final class GameMenu extends JMenu {
                       frame, scroll, "Politics Panel", JOptionPane.PLAIN_MESSAGE);
                 }));
     politicsMenuItem.setMnemonic(KeyEvent.VK_P);
+    // On Mac, Cmd-W is the standard "close window" shortcut, which we use for "Leave Game".
+    final int keyCode = (SystemProperties.isMac() ? KeyEvent.VK_P : KeyEvent.VK_W);
     politicsMenuItem.setAccelerator(
-        KeyStroke.getKeyStroke(
-            KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+        KeyStroke.getKeyStroke(keyCode, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
   }
 
   private void addNotificationSettings() {


### PR DESCRIPTION
## Change Summary & Additional Notes

On Mac, cmd-w is the standard shortcut for closing the window. So map it to "leave game". Change the shortcut for politics panel on Mac since cmd-w is not taken.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
