### PR TITLE
Omit some expensive GameData members when cloning for BattleCalc.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -401,10 +401,10 @@ public class GameData implements Serializable, GameState {
     return attachmentOrderAndValues;
   }
 
-  public void setAttachmentOrderAndValues(List<Tuple<IAttachment, List<Tuple<String, String>>>> values) {
+  public void setAttachmentOrderAndValues(
+      List<Tuple<IAttachment, List<Tuple<String, String>>>> values) {
     attachmentOrderAndValues = values;
   }
-
 
   /**
    * Returns all relationshipTypes that are valid in this game, default there is the NullRelation

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -107,7 +107,7 @@ public class GameData implements Serializable, GameState {
   @Getter private transient TechTracker techTracker = new TechTracker(this);
   private final IGameLoader loader = new TripleA();
   private History gameHistory = new History(this);
-  private final List<Tuple<IAttachment, List<Tuple<String, String>>>> attachmentOrderAndValues =
+  private List<Tuple<IAttachment, List<Tuple<String, String>>>> attachmentOrderAndValues =
       new ArrayList<>();
   private final Map<String, TerritoryEffect> territoryEffectList = new HashMap<>();
   private final BattleRecordsList battleRecordsList = new BattleRecordsList(this);
@@ -400,6 +400,11 @@ public class GameData implements Serializable, GameState {
   public List<Tuple<IAttachment, List<Tuple<String, String>>>> getAttachmentOrderAndValues() {
     return attachmentOrderAndValues;
   }
+
+  public void setAttachmentOrderAndValues(List<Tuple<IAttachment, List<Tuple<String, String>>>> values) {
+    attachmentOrderAndValues = values;
+  }
+
 
   /**
    * Returns all relationshipTypes that are valid in this game, default there is the NullRelation

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.IAttachment;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
@@ -18,7 +17,6 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -26,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.triplea.game.server.HeadlessGameServer;
 import org.triplea.injection.Injections;
-import org.triplea.util.Tuple;
 import org.triplea.util.Version;
 
 /** Responsible for loading saved games, new games from xml, and saving games. */

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -219,7 +219,8 @@ public final class GameDataManager {
           outStream.writeObject(data);
           writeDelegates(data, outStream);
         } else {
-          // TODO: Can we get rid of this and just compute it lazily when needed?
+          // TODO: Attachment order data is only used for XML export and takes up lots of memory.
+          // Could we remove it and just get the info again from the XML when exporting?
           var attachments = data.getAttachmentOrderAndValues();
           data.setAttachmentOrderAndValues(null);
           var history = data.getHistory();


### PR DESCRIPTION
## Change Summary & Additional Notes
Omit some expensive GameData members when cloning for BattleCalc.

Specifically, history and attachment order/values (used only for export XML option) are omitted.
This reduces the amount of data we need to serialize, improving speed of AIs and memory use.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
