### PR TITLE
Significantly speed up game data cloning for AI and battle calculator.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/SerializationProxySupport.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/SerializationProxySupport.java
@@ -12,8 +12,8 @@ package games.strategy.engine.data;
  *   <li>https://youtu.be/V1vQf4qyMXg?t=56m12s
  * </ul>
  *
- * <p>A typical usage of this annotation will and pattern will look like this: Code formatted below
- * for easy copy paste:
+ * <p>A typical usage of this annotation and pattern will look like this: Code formatted below for
+ * easy copy paste:
  *
  * <pre>
  * &#64;SerializationProxySupport

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -52,7 +52,7 @@ public final class GameDataUtils {
     try {
       return Optional.of(
           IoUtils.writeToMemory(
-              os -> GameDataManager.saveGame(os, data, copyDelegates, engineVersion)));
+              os -> GameDataManager.saveGameUncompressed(os, data, copyDelegates, engineVersion)));
     } catch (final IOException e) {
       log.error("Failed to clone game data", e);
       return Optional.empty();
@@ -63,7 +63,7 @@ public final class GameDataUtils {
       final byte[] bytes, final Version engineVersion) {
     try {
       return IoUtils.readFromMemory(
-          bytes, inputStream -> GameDataManager.loadGame(engineVersion, inputStream));
+          bytes, inputStream -> GameDataManager.loadGameUncompressed(engineVersion, inputStream));
     } catch (final IOException e) {
       log.error("Failed to clone game data", e);
       return Optional.empty();

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -40,15 +40,11 @@ public final class GameDataUtils {
    */
   public static Optional<GameData> cloneGameData(
       final GameData data, final boolean copyDelegates, final Version engineVersion) {
-    try {
-      final byte[] bytes =
-          IoUtils.writeToMemory(
-              os -> GameDataManager.saveGame(os, data, copyDelegates, engineVersion));
+    final byte[] bytes = gameDataToBytes(data, copyDelegates, engineVersion).orElse(null);
+    if (bytes != null) {
       return createGameDataFromBytes(bytes, engineVersion);
-    } catch (final IOException e) {
-      log.error("Failed to clone game data", e);
-      return Optional.empty();
     }
+    return Optional.empty();
   }
 
   public static Optional<byte[]> gameDataToBytes(

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -44,6 +44,28 @@ public final class GameDataUtils {
       final byte[] bytes =
           IoUtils.writeToMemory(
               os -> GameDataManager.saveGame(os, data, copyDelegates, engineVersion));
+      return createGameDataFromBytes(bytes, engineVersion);
+    } catch (final IOException e) {
+      log.error("Failed to clone game data", e);
+      return Optional.empty();
+    }
+  }
+
+  public static Optional<byte[]> gameDataToBytes(
+      GameData data, boolean copyDelegates, Version engineVersion) {
+    try {
+      return Optional.of(
+          IoUtils.writeToMemory(
+              os -> GameDataManager.saveGame(os, data, copyDelegates, engineVersion)));
+    } catch (final IOException e) {
+      log.error("Failed to clone game data", e);
+      return Optional.empty();
+    }
+  }
+
+  public static Optional<GameData> createGameDataFromBytes(
+      final byte[] bytes, final Version engineVersion) {
+    try {
       return IoUtils.readFromMemory(
           bytes, inputStream -> GameDataManager.loadGame(engineVersion, inputStream));
     } catch (final IOException e) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Setter;
 import org.triplea.util.Version;
 
@@ -32,14 +33,16 @@ class BattleCalculator implements IBattleCalculator {
   private volatile boolean cancelled = false;
   private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
-  BattleCalculator(
-      final GameData data, final boolean dataHasAlreadyBeenCloned, final Version engineVersion) {
-    gameData =
-        Preconditions.checkNotNull(
-            dataHasAlreadyBeenCloned
-                ? data
-                : GameDataUtils.cloneGameData(data, false, engineVersion).orElse(null),
-            "Error cloning game data (low memory?)");
+  private BattleCalculator(@Nullable GameData data) {
+    gameData = Preconditions.checkNotNull(data, "Error cloning game data (low memory?)");
+  }
+
+  BattleCalculator(GameData data, Version engineVersion) {
+    this(GameDataUtils.cloneGameData(data, false, engineVersion).orElse(null));
+  }
+
+  BattleCalculator(byte[] data, Version engineVersion) {
+    this(GameDataUtils.createGameDataFromBytes(data, engineVersion).orElse(null));
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -117,7 +117,10 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
   private void createWorkers(final GameData data) {
     workers.clear();
     if (data != null && cancelCurrentOperation.get() >= 0) {
+      final long startMemory =
+          Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
       // see how long 1 copy takes (some games can get REALLY big)
+      final long startTime = System.currentTimeMillis();
       final Version engineVersion = Injections.getInstance().getEngineVersion();
       final byte[] serializedData;
       try {
@@ -133,10 +136,7 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
         data.releaseWriteLock();
       }
       if (cancelCurrentOperation.get() >= 0) {
-        // Create the first data on this thread and see how long it takes.
-        final long startTime = System.currentTimeMillis();
-        final long startMemory =
-            Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        // Create the first battle calc on the current thread to measure the end-to-end copy time.
         workers.add(new BattleCalculator(serializedData, engineVersion));
         int threadsToUse = getThreadsToUse((System.currentTimeMillis() - startTime), startMemory);
         // Now, create the remaining ones in parallel.

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -117,16 +117,15 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
   private void createWorkers(final GameData data) {
     workers.clear();
     if (data != null && cancelCurrentOperation.get() >= 0) {
-      final long startMemory =
-          Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
       // see how long 1 copy takes (some games can get REALLY big)
       final long startTime = System.currentTimeMillis();
+      final long startMemory =
+          Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
       final Version engineVersion = Injections.getInstance().getEngineVersion();
       final byte[] serializedData;
       try {
         // Serialize the data, then release lock on it so game can continue (ie: we don't want to
-        // lock on it while we copy it 16 times). Don't let the data change while we make the first
-        // copy.
+        // lock on it while we copy it 16 times).
         data.acquireWriteLock();
         serializedData = GameDataUtils.gameDataToBytes(data, false, engineVersion).orElse(null);
         if (serializedData == null) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
@@ -35,7 +35,7 @@ class BattleCalculatorTest {
     final GamePlayer germans = germans(gameData);
     final List<Unit> attackingUnits = infantry(gameData).create(100, russians);
     final List<Unit> bombardingUnits = List.of();
-    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version("2.0.0"));
+    final BattleCalculator calculator = new BattleCalculator(gameData, new Version("2.0.0"));
     final AggregateResults results =
         calculator.calculate(
             russians,
@@ -65,7 +65,7 @@ class BattleCalculatorTest {
     final List<Unit> attackingUnits = infantry(gameData).create(1, germans);
     attackingUnits.addAll(bomber(gameData).create(1, germans));
     final List<Unit> bombardingUnits = List.of();
-    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version("2.0.0"));
+    final BattleCalculator calculator = new BattleCalculator(gameData, new Version("2.0.0"));
     calculator.setKeepOneAttackingLandUnit(true);
     final AggregateResults results =
         calculator.calculate(
@@ -88,7 +88,7 @@ class BattleCalculatorTest {
     final Territory sz1 = territory("1 Sea Zone", gameData);
     final List<Unit> attacking = transport(gameData).create(2, americans(gameData));
     final List<Unit> defending = submarine(gameData).create(2, germans(gameData));
-    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version("2.0.0"));
+    final BattleCalculator calculator = new BattleCalculator(gameData, new Version("2.0.0"));
     calculator.setKeepOneAttackingLandUnit(false);
     final AggregateResults results =
         calculator.calculate(
@@ -112,7 +112,7 @@ class BattleCalculatorTest {
     final Territory sz1 = territory("1 Sea Zone", gameData);
     final List<Unit> attacking = submarine(gameData).create(2, americans(gameData));
     final List<Unit> defending = transport(gameData).create(2, germans(gameData));
-    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version("2.0.0"));
+    final BattleCalculator calculator = new BattleCalculator(gameData, new Version("2.0.0"));
     calculator.setKeepOneAttackingLandUnit(false);
     final AggregateResults results =
         calculator.calculate(

--- a/lib/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/lib/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
@@ -55,9 +55,9 @@ public class PerfTimer implements Closeable {
   }
 
   /**
-   * Creates a perf timer with a reporting frequency. The reporting frequency specifies N specifies
-   * that performance information should be printed every N executions of the timer. If 0, no
-   * information is printed.
+   * Creates a perf timer with a reporting frequency. The reporting frequency N specifies that
+   * performance information should be printed every N executions of the timer. If 0, no information
+   * is printed.
    *
    * @param title The name of the timer
    * @param reportingFrequency The reporting frequency.


### PR DESCRIPTION
## Change Summary & Additional Notes
Cloning game data involved creating a byte[] array out of the data and then converting it to a new GameData object.
Previously, both steps would be done for each concurrent worker. With this change, we only create the byte[] array once instead of N times, speeding up the process.

Additionally, we no longer compress/decompress the data when cloning nor create temporary files to write the data to, which speeds up things considerably. (This is still done when saving games, but not for cloning data.)

Also fixes a couple comments.

With this change, opening up the battle calc goes from 7.2s to 2.5s on my machine on the "270BC Wars" map for example.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->
## Release Note

<!--RELEASE_NOTE-->Change|Major speed up to opening the battle calculator and AIs<!--END_RELEASE_NOTE-->
