### PR TITLE
Fix history related errors caused by some changes being done twice.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
@@ -50,7 +50,7 @@ public class ResourceCollection extends GameDataComponent {
     final int current = getQuantity(resource);
     if ((current - quantity) < 0) {
       throw new IllegalArgumentException(
-          "Cant remove more than player has of resource: "
+          "Can't remove more than player has of resource: "
               + resource.getName()
               + ". current:"
               + current
@@ -58,10 +58,6 @@ public class ResourceCollection extends GameDataComponent {
               + quantity);
     }
     change(resource, -quantity);
-  }
-
-  public void removeAllOfResource(final Resource resource) {
-    resources.removeKey(resource);
   }
 
   private void change(final Resource resource, final int quantity) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -88,7 +88,7 @@ public class History extends DefaultTreeModel {
     } else if (node instanceof EventChild) {
       lastChangeIndex = ((Event) node.getParent()).getChangeEndIndex();
     } else if (node instanceof IndexedHistoryNode) {
-      lastChangeIndex = ((IndexedHistoryNode) node).getChangeStartIndex();
+      lastChangeIndex = ((IndexedHistoryNode) node).getChangeEndIndex();
     } else {
       lastChangeIndex = 0;
     }
@@ -114,7 +114,7 @@ public class History extends DefaultTreeModel {
   /** Changes the game state to reflect the historical state at {@code node}. */
   public synchronized void gotoNode(final HistoryNode node) {
     assertCorrectThread();
-    getGameData().acquireWriteLock();
+    gameData.acquireWriteLock();
     try {
       if (currentNode == null) {
         currentNode = getLastNode();
@@ -125,7 +125,7 @@ public class History extends DefaultTreeModel {
         gameData.performChange(dataChange);
       }
     } finally {
-      getGameData().releaseWriteLock();
+      gameData.releaseWriteLock();
     }
   }
 
@@ -136,7 +136,7 @@ public class History extends DefaultTreeModel {
   public synchronized void removeAllHistoryAfterNode(final HistoryNode removeAfterNode) {
     gotoNode(removeAfterNode);
     assertCorrectThread();
-    getGameData().acquireWriteLock();
+    gameData.acquireWriteLock();
     try {
       final int lastChange = getLastChange(removeAfterNode) + 1;
       while (changes.size() > lastChange) {
@@ -163,7 +163,7 @@ public class History extends DefaultTreeModel {
         this.removeNodeFromParent(nodesToRemove.remove(0));
       }
     } finally {
-      getGameData().releaseWriteLock();
+      gameData.releaseWriteLock();
     }
   }
 


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix history related errors caused by some changes being done twice.

When you're not the active player, the game operates on a history view where events are added and changes are applied.
In some circumstances, the previous code would result in the same change being applied twice, which can result in an error - for example, in a custom map I have, I have a trigger that resets a resource to 0, which would sometimes trigger an error like "Ca't remove more than player has of resource:".

The root cause was a logic error in getLastChange(). When the current node was a Step node (and thus a IndexedHistoryNode), it would return its first change, rather than its last change. This would result in the history model "fast-forwarding" to apply its other changes, applying changes that were already applied.

I looked where the logic was first added and it looks like the bug existed in the very first implementation of history, here: https://github.com/triplea-game/triplea/commit/4ddf7a05237ea1e584bef959874c0b3697839988

A few small bits of clean up are included.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Some errors related to history view<!--END_RELEASE_NOTE-->
