### PR TITLE
Fix refresh of PickTerritoryAndUnitsPanel (random start delegate UI).

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -25,6 +25,7 @@ import org.triplea.java.collections.CollectionUtils;
 import org.triplea.swing.EventThreadJOptionPane;
 import org.triplea.swing.EventThreadJOptionPane.ConfirmDialogType;
 import org.triplea.swing.SwingAction;
+import org.triplea.swing.SwingComponents;
 import org.triplea.util.Tuple;
 
 /** For choosing territories and units for them, during RandomStartDelegate. */
@@ -159,6 +160,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
           doneButton = new JButton(doneAction);
           doneButton.setToolTipText(ActionButtons.DONE_BUTTON_TOOLTIP);
           add(doneButton);
+          SwingComponents.redraw(this);
           SwingUtilities.invokeLater(() -> selectTerritoryButton.requestFocusInWindow());
         });
   }


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix refresh of PickTerritoryAndUnitsPanel (random start delegate UI).

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->Fix|Refresh issue with random start pick territory UI<!--END_RELEASE_NOTE-->
