### PR TITLE
Deprecate NULL_PLAYERID in favor of PlayerList.getNullPlayer().

### DIFF
--- a/game-app/ai/src/main/java/org/triplea/ai/flowfield/influence/offense/ResourceToGet.java
+++ b/game-app/ai/src/main/java/org/triplea/ai/flowfield/influence/offense/ResourceToGet.java
@@ -26,7 +26,8 @@ public class ResourceToGet {
       final RelationshipTracker relationshipTracker,
       final Collection<Territory> territories,
       final Resource resource) {
-    final Collection<GamePlayer> enemies = new ArrayList<>(List.of(GamePlayer.NULL_PLAYERID));
+    final Collection<GamePlayer> enemies =
+        new ArrayList<>(List.of(gamePlayer.getData().getPlayerList().getNullPlayer()));
     enemies.addAll(relationshipTracker.getEnemies(gamePlayer));
 
     final Map<Territory, Long> territoryValuations =

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
 /** A game player (nation, power, etc.). */
 public class GamePlayer extends NamedAttachable implements NamedUnitHolder {
@@ -24,7 +25,8 @@ public class GamePlayer extends NamedAttachable implements NamedUnitHolder {
   private static final String DEFAULT_TYPE_AI = "AI";
   private static final String DEFAULT_TYPE_DOES_NOTHING = "DoesNothing";
 
-  public static final GamePlayer NULL_PLAYERID =
+  @RemoveOnNextMajorRelease
+  private static final GamePlayer NULL_PLAYERID =
       new GamePlayer(Constants.PLAYER_NAME_NEUTRAL, true, false, null, false, null) {
         private static final long serialVersionUID = -6596127754502509049L;
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
@@ -27,6 +27,7 @@ public class GamePlayer extends NamedAttachable implements NamedUnitHolder {
 
   @RemoveOnNextMajorRelease @Deprecated
   private static final GamePlayer NULL_PLAYERID =
+      // Kept for save game compatibility, or we'll get a class not found error loading neutrals.
       new GamePlayer(Constants.PLAYER_NAME_NEUTRAL, true, false, null, false, null) {
         private static final long serialVersionUID = -6596127754502509049L;
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
@@ -25,8 +25,7 @@ public class GamePlayer extends NamedAttachable implements NamedUnitHolder {
   private static final String DEFAULT_TYPE_AI = "AI";
   private static final String DEFAULT_TYPE_DOES_NOTHING = "DoesNothing";
 
-  @RemoveOnNextMajorRelease
-  @Deprecated
+  @RemoveOnNextMajorRelease @Deprecated
   private static final GamePlayer NULL_PLAYERID =
       new GamePlayer(Constants.PLAYER_NAME_NEUTRAL, true, false, null, false, null) {
         private static final long serialVersionUID = -6596127754502509049L;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
@@ -26,6 +26,7 @@ public class GamePlayer extends NamedAttachable implements NamedUnitHolder {
   private static final String DEFAULT_TYPE_DOES_NOTHING = "DoesNothing";
 
   @RemoveOnNextMajorRelease
+  @Deprecated
   private static final GamePlayer NULL_PLAYERID =
       new GamePlayer(Constants.PLAYER_NAME_NEUTRAL, true, false, null, false, null) {
         private static final long serialVersionUID = -6596127754502509049L;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.data;
 
 import com.google.common.annotations.VisibleForTesting;
+import games.strategy.triplea.Constants;
 import games.strategy.triplea.util.PlayerOrderComparator;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.Getter;
 import lombok.ToString;
 
 /** Wrapper around the set of players in a game to provide utility functions and methods. */
@@ -20,9 +22,19 @@ public class PlayerList extends GameDataComponent implements Iterable<GamePlayer
 
   // maps String playerName -> PlayerId
   private final Map<String, GamePlayer> players = new LinkedHashMap<>();
+  @Getter private final GamePlayer nullPlayer;
 
   public PlayerList(final GameData data) {
     super(data);
+    nullPlayer =
+        new GamePlayer(Constants.PLAYER_NAME_NEUTRAL, true, false, null, false, data) {
+          private static final long serialVersionUID = 1;
+
+          @Override
+          public boolean isNull() {
+            return true;
+          }
+        };
   }
 
   @VisibleForTesting
@@ -35,8 +47,8 @@ public class PlayerList extends GameDataComponent implements Iterable<GamePlayer
   }
 
   public GamePlayer getPlayerId(final String name) {
-    if (GamePlayer.NULL_PLAYERID.getName().equals(name)) {
-      return GamePlayer.NULL_PLAYERID;
+    if (getNullPlayer().getName().equals(name)) {
+      return getNullPlayer();
     }
     return players.get(name);
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -173,7 +173,10 @@ public class RelationshipTracker extends GameDataComponent {
     for (final GamePlayer p : getData().getPlayerList().getPlayers()) {
       setRelationship(p, p, getSelfRelationshipType());
     }
-    setRelationship(GamePlayer.NULL_PLAYERID, GamePlayer.NULL_PLAYERID, getSelfRelationshipType());
+    setRelationship(
+        getData().getPlayerList().getNullPlayer(),
+        getData().getPlayerList().getNullPlayer(),
+        getSelfRelationshipType());
   }
 
   /**
@@ -182,7 +185,7 @@ public class RelationshipTracker extends GameDataComponent {
    */
   public void setNullPlayerRelations() {
     for (final GamePlayer p : getData().getPlayerList().getPlayers()) {
-      setRelationship(p, GamePlayer.NULL_PLAYERID, getNullRelationshipType());
+      setRelationship(p, getData().getPlayerList().getNullPlayer(), getNullRelationshipType());
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -315,9 +315,10 @@ public class Route implements Serializable, Iterable<Territory> {
    * is not sea.
    */
   public boolean hasNeutralBeforeEnd() {
+    GamePlayer nullPlayer = start.getData().getPlayerList().getNullPlayer();
     for (final Territory current : getMiddleSteps()) {
       // neutral is owned by null and is not sea
-      if (!current.isWater() && current.isOwnedBy(GamePlayer.NULL_PLAYERID)) {
+      if (!current.isWater() && current.isOwnedBy(nullPlayer)) {
         return true;
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -315,10 +315,9 @@ public class Route implements Serializable, Iterable<Territory> {
    * is not sea.
    */
   public boolean hasNeutralBeforeEnd() {
-    GamePlayer nullPlayer = start.getData().getPlayerList().getNullPlayer();
     for (final Territory current : getMiddleSteps()) {
       // neutral is owned by null and is not sea
-      if (!current.isWater() && current.isOwnedBy(nullPlayer)) {
+      if (!current.isWater() && current.getOwner().isNull()) {
         return true;
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Territory.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Territory.java
@@ -12,21 +12,23 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
 
   private final boolean water;
   /**
-   * The territory owner; defaults to {@link GamePlayer#NULL_PLAYERID} if the territory is not
+   * The territory owner; defaults to {@link PlayerList#getNullPlayer()} if the territory is not
    * owned.
    */
-  private GamePlayer owner = GamePlayer.NULL_PLAYERID;
+  private GamePlayer owner;
 
   @Getter(onMethod_ = {@Override})
   private final UnitCollection unitCollection;
 
   public Territory(final String name, final GameData data) {
     this(name, false, data);
+    owner = data.getPlayerList().getNullPlayer();
   }
 
   public Territory(final String name, final boolean water, final GameData data) {
     super(name, data);
     this.water = water;
+    owner = data.getPlayerList().getNullPlayer();
     unitCollection = new UnitCollection(this, getData());
   }
 
@@ -36,7 +38,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   }
 
   public void setOwner(final @Nullable GamePlayer owner) {
-    this.owner = Optional.ofNullable(owner).orElse(GamePlayer.NULL_PLAYERID);
+    this.owner = Optional.ofNullable(owner).orElse(getData().getPlayerList().getNullPlayer());
     getData().notifyTerritoryOwnerChanged(this);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -117,7 +117,7 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
   }
 
   public void setOwner(final @Nullable GamePlayer player) {
-    owner = Optional.ofNullable(player).orElse(GamePlayer.NULL_PLAYERID);
+    owner = Optional.ofNullable(player).orElse(getData().getPlayerList().getNullPlayer());
   }
 
   public final boolean isOwnedBy(final GamePlayer player) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -46,7 +46,7 @@ public class AddUnits extends Change {
                 Unit::getId,
                 unit -> {
                   if (unit.getOwner() == null || unit.getOwner().getName() == null) {
-                    return GamePlayer.NULL_PLAYERID.getName();
+                    return unit.getData().getPlayerList().getNullPlayer().getName();
                   }
                   return unit.getOwner().getName();
                 }));

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -1024,7 +1024,7 @@ public final class GameParser {
 
       final GamePlayer owner;
       if (ownerString == null || ownerString.isBlank()) {
-        owner = GamePlayer.NULL_PLAYERID;
+        owner = territory.getData().getPlayerList().getNullPlayer();
       } else {
         owner = getPlayerIdOptional(current.getOwner()).orElse(null);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.TechnologyFrontier;
@@ -884,7 +883,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
               // we subtract the base rolls to get the bonus
               final int heavyBomberDiceRollsBonus =
                   heavyBomberDiceRollsTotal
-                      - UnitAttachment.get(bomber).getAttackRolls(GamePlayer.NULL_PLAYERID);
+                      - UnitAttachment.get(bomber)
+                          .getAttackRolls(data.getPlayerList().getNullPlayer());
               taa.setAttackRollsBonus(heavyBomberDiceRollsBonus + ":" + bomber.getName());
               if (heavyBombersLhtr) {
                 // TODO: this all happens WHEN the xml is parsed. Which means if the user changes

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -146,14 +146,13 @@ class AaInMoveUtil implements Serializable {
             public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
               if (!validTargetedUnitsForThisRoll.isEmpty()) {
                 final int hitCount = dice.get().getHits();
+                GamePlayer defender = findDefender(getData(), currentPossibleAa, territory);
                 if (hitCount == 0) {
                   if (currentTypeAa.equals("AA")) {
                     AaInMoveUtil.this
                         .bridge
                         .getSoundChannelBroadcaster()
-                        .playSoundForAll(
-                            SoundPath.CLIP_BATTLE_AA_MISS,
-                            findDefender(currentPossibleAa, territory));
+                        .playSoundForAll(SoundPath.CLIP_BATTLE_AA_MISS, defender);
                   } else {
                     AaInMoveUtil.this
                         .bridge
@@ -162,7 +161,7 @@ class AaInMoveUtil implements Serializable {
                             SoundPath.CLIP_BATTLE_X_PREFIX
                                 + currentTypeAa.toLowerCase()
                                 + SoundPath.CLIP_BATTLE_X_MISS,
-                            findDefender(currentPossibleAa, territory));
+                            defender);
                   }
                   AaInMoveUtil.this
                       .bridge
@@ -175,9 +174,7 @@ class AaInMoveUtil implements Serializable {
                     AaInMoveUtil.this
                         .bridge
                         .getSoundChannelBroadcaster()
-                        .playSoundForAll(
-                            SoundPath.CLIP_BATTLE_AA_HIT,
-                            findDefender(currentPossibleAa, territory));
+                        .playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT, defender);
                   } else {
                     AaInMoveUtil.this
                         .bridge
@@ -186,7 +183,7 @@ class AaInMoveUtil implements Serializable {
                             SoundPath.CLIP_BATTLE_X_PREFIX
                                 + currentTypeAa.toLowerCase()
                                 + SoundPath.CLIP_BATTLE_X_HIT,
-                            findDefender(currentPossibleAa, territory));
+                            defender);
                   }
                   selectCasualties(
                       dice.get(),
@@ -303,16 +300,16 @@ class AaInMoveUtil implements Serializable {
         .map(Unit::getOwner)
         .filter(Objects::nonNull)
         .findAny()
-        .orElse(GamePlayer.NULL_PLAYERID);
+        .orElse(player.getData().getPlayerList().getNullPlayer());
   }
 
   private static GamePlayer findDefender(
-      final Collection<Unit> defendingUnits, final Territory territory) {
+      final GameData data, final Collection<Unit> defendingUnits, final Territory territory) {
     if (defendingUnits == null || defendingUnits.isEmpty()) {
       if (territory != null && territory.getOwner() != null && !territory.getOwner().isNull()) {
         return territory.getOwner();
       }
-      return GamePlayer.NULL_PLAYERID;
+      return data.getPlayerList().getNullPlayer();
     } else if (territory != null
         && territory.getOwner() != null
         && !territory.getOwner().isNull()
@@ -324,7 +321,7 @@ class AaInMoveUtil implements Serializable {
         .map(Unit::getOwner)
         .filter(Objects::nonNull)
         .findAny()
-        .orElse(GamePlayer.NULL_PLAYERID);
+        .orElse(data.getPlayerList().getNullPlayer());
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -40,7 +40,7 @@ final class EditValidator {
 
   static String validateChangeTerritoryOwner(final GameData data, final Territory territory) {
     if (territory.isWater()
-        && territory.isOwnedBy(GamePlayer.NULL_PLAYERID)
+        && territory.getOwner().isNull()
         && TerritoryAttachment.get(territory) == null) {
       return "Territory is water and has no attachment";
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -302,7 +302,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
               SoundPath.CLIP_GAME_WON,
               ((this.winners != null && !this.winners.isEmpty())
                   ? CollectionUtils.getAny(this.winners)
-                  : GamePlayer.NULL_PLAYERID));
+                  : getData().getPlayerList().getNullPlayer()));
       // send a message to everyone's screen except the HOST (there is no 'current player' for the
       // end round delegate)
       final String title =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
@@ -54,7 +54,7 @@ public class OriginalOwnerTracker implements Serializable {
     for (final Territory t : data.getMap()) {
       GamePlayer originalOwner = getOriginalOwner(t);
       if (originalOwner == null) {
-        originalOwner = GamePlayer.NULL_PLAYERID;
+        originalOwner = data.getPlayerList().getNullPlayer();
       }
       if (originalOwner.equals(player)) {
         territories.add(t);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -264,14 +264,14 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   private static Predicate<Territory> getTerritoryPickableMatch() {
     return Matches.territoryIsLand()
         .and(Matches.territoryIsNotImpassable())
-        .and(Matches.isTerritoryOwnedBy(GamePlayer.NULL_PLAYERID))
+        .and(Matches.isTerritoryNeutral())
         .and(Matches.territoryIsEmpty());
   }
 
   private static Predicate<GamePlayer> getPlayerCanPickMatch() {
     return player ->
         player != null
-            && !player.equals(GamePlayer.NULL_PLAYERID)
+            && !player.isNull()
             && !player.getUnitCollection().isEmpty()
             && !player.getIsDisabled();
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -269,7 +269,7 @@ abstract class AbstractBattle implements IBattle {
   static GamePlayer findDefender(
       final Territory battleSite, final GamePlayer attacker, final GameState data) {
     if (battleSite == null) {
-      return GamePlayer.NULL_PLAYERID;
+      return data.getPlayerList().getNullPlayer();
     }
     GamePlayer defender = null;
     if (!battleSite.isWater()) {
@@ -278,7 +278,7 @@ abstract class AbstractBattle implements IBattle {
     if (data == null || attacker == null) {
       // This is needed for many TESTs, so do not delete
       if (defender == null) {
-        return GamePlayer.NULL_PLAYERID;
+        return data.getPlayerList().getNullPlayer();
       }
       return defender;
     }
@@ -300,7 +300,7 @@ abstract class AbstractBattle implements IBattle {
       }
     }
     if (defender == null) {
-      return GamePlayer.NULL_PLAYERID;
+      return data.getPlayerList().getNullPlayer();
     }
     return defender;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -730,7 +730,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               });
 
       boolean scrambledHere = false;
-      GamePlayer defender = GamePlayer.NULL_PLAYERID;
+      GamePlayer defender = data.getPlayerList().getNullPlayer();
       if (!scramblers.isEmpty()) {
         // Determine defender.
         if (battleTracker.hasPendingNonBombingBattle(to)) {
@@ -743,7 +743,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                   .map(from -> AbstractBattle.findDefender(from, player, data))
                   .filter(player -> !player.isNull())
                   .findFirst()
-                  .orElse(GamePlayer.NULL_PLAYERID);
+                  .orElse(data.getPlayerList().getNullPlayer());
         }
         if (defender.isNull()) {
           continue;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -778,7 +778,8 @@ public class BattleTracker implements Serializable {
         newOwner = gamePlayer;
         for (final Territory current :
             TerritoryAttachment.getAllCapitals(terrOrigOwner, data.getMap())) {
-          if (territory.equals(current) || current.isOwnedBy(GamePlayer.NULL_PLAYERID)) {
+          if (territory.equals(current)
+              || current.isOwnedBy(data.getPlayerList().getNullPlayer())) {
             // if a neutral controls our capital, our territories get liberated (ie: china in ww2v3)
             newOwner = terrOrigOwner;
             break;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -778,8 +778,7 @@ public class BattleTracker implements Serializable {
         newOwner = gamePlayer;
         for (final Territory current :
             TerritoryAttachment.getAllCapitals(terrOrigOwner, data.getMap())) {
-          if (territory.equals(current)
-              || current.isOwnedBy(data.getPlayerList().getNullPlayer())) {
+          if (territory.equals(current) || current.getOwner().isNull()) {
             // if a neutral controls our capital, our territories get liberated (ie: china in ww2v3)
             newOwner = terrOrigOwner;
             break;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportRuleSort.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportRuleSort.java
@@ -105,16 +105,13 @@ class SupportRuleSort implements Comparator<UnitSupportAttachment> {
     final UnitAttachment ua2 = UnitAttachment.get(unitType2);
     final int unitPower1;
     final int unitPower2;
+    final GamePlayer nullPlayer = u1.getData().getPlayerList().getNullPlayer();
     if (u1.getDefence()) {
-      unitPower1 =
-          ua1.getDefenseRolls(GamePlayer.NULL_PLAYERID) * ua1.getDefense(GamePlayer.NULL_PLAYERID);
-      unitPower2 =
-          ua2.getDefenseRolls(GamePlayer.NULL_PLAYERID) * ua2.getDefense(GamePlayer.NULL_PLAYERID);
+      unitPower1 = ua1.getDefenseRolls(nullPlayer) * ua1.getDefense(nullPlayer);
+      unitPower2 = ua2.getDefenseRolls(nullPlayer) * ua2.getDefense(nullPlayer);
     } else {
-      unitPower1 =
-          ua1.getAttackRolls(GamePlayer.NULL_PLAYERID) * ua1.getAttack(GamePlayer.NULL_PLAYERID);
-      unitPower2 =
-          ua2.getAttackRolls(GamePlayer.NULL_PLAYERID) * ua2.getAttack(GamePlayer.NULL_PLAYERID);
+      unitPower1 = ua1.getAttackRolls(nullPlayer) * ua1.getAttack(nullPlayer);
+      unitPower2 = ua2.getAttackRolls(nullPlayer) * ua2.getAttack(nullPlayer);
     }
 
     return Integer.compare(unitPower2, unitPower1);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelector.java
@@ -79,7 +79,7 @@ public class AttackerAndDefenderSelector {
       // case the owner has units in the land, then they are already in the list but adding a second
       // entry to the list doesn't impact the algorithm.
       final GamePlayer territoryOwner = territory.getOwner();
-      if (territoryOwner != territory.getData().getPlayerList().getNullPlayer()) {
+      if (!territoryOwner.isNull()) {
         playersWithUnits.add(territoryOwner);
       }
       final GamePlayer attacker = currentPlayer;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelector.java
@@ -79,7 +79,7 @@ public class AttackerAndDefenderSelector {
       // case the owner has units in the land, then they are already in the list but adding a second
       // entry to the list doesn't impact the algorithm.
       final GamePlayer territoryOwner = territory.getOwner();
-      if (territoryOwner != GamePlayer.NULL_PLAYERID) {
+      if (territoryOwner != territory.getData().getPlayerList().getNullPlayer()) {
         playersWithUnits.add(territoryOwner);
       }
       final GamePlayer attacker = currentPlayer;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -63,12 +63,16 @@ class BattleCalculator implements IBattleCalculator {
           gameData
               .getPlayerList()
               .getPlayerId(
-                  attacker == null ? GamePlayer.NULL_PLAYERID.getName() : attacker.getName());
+                  attacker == null
+                      ? gameData.getPlayerList().getNullPlayer().getName()
+                      : attacker.getName());
       final GamePlayer defender2 =
           gameData
               .getPlayerList()
               .getPlayerId(
-                  defender == null ? GamePlayer.NULL_PLAYERID.getName() : defender.getName());
+                  defender == null
+                      ? gameData.getPlayerList().getNullPlayer().getName()
+                      : defender.getName());
       final Territory location2 = gameData.getMap().getTerritory(location.getName());
       final Collection<Unit> attackingUnits =
           GameDataUtils.translateIntoOtherGameData(attacking, gameData);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -110,8 +110,8 @@ class BattleCalculatorPanel extends JPanel {
     data.acquireReadLock();
     try {
       final Collection<GamePlayer> playerList = new ArrayList<>(data.getPlayerList().getPlayers());
-      if (doesPlayerHaveUnitsOnMap(GamePlayer.NULL_PLAYERID, data)) {
-        playerList.add(GamePlayer.NULL_PLAYERID);
+      if (doesPlayerHaveUnitsOnMap(data.getPlayerList().getNullPlayer(), data)) {
+        playerList.add(data.getPlayerList().getNullPlayer());
       }
       attackerCombo = new JComboBox<>(SwingComponents.newComboBoxModel(playerList));
       defenderCombo = new JComboBox<>(SwingComponents.newComboBoxModel(playerList));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
@@ -52,14 +52,15 @@ class UnitInformation {
             unitInformation.write(StringUtils.capitalize(currentType.getName()) + ",");
           }
           unitInformation.write(getCostInformation(currentType, printData.getData()) + ",");
+          final GamePlayer nullPlayer = currentType.getData().getPlayerList().getNullPlayer();
           unitInformation.write(
-              currentAttachment.getMovement(GamePlayer.NULL_PLAYERID)
+              currentAttachment.getMovement(nullPlayer)
                   + ","
-                  + currentAttachment.getAttack(GamePlayer.NULL_PLAYERID)
+                  + currentAttachment.getAttack(nullPlayer)
                   + ","
-                  + currentAttachment.getDefense(GamePlayer.NULL_PLAYERID)
+                  + currentAttachment.getDefense(nullPlayer)
                   + ","
-                  + (!currentAttachment.getCanBlitz(GamePlayer.NULL_PLAYERID) ? "-" : "true")
+                  + (!currentAttachment.getCanBlitz(nullPlayer) ? "-" : "true")
                   + ","
                   + (!currentAttachment.getArtillery() ? "-" : "true")
                   + ","

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -1078,7 +1078,7 @@ class EditPanel extends ActionPanel {
 
   private static boolean doesNeutralHaveUnitsOnMap(final GameState data) {
     return data.getMap().getTerritories().stream()
-        .anyMatch(Matches.territoryHasUnitsOwnedBy(GamePlayer.NULL_PLAYERID));
+        .anyMatch(Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getNullPlayer()));
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
@@ -102,7 +102,7 @@ public class ObjectiveDummyDelegateBridge implements IDelegateBridge {
 
   @Override
   public GamePlayer getGamePlayer() {
-    return GamePlayer.NULL_PLAYERID;
+    return gameData.getPlayerList().getNullPlayer();
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -46,7 +46,7 @@ class PlayerChooser extends JOptionPane {
   private void createComponents() {
     final Collection<GamePlayer> players = new ArrayList<>(this.players.getPlayers());
     if (allowNeutral) {
-      players.add(GamePlayer.NULL_PLAYERID);
+      players.add(this.players.getNullPlayer());
     }
     list = new JList<>(players.toArray(new GamePlayer[0]));
     list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -99,9 +99,9 @@ class PlayerChooser extends JOptionPane {
         final int index,
         final boolean isSelected,
         final boolean cellHasFocus) {
-      super.getListCellRendererComponent(
-          list, ((GamePlayer) value).getName(), index, isSelected, cellHasFocus);
-      if (uiContext == null || value == GamePlayer.NULL_PLAYERID) {
+      GamePlayer player = (GamePlayer) value;
+      super.getListCellRendererComponent(list, player.getName(), index, isSelected, cellHasFocus);
+      if (uiContext == null || player.isNull()) {
         setIcon(new ImageIcon(Util.newImage(32, 32, true)));
       } else {
         setIcon(new ImageIcon(uiContext.getFlagImageFactory().getFlag((GamePlayer) value)));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
@@ -21,7 +21,6 @@ public final class TooltipProperties extends PropertyFile {
 
   /** Get unit type tooltip checking for custom tooltip content. */
   public String getTooltip(final UnitType unitType, final GamePlayer gamePlayer) {
-
     final String customTip = getToolTip(unitType, gamePlayer, false);
     if (!customTip.isEmpty()) {
       return LocalizeHtml.localizeImgLinksInHtml(customTip, UiContext.getMapLocation());
@@ -29,7 +28,9 @@ public final class TooltipProperties extends PropertyFile {
     final String generated =
         UnitAttachment.get(unitType)
             .toStringShortAndOnlyImportantDifferences(
-                (gamePlayer == null ? GamePlayer.NULL_PLAYERID : gamePlayer));
+                (gamePlayer == null
+                    ? unitType.getData().getPlayerList().getNullPlayer()
+                    : gamePlayer));
     final String appendedTip = getToolTip(unitType, gamePlayer, true);
     if (!appendedTip.isEmpty()) {
       return generated
@@ -49,7 +50,9 @@ public final class TooltipProperties extends PropertyFile {
                 + "."
                 + ut.getName()
                 + "."
-                + (gamePlayer == null ? GamePlayer.NULL_PLAYERID.getName() : gamePlayer.getName())
+                + (gamePlayer == null
+                    ? ut.getData().getPlayerList().getNullPlayer().getName()
+                    : gamePlayer.getName())
                 + append,
             "");
     return (tooltip == null || tooltip.isEmpty())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -558,7 +558,9 @@ public class HistoryLog extends JFrame {
       final TerritoryAttachment ta = TerritoryAttachment.get(place);
       if (!place.isWater()
           || (ta != null
-              && !GamePlayer.NULL_PLAYERID.equals(OriginalOwnerTracker.getOriginalOwner(place))
+              && !data.getPlayerList()
+                  .getNullPlayer()
+                  .equals(OriginalOwnerTracker.getOriginalOwner(place))
               && player.equals(OriginalOwnerTracker.getOriginalOwner(place))
               && place.isOwnedBy(player))) {
         isConvoyOrLand = true;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -76,9 +76,9 @@ final class FileMenu extends JMenu {
                 final GameStep step = gameData.getSequence().getStep();
                 final GamePlayer currentPlayer =
                     (step == null
-                        ? GamePlayer.NULL_PLAYERID
+                        ? gameData.getPlayerList().getNullPlayer()
                         : (step.getPlayerId() == null
-                            ? GamePlayer.NULL_PLAYERID
+                            ? gameData.getPlayerList().getNullPlayer()
                             : step.getPlayerId()));
                 final int round = gameData.getSequence().getRound();
                 final HistoryLog historyLog = new HistoryLog();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitStatsTable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitStatsTable.java
@@ -102,9 +102,9 @@ public class UnitStatsTable {
     final Set<UnitType> all = data.getUnitTypeList().getAllUnitTypes();
     all.removeAll(unitsSoFar);
     unitTypes.put(
-        GamePlayer.NULL_PLAYERID,
-        getPlayerUnitsWithImages(GamePlayer.NULL_PLAYERID, data, uiContext));
-    unitsSoFar.addAll(unitTypes.get(GamePlayer.NULL_PLAYERID));
+        data.getPlayerList().getNullPlayer(),
+        getPlayerUnitsWithImages(data.getPlayerList().getNullPlayer(), data, uiContext));
+    unitsSoFar.addAll(unitTypes.get(data.getPlayerList().getNullPlayer()));
     all.removeAll(unitsSoFar);
     if (!all.isEmpty()) {
       unitTypes.put(null, new ArrayList<>(all));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
@@ -38,15 +38,15 @@ public class KamikazeZoneDrawable extends AbstractDrawable {
     if (Properties.getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(data.getProperties())) {
       owner = terr.getOwner();
       if (owner == null) {
-        owner = GamePlayer.NULL_PLAYERID;
+        owner = data.getPlayerList().getNullPlayer();
       }
     } else {
       if (ta == null) {
-        owner = GamePlayer.NULL_PLAYERID;
+        owner = data.getPlayerList().getNullPlayer();
       } else {
         owner = ta.getOriginalOwner();
         if (owner == null) {
-          owner = GamePlayer.NULL_PLAYERID;
+          owner = data.getPlayerList().getNullPlayer();
         }
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -178,7 +178,7 @@ public class TuvUtils {
             ? TuvUtils.getResourceCostsForTuvForAllPlayersMergedAndAveraged(data)
             : new HashMap<>();
     final List<GamePlayer> players = data.getPlayerList().getPlayers();
-    players.add(GamePlayer.NULL_PLAYERID);
+    players.add(data.getPlayerList().getNullPlayer());
     for (final GamePlayer p : players) {
       final ProductionFrontier frontier = p.getProductionFrontier();
       // any one will do then

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/MapTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/MapTest.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.data;
 
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("UnmatchedTest")
 class MapTest {
+  private GameData gameData = givenGameData().build();
+
   private Territory aa;
   private Territory ab;
   private Territory ac;
@@ -38,22 +41,22 @@ class MapTest {
     // llww
     // llwl
     // llww
-    aa = new Territory("aa", false, null);
-    ab = new Territory("ab", false, null);
-    ac = new Territory("ac", false, null);
-    ad = new Territory("ad", false, null);
-    ba = new Territory("ba", false, null);
-    bb = new Territory("bb", false, null);
-    bc = new Territory("bc", true, null);
-    bd = new Territory("bd", true, null);
-    ca = new Territory("ca", false, null);
-    cb = new Territory("cb", false, null);
-    cc = new Territory("cc", true, null);
-    cd = new Territory("cd", false, null);
-    da = new Territory("da", false, null);
-    db = new Territory("db", false, null);
-    dc = new Territory("dc", true, null);
-    dd = new Territory("dd", true, null);
+    aa = new Territory("aa", false, gameData);
+    ab = new Territory("ab", false, gameData);
+    ac = new Territory("ac", false, gameData);
+    ad = new Territory("ad", false, gameData);
+    ba = new Territory("ba", false, gameData);
+    bb = new Territory("bb", false, gameData);
+    bc = new Territory("bc", true, gameData);
+    bd = new Territory("bd", true, gameData);
+    ca = new Territory("ca", false, gameData);
+    cb = new Territory("cb", false, gameData);
+    cc = new Territory("cc", true, gameData);
+    cd = new Territory("cd", false, gameData);
+    da = new Territory("da", false, gameData);
+    db = new Territory("db", false, gameData);
+    dc = new Territory("dc", true, gameData);
+    dd = new Territory("dd", true, gameData);
     map = new GameMap(null);
     map.addTerritory(aa);
     map.addTerritory(ab);
@@ -95,7 +98,7 @@ class MapTest {
     map.addConnection(ad, bd);
     map.addConnection(bd, cd);
     map.addConnection(cd, dd);
-    nowhere = new Territory("nowhere", false, null);
+    nowhere = new Territory("nowhere", false, gameData);
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.data;
 
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,7 +23,7 @@ import org.triplea.java.collections.IntegerMap;
 @ExtendWith(MockitoExtension.class)
 class UnitCollectionTest {
 
-  @Mock private GameData mockGameData;
+  private GameData mockGameData = givenGameData().build();
   private UnitType unitTypeOne;
   private UnitType unitTypeTwo;
   private final GamePlayer defaultGamePlayer =

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -209,14 +209,14 @@ final class MatchesTest {
 
     @Test
     void shouldMatchWhenLandTerritoryIsUnownedAndHasTerritoryAttachment() {
-      landTerritory.setOwner(GamePlayer.NULL_PLAYERID);
+      landTerritory.setOwner(gameData.getPlayerList().getNullPlayer());
 
       assertThat(newMatch(), matches(landTerritory));
     }
 
     @Test
     void shouldMatchWhenLandTerritoryIsUnownedAndDoesNotHaveTerritoryAttachment() {
-      landTerritory.setOwner(GamePlayer.NULL_PLAYERID);
+      landTerritory.setOwner(gameData.getPlayerList().getNullPlayer());
       TerritoryAttachment.remove(landTerritory);
 
       assertThat(newMatch(), matches(landTerritory));
@@ -236,14 +236,14 @@ final class MatchesTest {
 
     @Test
     void shouldMatchWhenSeaTerritoryIsUnownedAndHasTerritoryAttachment() {
-      seaTerritory.setOwner(GamePlayer.NULL_PLAYERID);
+      seaTerritory.setOwner(gameData.getPlayerList().getNullPlayer());
 
       assertThat(newMatch(), matches(seaTerritory));
     }
 
     @Test
     void shouldNotMatchWhenSeaTerritoryIsUnownedAndDoesNotHaveTerritoryAttachment() {
-      seaTerritory.setOwner(GamePlayer.NULL_PLAYERID);
+      seaTerritory.setOwner(gameData.getPlayerList().getNullPlayer());
       TerritoryAttachment.remove(seaTerritory);
 
       assertThat(newMatch(), notMatches(seaTerritory));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.Change;
-import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.MoveDescription;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Unit;
@@ -310,7 +309,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final Route route = new Route(equatorialAfrica, westAfrica);
     assertEquals(4, equatorialAfrica.getUnitCollection().size());
     assertEquals(0, westAfrica.getUnitCollection().size());
-    assertEquals(GamePlayer.NULL_PLAYERID, westAfrica.getOwner());
+    assertEquals(gameData.getPlayerList().getNullPlayer(), westAfrica.getOwner());
     assertEquals(35, british.getResources().getQuantity(pus));
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.delegate.battle.casualty;
 
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -12,7 +13,6 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.data.UnitTypeList;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
@@ -27,9 +27,7 @@ import org.triplea.java.collections.IntegerMap;
 
 @ExtendWith(MockitoExtension.class)
 class CasualtyOrderOfLossesTest {
-
-  @Mock GameData gameData;
-  @Mock UnitTypeList unitTypeList;
+  final GameData gameData = givenGameData().build();
   @Mock GamePlayer player;
   @Mock UnitAttachment unitAttachment;
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySortingUtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySortingUtilTest.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.delegate.battle.casualty;
 
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.lenient;
@@ -23,7 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CasualtySortingUtilTest {
 
-  @Mock GameData gameData;
+  final GameData gameData = givenGameData().build();
   @Mock GamePlayer player;
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -25,6 +25,7 @@ import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.data.GameStep;
+import games.strategy.engine.data.PlayerList;
 import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.ResourceList;
 import games.strategy.engine.data.TechnologyFrontier;
@@ -43,6 +44,7 @@ public class MockGameData {
   private final GameSequence gameSequence = mock(GameSequence.class);
   private final TechTracker techTracker = mock(TechTracker.class);
   private final ResourceList resourceList = mock(ResourceList.class);
+  private final PlayerList playerList = mock(PlayerList.class);
 
   private MockGameData() {
     lenient().when(gameData.getProperties()).thenReturn(gameProperties);
@@ -52,6 +54,7 @@ public class MockGameData {
     lenient().when(gameData.getSequence()).thenReturn(gameSequence);
     lenient().when(gameData.getTechTracker()).thenReturn(techTracker);
     lenient().when(gameData.getResourceList()).thenReturn(resourceList);
+    lenient().when(gameData.getPlayerList()).thenReturn(playerList);
   }
 
   public static MockGameData givenGameData() {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
@@ -4,6 +4,7 @@ import static games.strategy.engine.data.CompositeChangeMatcher.compositeChangeC
 import static games.strategy.engine.data.changefactory.ObjectPropertyChangeMatcher.propertyChange;
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -13,7 +14,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
@@ -85,7 +85,7 @@ class MarkNoMovementLeftTest {
     final UnitAttachment unitAttachment = mock(UnitAttachment.class);
     when(unitType.getAttachment(UNIT_ATTACHMENT_NAME)).thenReturn(unitAttachment);
     when(unitAttachment.getIsAir()).thenReturn(false);
-    final Unit unit = spy(new Unit(unitType, mock(GamePlayer.class), mock(GameData.class)));
+    final Unit unit = spy(new Unit(unitType, mock(GamePlayer.class), givenGameData().build()));
     doReturn(movement).when(unit).getMovementLeft();
     return unit;
   }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/FiringGroupTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/FiringGroupTest.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.delegate.battle.steps.fire;
 
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -23,7 +24,7 @@ class FiringGroupTest {
 
   private static final String GROUP_NAME = "test";
 
-  @Mock GameData gameData;
+  final GameData gameData = givenGameData().build();
   @Mock GamePlayer player;
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardmentTest.java
@@ -4,6 +4,7 @@ import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenAnyUnit;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenSeaBattleSite;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -16,7 +17,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
@@ -43,7 +43,7 @@ class NavalBombardmentTest {
   @Test
   @DisplayName("Has bombardment units and first round")
   void bombardmentHappensIfHasBombardmentUnitsAndIsFirstRound() {
-    final UnitType unitType = spy(new UnitType("type", mock(GameData.class)));
+    final UnitType unitType = spy(new UnitType("type", givenGameData().build()));
     when(unitType.getAttachment(UNIT_ATTACHMENT_NAME)).thenReturn(mock(UnitAttachment.class));
     final Unit bombarder = spy(unitType.createTemp(1, mock(GamePlayer.class)).get(0));
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
@@ -7,6 +7,7 @@ import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattle
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenAnyUnit;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitCanEvadeAndCanNotBeTargetedByRandomUnit;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
@@ -16,7 +17,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
@@ -129,7 +129,7 @@ class SubmergeSubsVsOnlyAirStepTest {
     when(unitType.getAttachment(UNIT_ATTACHMENT_NAME)).thenReturn(unitAttachment);
     when(unitAttachment.getCanEvade()).thenReturn(true);
     when(unitAttachment.getCanNotBeTargetedBy()).thenReturn(Set.of(mock(UnitType.class)));
-    final Unit sub = new Unit(unitType, mock(GamePlayer.class), mock(GameData.class));
+    final Unit sub = new Unit(unitType, mock(GamePlayer.class), givenGameData().build());
     return List.of(
         Arguments.of(
             "Attacking subs submerge",

--- a/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelectorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelectorTest.java
@@ -44,7 +44,13 @@ public class AttackerAndDefenderSelectorTest {
   private final Territory russia = gameData.getMap().getTerritory("Russia");
 
   private final List<GamePlayer> players =
-      List.of(russians, germans, british, japanese, americans, GamePlayer.NULL_PLAYERID);
+      List.of(
+          russians,
+          germans,
+          british,
+          japanese,
+          americans,
+          gameData.getPlayerList().getNullPlayer());
 
   @Test
   void testNoCurrentPlayer() {
@@ -306,7 +312,7 @@ public class AttackerAndDefenderSelectorTest {
     assertThat(
         gameData.getRelationshipTracker().isAtWar(attacker.orElseThrow(), defender.orElseThrow()),
         is(true));
-    assertThat(defender.orElseThrow(), is(not(GamePlayer.NULL_PLAYERID)));
+    assertThat(defender.orElseThrow(), is(not(gameData.getPlayerList().getNullPlayer())));
     assertThat(attAndDef.getAttackingUnits(), is(empty()));
     assertThat(attAndDef.getDefendingUnits(), is(empty()));
   }


### PR DESCRIPTION
## Change Summary & Additional Notes
Deprecate NULL_PLAYERID in favor of PlayerList.getNullPlayer().

This change makes the null player be bound to an actual GameData object and fixes the issue where player.getData() may return null. This allows us to simplify a lot of code in the future by passing around fewer parameters to methods that take a GamePlayer, since the GameData can be retrieved from it at all times.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
