### PR TITLE
Convert getOrDefault() that creating collections to computeIfAbsent.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -780,15 +780,12 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
       for (final Entry<Territory, IntegerMap<Unit>> selectionEntry : selection.entrySet()) {
         final Territory territory = selectionEntry.getKey();
         final Map<Unit, IntegerMap<Resource>> currentTerr =
-            kamikazeSuicideAttacks.getOrDefault(territory, new HashMap<>());
+            kamikazeSuicideAttacks.computeIfAbsent(territory, key -> new HashMap<>());
         for (final Entry<Unit, Integer> unitEntry : selectionEntry.getValue().entrySet()) {
           final Unit unit = unitEntry.getKey();
-          final IntegerMap<Resource> currentUnit =
-              currentTerr.getOrDefault(unit, new IntegerMap<>());
-          currentUnit.add(resource, unitEntry.getValue());
-          currentTerr.put(unit, currentUnit);
+          final Integer amount = unitEntry.getValue();
+          currentTerr.computeIfAbsent(unit, key -> new IntegerMap<>()).add(resource, amount);
         }
-        kamikazeSuicideAttacks.put(territory, currentTerr);
       }
     }
     return kamikazeSuicideAttacks;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
@@ -309,10 +309,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
                 (UnitAttachment.get(u.getType()).getHitPoints()
                     * (Math.random() < .3 ? 1 : (Math.random() < .5 ? 2 : 3))));
         resourceMap.put(resource, num);
-        final Map<Unit, IntegerMap<Resource>> attMap =
-            kamikazeSuicideAttacks.getOrDefault(t, new HashMap<>());
-        attMap.put(u, resourceMap);
-        kamikazeSuicideAttacks.put(t, attMap);
+        kamikazeSuicideAttacks.computeIfAbsent(t, key -> new HashMap<>()).put(u, resourceMap);
         attackTokens.add(resource, -num);
         if (attackTokens.getInt(resource) <= 0) {
           attackTokens.removeKey(resource);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -480,7 +480,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     final String unitType = s[0];
     // validate that this unit exists in the xml
     final UnitType ut = getUnitType(unitType);
-    final Set<String> abilities = unitAbilitiesGained.getOrDefault(ut, new HashSet<>());
+    final Set<String> abilities = unitAbilitiesGained.computeIfAbsent(ut, key -> new HashSet<>());
     // start at 1
     for (int i = 1; i < s.length; i++) {
       final String ability = s[i];
@@ -494,7 +494,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
       }
       abilities.add(ability);
     }
-    unitAbilitiesGained.put(ut, abilities);
   }
 
   private void setUnitAbilitiesGained(final Map<UnitType, Set<String>> value) {
@@ -678,10 +677,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
         final Map<String, Set<UnitType>> mapAa = taa.getAirborneTargettedByAa();
         if (mapAa != null && !mapAa.isEmpty()) {
           for (final Entry<String, Set<UnitType>> entry : mapAa.entrySet()) {
-            final Set<UnitType> current =
-                airborneTargettedByAa.getOrDefault(entry.getKey(), new HashSet<>());
-            current.addAll(entry.getValue());
-            airborneTargettedByAa.put(entry.getKey(), current);
+            airborneTargettedByAa
+                .computeIfAbsent(entry.getKey(), key -> new HashSet<>())
+                .addAll(entry.getValue());
           }
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -1298,10 +1298,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             continue;
           }
         }
-        final Collection<Territory> currentTerrs =
-            kamikazeZonesByEnemy.getOrDefault(owner, new ArrayList<>());
-        currentTerrs.add(t);
-        kamikazeZonesByEnemy.put(owner, currentTerrs);
+        kamikazeZonesByEnemy.computeIfAbsent(owner, key -> new ArrayList<>()).add(t);
       }
     }
     if (kamikazeZonesByEnemy.isEmpty()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
@@ -152,15 +152,11 @@ public class ScrambleLogic {
             ((DependentBattle) battle).getAmphibiousAttackTerritories();
         amphibFromTerrs.removeAll(territoriesWithBattlesWater);
         for (final Territory amphibFrom : amphibFromTerrs) {
-          final Set<Territory> canScrambleFrom =
-              scrambleTerrs.getOrDefault(amphibFrom, new HashSet<>());
           if (toAnyAmphibious) {
-            canScrambleFrom.addAll(getCanScrambleFromTerritories(amphibFrom));
+            final Collection<Territory> territories = getCanScrambleFromTerritories(amphibFrom);
+            scrambleTerrs.computeIfAbsent(amphibFrom, key -> new HashSet<>()).addAll(territories);
           } else if (canScrambleFromPredicate.test(battleTerr)) {
-            canScrambleFrom.add(battleTerr);
-          }
-          if (!canScrambleFrom.isEmpty()) {
-            scrambleTerrs.put(amphibFrom, canScrambleFrom);
+            scrambleTerrs.computeIfAbsent(amphibFrom, key -> new HashSet<>()).add(battleTerr);
           }
         }
       }


### PR DESCRIPTION
## Change Summary & Additional Notes

Convert getOrDefault() calls that create collections to computeIfAbsent(). These are cheaper since the empty collections are not constructed if present and can avoid an extra put() call afterward, since computeIfAbsent() will add the new value, unlike getOrDefault().

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
