### PR TITLE
Small refinements to action panel UIs.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -45,12 +45,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
 
   private final JButton cancelMoveButton =
       new JButtonBuilder().title("Cancel").actionListener(this::cancelMove).build();
-  private final JButton doneButton =
-      new JButtonBuilder()
-          .title("Done")
-          .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
-          .actionListener(this::performDone)
-          .build();
+  private final JButton doneButton = createDoneButton();
   private final JButton undoAllButton =
       new JButtonBuilder().title("Undo All").actionListener(this::undoAll).build();
 
@@ -158,7 +153,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
     return error;
   }
 
-  private final void undoAll() {
+  private void undoAll() {
     final int moveCount = getUndoableMoves().size();
     final boolean suppressErrorMsgToUser = true;
     for (int i = moveCount - 1; i >= 0; i--) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -7,12 +7,14 @@ import java.awt.Dimension;
 import java.util.concurrent.CountDownLatch;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.SwingComponents;
 
@@ -108,6 +110,14 @@ public abstract class ActionPanel extends JPanel {
   public void display(final GamePlayer player) {
     currentPlayer = player;
     setActive(true);
+  }
+
+  protected JButton createDoneButton() {
+    return new JButtonBuilder()
+        .title("Done")
+        .actionListener(this::performDone)
+        .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
+        .build();
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.swing.EventThreadJOptionPane;
 import org.triplea.swing.EventThreadJOptionPane.ConfirmDialogType;
-import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
 import org.triplea.util.Tuple;
 
@@ -43,8 +42,6 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
   private int unitsPerPick = 1;
   private Action currentAction = null;
   private @Nullable Territory currentHighlightedTerritory;
-
-  private final Action doneAction = SwingAction.of("Done", this::performDone);
 
   private final Action selectUnitsAction =
       new AbstractAction("Select Units") {
@@ -87,8 +84,8 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
             if (!territoryChoices.contains(territory)) {
               EventThreadJOptionPane.showMessageDialog(
                   parent,
-                  "Must Pick An Unowned Territory (will have a white highlight)",
-                  "Must Pick An Unowned Territory",
+                  "You must pick an unowned land territory (will have a white highlight)",
+                  "Must Pick An Unowned Land Territory",
                   JOptionPane.WARNING_MESSAGE);
               return;
             }
@@ -157,8 +154,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
           add(selectTerritoryButton);
           selectUnitsButton = new JButton(selectUnitsAction);
           add(selectUnitsButton);
-          doneButton = new JButton(doneAction);
-          doneButton.setToolTipText(ActionButtons.DONE_BUTTON_TOOLTIP);
+          doneButton = createDoneButton();
           add(doneButton);
           SwingComponents.redraw(this);
           SwingUtilities.invokeLater(() -> selectTerritoryButton.requestFocusInWindow());
@@ -167,7 +163,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
 
   @Override
   public void performDone() {
-    currentAction = doneAction;
+    currentAction = doneButton.getAction();
     setWidgetActivation();
     if (pickedTerritory == null || !territoryChoices.contains(pickedTerritory)) {
       EventThreadJOptionPane.showMessageDialog(
@@ -263,11 +259,11 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
         () -> {
           if (!isActive()) {
             // current turn belongs to remote player or AI player
-            doneAction.setEnabled(false);
+            doneButton.setEnabled(false);
             selectUnitsAction.setEnabled(false);
             selectTerritoryAction.setEnabled(false);
           } else {
-            doneAction.setEnabled(currentAction == null);
+            doneButton.setEnabled(currentAction == null);
             selectUnitsAction.setEnabled(currentAction == null);
             selectTerritoryAction.setEnabled(currentAction == null);
           }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -31,8 +31,8 @@ import javax.swing.SwingUtilities;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.sound.ClipPlayer;
 import org.triplea.sound.SoundPath;
-import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
+import org.triplea.swing.SwingComponents;
 import org.triplea.swing.key.binding.ButtonDownMask;
 import org.triplea.swing.key.binding.KeyCode;
 import org.triplea.swing.key.binding.KeyCombination;
@@ -177,18 +177,19 @@ public class PoliticsPanel extends ActionPanel {
           removeAll();
           actionLabel.setText(gamePlayer.getName() + " Politics");
           add(actionLabel);
+          add(SwingComponents.leftBox(actionLabel));
+
           selectPoliticalActionButton = new JButton(selectPoliticalActionAction);
           selectPoliticalActionButton.setEnabled(false);
-          add(selectPoliticalActionButton);
-          doneButton =
-              new JButtonBuilder()
-                  .title("Done")
-                  .actionListener(this::performDone)
-                  .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
-                  .enabled(false)
-                  .build();
+          doneButton = createDoneButton();
+          doneButton.setEnabled(false);
+
+          final JPanel buttonsPanel = new JPanel();
+          buttonsPanel.add(selectPoliticalActionButton);
+          buttonsPanel.add(doneButton);
+          add(buttonsPanel);
+
           SwingUtilities.invokeLater(() -> doneButton.requestFocusInWindow());
-          add(doneButton);
         });
   }
 
@@ -305,7 +306,7 @@ public class PoliticsPanel extends ActionPanel {
     final int selectedOption =
         JOptionPane.showConfirmDialog(
             JOptionPane.getFrameForComponent(PoliticsPanel.this),
-            "Are you sure you dont want to do anything?",
+            "Are you sure you don't want to do anything?",
             "End Politics",
             JOptionPane.YES_NO_OPTION);
     return selectedOption == JOptionPane.YES_OPTION;
@@ -370,7 +371,7 @@ public class PoliticsPanel extends ActionPanel {
           return order;
         }
       }
-      // sort by achetype
+      // sort by archetype
       if (!paa1NewType.equals(paa2NewType)) {
         if (paa1NewType.getRelationshipTypeAttachment().isWar()
             && !paa2NewType.getRelationshipTypeAttachment().isWar()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -23,10 +23,11 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
-import org.triplea.swing.JButtonBuilder;
+import org.triplea.swing.SwingComponents;
 
 /** The action panel displayed during the purchase action. */
 public class PurchasePanel extends ActionPanel {
@@ -92,16 +93,13 @@ public class PurchasePanel extends ActionPanel {
           removeAll();
           actionLabel.setText(gamePlayer.getName() + " production");
           add(actionLabel);
+          add(SwingComponents.leftBox(actionLabel));
 
           buyButton.setText(BUY);
-          add(buyButton);
-
-          add(
-              new JButtonBuilder()
-                  .title("Done")
-                  .actionListener(this::performDone)
-                  .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
-                  .build());
+          final JPanel buttonsPanel = new JPanel();
+          buttonsPanel.add(buyButton);
+          buttonsPanel.add(createDoneButton());
+          add(buttonsPanel);
 
           add(Box.createVerticalStrut(9));
 
@@ -137,7 +135,7 @@ public class PurchasePanel extends ActionPanel {
       final int selectedOption =
           JOptionPane.showConfirmDialog(
               JOptionPane.getFrameForComponent(PurchasePanel.this),
-              "Are you sure you dont want to buy anything?",
+              "Are you sure you don't want to buy anything?",
               "End Purchase",
               JOptionPane.YES_NO_OPTION);
       if (selectedOption != JOptionPane.YES_OPTION) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
@@ -16,9 +16,10 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import org.triplea.java.collections.IntegerMap;
-import org.triplea.swing.JButtonBuilder;
+import org.triplea.swing.SwingComponents;
 
 class RepairPanel extends ActionPanel {
   private static final long serialVersionUID = 3045997038627313714L;
@@ -74,20 +75,20 @@ class RepairPanel extends ActionPanel {
         () -> {
           removeAll();
           actionLabel.setText(gamePlayer.getName() + " repair");
-          buyButton.setText(BUY);
           add(actionLabel);
-          add(buyButton);
-          add(
-              new JButtonBuilder()
-                  .title("Done")
-                  .actionListener(this::performDone)
-                  .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
-                  .build());
+          add(SwingComponents.leftBox(actionLabel));
+
+          buyButton.setText(BUY);
+          final JPanel buttonsPanel = new JPanel();
+          buttonsPanel.add(buyButton);
+          buttonsPanel.add(createDoneButton());
+          add(buttonsPanel);
+
           repairedSoFar.setText("");
           add(Box.createVerticalStrut(9));
           add(repairedSoFar);
           add(Box.createVerticalStrut(4));
-          unitsPanel.setUnitsFromRepairRuleMap(new HashMap<>(), gamePlayer, getData());
+          unitsPanel.setUnitsFromRepairRuleMap(Map.of(), gamePlayer, getData());
           add(unitsPanel);
           add(Box.createVerticalGlue());
           refresh.run();
@@ -101,7 +102,7 @@ class RepairPanel extends ActionPanel {
       final int selectedOption =
           JOptionPane.showConfirmDialog(
               JOptionPane.getFrameForComponent(RepairPanel.this),
-              "Are you sure you dont want to repair anything?",
+              "Are you sure you don't want to repair anything?",
               "End Purchase",
               JOptionPane.YES_NO_OPTION);
       if (selectedOption != JOptionPane.YES_OPTION) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -34,7 +34,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
-import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
 
@@ -226,18 +225,17 @@ class TechPanel extends ActionPanel {
           removeAll();
           actionLabel.setText(gamePlayer.getName() + " Tech Roll");
           add(actionLabel);
+          add(SwingComponents.leftBox(actionLabel));
+
+          final JPanel buttonsPanel = new JPanel();
           if (Properties.getWW2V3TechModel(getData().getProperties())) {
-            add(new JButton(getTechTokenAction));
-            add(new JButton(justRollTech));
+            buttonsPanel.add(new JButton(getTechTokenAction));
+            buttonsPanel.add(new JButton(justRollTech));
           } else {
-            add(new JButton(getTechRollsAction));
-            add(
-                new JButtonBuilder()
-                    .title("Done")
-                    .actionListener(this::performDone)
-                    .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
-                    .build());
+            buttonsPanel.add(new JButton(getTechRollsAction));
+            buttonsPanel.add(createDoneButton());
           }
+          add(buttonsPanel);
         });
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -29,8 +29,8 @@ import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import org.triplea.sound.ClipPlayer;
 import org.triplea.sound.SoundPath;
-import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
+import org.triplea.swing.SwingComponents;
 
 /** Similar to PoliticsPanel, but for UserActionAttachment/Delegate. */
 public class UserActionPanel extends ActionPanel {
@@ -122,19 +122,19 @@ public class UserActionPanel extends ActionPanel {
           removeAll();
           actionLabel.setText(gamePlayer.getName() + " Actions and Operations");
           add(actionLabel);
+          add(SwingComponents.leftBox(actionLabel));
+
           selectUserActionButton = new JButton(selectUserActionAction);
           selectUserActionButton.setEnabled(false);
-          add(selectUserActionButton);
-          doneButton =
-              new JButtonBuilder()
-                  .title("Done")
-                  .actionListener(this::performDone)
-                  .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
-                  .enabled(false)
-                  .build();
+          doneButton = createDoneButton();
           doneButton.setEnabled(false);
+
+          final JPanel buttonsPanel = new JPanel();
+          buttonsPanel.add(selectUserActionButton);
+          buttonsPanel.add(doneButton);
+          add(buttonsPanel);
+
           SwingUtilities.invokeLater(() -> doneButton.requestFocusInWindow());
-          add(doneButton);
         });
   }
 
@@ -143,7 +143,7 @@ public class UserActionPanel extends ActionPanel {
     if (!firstRun
         || JOptionPane.showConfirmDialog(
                 JOptionPane.getFrameForComponent(UserActionPanel.this),
-                "Are you sure you dont want to do anything?",
+                "Are you sure you don't want to do anything?",
                 "End Actions",
                 JOptionPane.YES_NO_OPTION)
             == JOptionPane.YES_OPTION) {


### PR DESCRIPTION
## Change Summary & Additional Notes
Small refinements to action panel UIs.

- Makes the "Done" and other buttons be on the same row, to match the improvements to the move panel in #10281
- Fixes some typos in message boxes (dont -> don't)
- Makes the pick territory panel (for random start delegate) actually say "land" territory
- A few small code clean ups.


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
