### PR TITLE
Intern attachment-related strings to minimize memory and speed up cloning.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -961,7 +961,7 @@ public final class GameParser {
                 xmlUri, attachment, e.getMessage()),
             e);
       }
-      results.add(Tuple.of(name, finalValue));
+      results.add(Tuple.of(name.intern(), finalValue.intern()));
     }
     return results;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -113,7 +113,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     if (uppercaseValue.matches("AND|OR|\\d+(?:-\\d+)?")) {
       final String[] split = splitOnHyphen(uppercaseValue);
       if (split.length != 2 || Integer.parseInt(split[1]) > Integer.parseInt(split[0])) {
-        conditionType = uppercaseValue;
+        conditionType = uppercaseValue.intern();
         return;
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -280,7 +280,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
               + " format: \"1:10\" for 10% chance"
               + thisErrorMsg());
     }
-    this.chance = chance;
+    this.chance = chance.intern();
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -140,7 +140,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
       throw new GameParseException(
           "movementRestrictionType must be allowed or disallowed" + thisErrorMsg());
     }
-    movementRestrictionType = value;
+    movementRestrictionType = value.intern();
   }
 
   public @Nullable String getMovementRestrictionType() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -161,7 +161,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   private void setGameProperty(final String value) {
-    gameProperty = value;
+    gameProperty = value.intern();
   }
 
   private @Nullable String getGameProperty() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -341,6 +341,9 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     if (terrList != null && terrList.length > 0) {
       getListedTerritories(terrList, true, true);
       // removed checks for length & group commands because it breaks the setTerritoryCount feature.
+      for (int i = 0; i < terrList.length; i++) {
+        terrList[i] = terrList[i].intern();
+      }
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -261,7 +261,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     if (sb.length() > 0 && sb.substring(0, 1).equals(":")) {
       sb.replace(0, 1, "");
     }
-    return sb.toString();
+    return sb.toString().intern();
   }
 
   public static int getEachMultiple(final AbstractTriggerAttachment t) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -133,7 +133,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     if (this.when == null) {
       this.when = new ArrayList<>();
     }
-    this.when.add(Tuple.of(s[0], s[1]));
+    this.when.add(Tuple.of(s[0].intern(), s[1].intern()));
   }
 
   private void setWhen(final List<Tuple<String, String>> value) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -59,7 +59,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   private void setText(final String text) {
-    this.text = text;
+    this.text = text.intern();
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -73,7 +73,7 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   private void setCanalName(final String name) {
-    canalName = name;
+    canalName = name.intern();
   }
 
   public String getCanalName() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -85,10 +85,6 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   private void setLandTerritories(final String landTerritories) {
-    if (landTerritories == null) {
-      this.landTerritories = null;
-      return;
-    }
     final Set<Territory> terrs = new HashSet<>();
     for (final String name : splitOnColon(landTerritories)) {
       final Territory territory = getData().getMap().getTerritory(name);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -164,7 +164,7 @@ public class PlayerAttachment extends DefaultAttachment {
         types.add(getUnitTypeOrThrow(s[i]));
       }
     }
-    return Triple.of(max, s[1], types);
+    return Triple.of(max, s[1].intern(), types);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -131,7 +131,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
     if (relationshipChange == null) {
       relationshipChange = new ArrayList<>();
     }
-    relationshipChange.add(relChange);
+    relationshipChange.add(relChange.intern());
   }
 
   private void setRelationshipChange(final List<String> value) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -74,7 +74,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
       case ARCHETYPE_WAR:
       case ARCHETYPE_ALLIED:
       case ARCHETYPE_NEUTRAL:
-        this.archeType = lowerArcheType;
+        this.archeType = lowerArcheType.intern();
         break;
       default:
         throw new GameParseException(
@@ -109,7 +109,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
    * @param canFlyOver should be "true", "false" or "default"
    */
   private void setCanMoveAirUnitsOverOwnedLand(final String canFlyOver) {
-    canMoveAirUnitsOverOwnedLand = canFlyOver;
+    canMoveAirUnitsOverOwnedLand = canFlyOver.intern();
   }
 
   private String getCanMoveAirUnitsOverOwnedLand() {
@@ -135,7 +135,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   }
 
   private void setCanMoveLandUnitsOverOwnedLand(final String canFlyOver) {
-    canMoveLandUnitsOverOwnedLand = canFlyOver;
+    canMoveLandUnitsOverOwnedLand = canFlyOver.intern();
   }
 
   private String getCanMoveLandUnitsOverOwnedLand() {
@@ -154,7 +154,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   }
 
   private void setCanLandAirUnitsOnOwnedLand(final String canLandAir) {
-    canLandAirUnitsOnOwnedLand = canLandAir;
+    canLandAirUnitsOnOwnedLand = canLandAir.intern();
   }
 
   private String getCanLandAirUnitsOnOwnedLand() {
@@ -174,7 +174,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   }
 
   private void setCanTakeOverOwnedTerritory(final String canTakeOver) {
-    canTakeOverOwnedTerritory = canTakeOver;
+    canTakeOverOwnedTerritory = canTakeOver.intern();
   }
 
   private String getCanTakeOverOwnedTerritory() {
@@ -222,7 +222,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
                     + thisErrorMsg());
         }
       }
-      upkeepCost = integerCost;
+      upkeepCost = integerCost.intern();
     }
   }
 
@@ -250,7 +250,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
               + PROPERTY_TRUE
               + thisErrorMsg());
     }
-    alliancesCanChainTogether = value;
+    alliancesCanChainTogether = value.intern();
   }
 
   private String getAlliancesCanChainTogether() {
@@ -281,7 +281,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
               + PROPERTY_TRUE
               + thisErrorMsg());
     }
-    isDefaultWarPosition = value;
+    isDefaultWarPosition = value.intern();
   }
 
   private String getIsDefaultWarPosition() {
@@ -312,7 +312,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
               + PROPERTY_TRUE
               + thisErrorMsg());
     }
-    givesBackOriginalTerritories = value;
+    givesBackOriginalTerritories = value.intern();
   }
 
   private String getGivesBackOriginalTerritories() {
@@ -341,7 +341,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
               + PROPERTY_TRUE
               + thisErrorMsg());
     }
-    canMoveIntoDuringCombatMove = value;
+    canMoveIntoDuringCombatMove = value.intern();
   }
 
   private String getCanMoveIntoDuringCombatMove() {
@@ -371,7 +371,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
               + PROPERTY_TRUE
               + thisErrorMsg());
     }
-    canMoveThroughCanals = value;
+    canMoveThroughCanals = value.intern();
   }
 
   private String getCanMoveThroughCanals() {
@@ -403,7 +403,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
               + PROPERTY_TRUE
               + thisErrorMsg());
     }
-    rocketsCanFlyOver = value;
+    rocketsCanFlyOver = value.intern();
   }
 
   private String getRocketsCanFlyOver() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -499,10 +499,6 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   private void setAtWarPlayers(final String players) throws GameParseException {
-    if (players == null) {
-      atWarPlayers = null;
-      return;
-    }
     final String[] s = splitOnColon(players);
     if (s.length < 1) {
       throw new GameParseException("Empty enemy list" + thisErrorMsg());
@@ -536,10 +532,6 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   private void setTechs(final String newTechs) throws GameParseException {
-    if (newTechs == null) {
-      techs = null;
-      return;
-    }
     final String[] s = splitOnColon(newTechs);
     if (s.length < 1) {
       throw new GameParseException("Empty tech list" + thisErrorMsg());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -164,7 +164,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       throw new GameParseException(
           "destroyedTUV value must be currentRound or allRounds" + thisErrorMsg());
     }
-    destroyedTuv = value;
+    destroyedTuv = value.intern();
   }
 
   private @Nullable String getDestroyedTuv() {
@@ -216,7 +216,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     if (battle == null) {
       battle = new ArrayList<>();
     }
-    battle.add(Tuple.of((s[0] + ":" + s[1] + ":" + s[2] + ":" + s[3]), terrs));
+    battle.add(Tuple.of((s[0] + ":" + s[1] + ":" + s[2] + ":" + s[3]).intern(), terrs));
   }
 
   private void setBattle(final List<Tuple<String, List<Territory>>> value) {
@@ -280,7 +280,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     if (relationship == null) {
       relationship = new ArrayList<>();
     }
-    relationship.add((s.length == 3) ? (value + ":-1") : value);
+    String str = (s.length == 3) ? (value + ":-1") : value;
+    relationship.add(str.intern());
   }
 
   private void setRelationship(final List<String> value) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -474,7 +474,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     if (unitPresence == null) {
       unitPresence = new IntegerMap<>();
     }
-    unitPresence.put(value.replaceFirst(s[0] + ":", ""), n);
+    unitPresence.put(value.replaceFirst(s[0] + ":", "").intern(), n);
   }
 
   private void setUnitPresence(final IntegerMap<String> value) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -511,7 +511,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
                 + ABILITY_CAN_BOMBARD
                 + thisErrorMsg());
       }
-      abilities.add(ability);
+      abilities.add(ability.intern());
     }
   }
 
@@ -673,7 +673,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (airborneTargetedByAa == null) {
       airborneTargetedByAa = new HashMap<>();
     }
-    airborneTargetedByAa.put(s[0], unitTypes);
+    airborneTargetedByAa.put(s[0].intern(), unitTypes);
   }
 
   private void setAirborneTargettedByAa(final Map<String, Set<UnitType>> value) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -334,7 +334,7 @@ public class TechAttachment extends DefaultAttachment {
   private void setGenericTechs() {
     for (final TechAdvance ta : getData().getTechnologyFrontier()) {
       if (ta instanceof GenericTechAdvance && ((GenericTechAdvance) ta).getAdvance() == null) {
-        genericTech.put(ta.getProperty(), Boolean.FALSE);
+        genericTech.put(ta.getProperty().intern(), Boolean.FALSE);
       }
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -430,7 +430,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     if (whenCapturedByGoesTo == null) {
       whenCapturedByGoesTo = new ArrayList<>();
     }
-    whenCapturedByGoesTo.add(value);
+    whenCapturedByGoesTo.add(value.intern());
   }
 
   private void setWhenCapturedByGoesTo(final List<String> value) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -678,10 +678,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setUnitAttachmentName(final String name) throws GameParseException {
-    if (name == null) {
-      unitAttachmentName = null;
-      return;
-    }
     final String[] s = splitOnColon(name);
     if (s.length != 2) {
       throw new GameParseException(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -382,7 +382,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (activateTrigger == null) {
       activateTrigger = new ArrayList<>();
     }
-    activateTrigger.add(Tuple.of(s[0], options));
+    activateTrigger.add(Tuple.of(s[0].intern(), options.intern()));
   }
 
   private void setActivateTrigger(final List<Tuple<String, String>> value) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -435,7 +435,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (productionRule == null) {
       productionRule = new ArrayList<>();
     }
-    productionRule.add(prop);
+    productionRule.add(prop.intern());
   }
 
   private void setProductionRule(final List<String> value) {
@@ -467,7 +467,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setVictory(final String s) {
-    victory = s;
+    victory = s.intern();
   }
 
   private @Nullable String getVictory() {
@@ -535,7 +535,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (availableTech.containsKey(cat)) {
       tlist.putAll(availableTech.get(cat));
     }
-    availableTech.put(cat, tlist);
+    availableTech.put(cat.intern(), tlist);
   }
 
   private void setAvailableTech(final Map<String, Map<TechAdvance, Boolean>> value) {
@@ -564,7 +564,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       if (support == null) {
         support = new LinkedHashMap<>();
       }
-      support.put(name, !remove);
+      support.put(name.intern(), !remove);
     }
   }
 
@@ -585,7 +585,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (r == null) {
       throw new GameParseException("Invalid resource: " + s + thisErrorMsg());
     }
-    resource = s;
+    resource = s.intern();
   }
 
   private @Nullable String getResource() {
@@ -641,7 +641,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (relationshipChange == null) {
       relationshipChange = new ArrayList<>();
     }
-    relationshipChange.add(relChange);
+    relationshipChange.add(relChange.intern());
   }
 
   private void setRelationshipChange(final List<String> value) {
@@ -707,7 +707,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         && !s[0].startsWith(Constants.SUPPORT_ATTACHMENT_PREFIX)) {
       throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
-    unitAttachmentName = Tuple.of(s[1], s[0]);
+    unitAttachmentName = Tuple.of(s[1].intern(), s[0].intern());
   }
 
   private void setUnitAttachmentName(final Tuple<String, String> value) {
@@ -736,7 +736,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     // the last one is the property we are changing, while the rest is the string we are changing it
     // to
-    final String property = s[s.length - 1];
+    final String property = s[s.length - 1].intern();
     unitProperty.add(Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
 
@@ -775,10 +775,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setTerritoryAttachmentName(final String name) throws GameParseException {
-    if (name == null) {
-      territoryAttachmentName = null;
-      return;
-    }
     final String[] s = splitOnColon(name);
     if (s.length != 2) {
       throw new GameParseException(
@@ -804,7 +800,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (s[1].equals("CanalAttachment") && !s[0].startsWith(Constants.CANAL_ATTACHMENT_PREFIX)) {
       throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
-    territoryAttachmentName = Tuple.of(s[1], s[0]);
+    territoryAttachmentName = Tuple.of(s[1].intern(), s[0].intern());
   }
 
   private void setTerritoryAttachmentName(final Tuple<String, String> value) {
@@ -823,17 +819,13 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setTerritoryProperty(final String prop) {
-    if (prop == null) {
-      territoryProperty = null;
-      return;
-    }
     final String[] s = splitOnColon(prop);
     if (territoryProperty == null) {
       territoryProperty = new ArrayList<>();
     }
     // the last one is the property we are changing, while the rest is the string we are changing it
     // to
-    final String property = s[s.length - 1];
+    final String property = s[s.length - 1].intern();
     territoryProperty.add(Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
 
@@ -869,10 +861,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private void setPlayerAttachmentName(final String playerAttachmentName)
       throws GameParseException {
-    if (playerAttachmentName == null) {
-      this.playerAttachmentName = null;
-      return;
-    }
     // replace-all to automatically correct legacy (1.8) attachment spelling
     final String name = playerAttachmentName.replaceAll("ttatch", "ttach");
     final String[] s = splitOnColon(name);
@@ -923,7 +911,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         && !s[0].startsWith(Constants.USERACTION_ATTACHMENT_PREFIX)) {
       throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
-    this.playerAttachmentName = Tuple.of(s[1], s[0]);
+    this.playerAttachmentName = Tuple.of(s[1].intern(), s[0].intern());
   }
 
   private void setPlayerAttachmentName(final Tuple<String, String> value) {
@@ -942,17 +930,13 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setPlayerProperty(final String prop) {
-    if (prop == null) {
-      playerProperty = null;
-      return;
-    }
     final String[] s = splitOnColon(prop);
     if (playerProperty == null) {
       playerProperty = new ArrayList<>();
     }
     // the last one is the property we are changing, while the rest is the string we are changing it
     // to
-    final String property = s[s.length - 1];
+    final String property = s[s.length - 1].intern();
     playerProperty.add(Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
 
@@ -1021,7 +1005,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (!s[0].startsWith(Constants.RELATIONSHIPTYPE_ATTACHMENT_NAME)) {
       throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
-    relationshipTypeAttachmentName = Tuple.of(s[1], s[0]);
+    relationshipTypeAttachmentName = Tuple.of(s[1].intern(), s[0].intern());
   }
 
   private void setRelationshipTypeAttachmentName(final Tuple<String, String> value) {
@@ -1050,7 +1034,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     // the last one is the property we are changing, while the rest is the string we are changing it
     // to
-    final String property = s[s.length - 1];
+    final String property = s[s.length - 1].intern();
     relationshipTypeProperty.add(
         Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
@@ -1118,7 +1102,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (!s[0].startsWith(Constants.TERRITORYEFFECT_ATTACHMENT_NAME)) {
       throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
-    territoryEffectAttachmentName = Tuple.of(s[1], s[0]);
+    territoryEffectAttachmentName = Tuple.of(s[1].intern(), s[0].intern());
   }
 
   private void setTerritoryEffectAttachmentName(final Tuple<String, String> value) {
@@ -1137,17 +1121,13 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setTerritoryEffectProperty(final String prop) {
-    if (prop == null) {
-      territoryEffectProperty = null;
-      return;
-    }
     final String[] s = splitOnColon(prop);
     if (territoryEffectProperty == null) {
       territoryEffectProperty = new ArrayList<>();
     }
     // the last one is the property we are changing, while the rest is the string we are changing it
     // to
-    final String property = s[s.length - 1];
+    final String property = s[s.length - 1].intern();
     territoryEffectProperty.add(
         Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
@@ -1342,7 +1322,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (changeOwnership == null) {
       changeOwnership = new ArrayList<>();
     }
-    changeOwnership.add(value);
+    changeOwnership.add(value.intern());
   }
 
   private void setChangeOwnership(final List<String> value) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -726,10 +726,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setUnitProperty(final String prop) {
-    if (prop == null) {
-      unitProperty = null;
-      return;
-    }
     final String[] s = splitOnColon(prop);
     if (unitProperty == null) {
       unitProperty = new ArrayList<>();
@@ -980,10 +976,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setRelationshipTypeAttachmentName(final String name) throws GameParseException {
-    if (name == null) {
-      relationshipTypeAttachmentName = null;
-      return;
-    }
     final String[] s = splitOnColon(name);
     if (s.length != 2) {
       throw new GameParseException(
@@ -1024,10 +1016,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setRelationshipTypeProperty(final String prop) {
-    if (prop == null) {
-      relationshipTypeProperty = null;
-      return;
-    }
     final String[] s = splitOnColon(prop);
     if (relationshipTypeProperty == null) {
       relationshipTypeProperty = new ArrayList<>();
@@ -1078,10 +1066,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setTerritoryEffectAttachmentName(final String name) throws GameParseException {
-    if (name == null) {
-      territoryEffectAttachmentName = null;
-      return;
-    }
     final String[] s = splitOnColon(name);
     if (s.length != 2) {
       throw new GameParseException(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -533,7 +533,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (whenCapturedChangesInto == null) {
       whenCapturedChangesInto = new LinkedHashMap<>();
     }
-    whenCapturedChangesInto.put(s[0] + ":" + s[1], Tuple.of(s[2], unitsToMake));
+    whenCapturedChangesInto.put((s[0] + ":" + s[1]).intern(), Tuple.of(s[2].intern(), unitsToMake));
   }
 
   private void setWhenCapturedChangesInto(
@@ -574,7 +574,7 @@ public class UnitAttachment extends DefaultAttachment {
       if (destroyedWhenCapturedBy == null) {
         destroyedWhenCapturedBy = new ArrayList<>();
       }
-      destroyedWhenCapturedBy.add(Tuple.of(byOrFrom, getPlayerOrThrow(name)));
+      destroyedWhenCapturedBy.add(Tuple.of(byOrFrom.intern(), getPlayerOrThrow(name)));
     }
   }
 
@@ -968,7 +968,7 @@ public class UnitAttachment extends DefaultAttachment {
       if (special == null) {
         special = new HashSet<>();
       }
-      special.add(option);
+      special.add(option.intern());
     }
   }
 
@@ -993,6 +993,9 @@ public class UnitAttachment extends DefaultAttachment {
     if (canOnlyInvadeFrom[0].equalsIgnoreCase("all")) {
       canInvadeOnlyFrom = new String[] {"all"};
       return;
+    }
+    for (int i = 0; i < canOnlyInvadeFrom.length; i++) {
+      canOnlyInvadeFrom[i] = canOnlyInvadeFrom[i].intern();
     }
     canInvadeOnlyFrom = canOnlyInvadeFrom;
   }
@@ -1021,7 +1024,11 @@ public class UnitAttachment extends DefaultAttachment {
     if (requiresUnits == null) {
       requiresUnits = new ArrayList<>();
     }
-    requiresUnits.add(splitOnColon(value));
+    final String[] s = splitOnColon(value);
+    for (int i = 0; i < s.length; i++) {
+      s[i] = s[i].intern();
+    }
+    requiresUnits.add(s);
   }
 
   private void setRequiresUnits(final List<String[]> value) {
@@ -1042,8 +1049,9 @@ public class UnitAttachment extends DefaultAttachment {
       throw new GameParseException(
           "requiresUnitsToMove must have at least 1 unit type" + thisErrorMsg());
     }
-    for (final String s : array) {
-      getUnitTypeOrThrow(s);
+    for (int i = 0; i < array.length; i++) {
+      getUnitTypeOrThrow(array[i]);
+      array[i] = array[i].intern();
     }
     if (requiresUnitsToMove == null) {
       requiresUnitsToMove = new ArrayList<>();
@@ -1082,9 +1090,9 @@ public class UnitAttachment extends DefaultAttachment {
     final Tuple<Integer, Integer> fromTo = Tuple.of(from, to);
     final Tuple<String, String> effectNum;
     if (s.length == 3) {
-      effectNum = Tuple.of(s[2], null);
+      effectNum = Tuple.of(s[2].intern(), null);
     } else {
-      effectNum = Tuple.of(s[2], s[3]);
+      effectNum = Tuple.of(s[2].intern(), s[3].intern());
     }
     if (whenCombatDamaged == null) {
       whenCombatDamaged = new ArrayList<>();
@@ -1129,7 +1137,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (receivesAbilityWhenWith == null) {
       receivesAbilityWhenWith = new ArrayList<>();
     }
-    receivesAbilityWhenWith.add(value);
+    receivesAbilityWhenWith.add(value.intern());
   }
 
   private void setReceivesAbilityWhenWith(final List<String> value) {
@@ -2339,7 +2347,7 @@ public class UnitAttachment extends DefaultAttachment {
 
   @VisibleForTesting
   public void setTypeAa(final String s) {
-    typeAa = s;
+    typeAa = s.intern();
   }
 
   public String getTypeAa() {
@@ -2502,7 +2510,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
       throw new GameParseException(type + " value must owned, allied, or total" + thisErrorMsg());
     }
-    return Tuple.of(max, s[1]);
+    return Tuple.of(max, s[1].intern());
   }
 
   private void setTuv(final String s) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -159,7 +159,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
         throw new GameParseException(side + " side must be defence or offence" + thisErrorMsg());
       }
     }
-    this.side = side;
+    this.side = side.intern();
     return this;
   }
 
@@ -176,7 +176,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   @VisibleForTesting
   public UnitSupportAttachment setDice(final String dice) throws GameParseException {
     resetDice();
-    this.dice = dice;
+    this.dice = dice.intern();
     for (final String element : splitOnColon(dice)) {
       if (element.equalsIgnoreCase("roll")) {
         roll = true;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -87,7 +87,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     if (activateTrigger == null) {
       activateTrigger = new ArrayList<>();
     }
-    activateTrigger.add(Tuple.of(s[0], options));
+    activateTrigger.add(Tuple.of(s[0].intern(), options.intern()));
   }
 
   private void setActivateTrigger(final List<Tuple<String, String>> value) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1054,13 +1054,14 @@ class BattleCalculatorPanel extends JPanel {
     }
     setupAttackerAndDefender();
 
-    Instant t = Instant.now();
+    final Instant t = Instant.now();
     calculator =
         new ConcurrentBattleCalculator(
             () ->
                 SwingUtilities.invokeLater(
                     () -> {
-                      calculateButton.setText("Calculate Odds " + Duration.between(t, Instant.now()));
+                      log.debug("Battle Calculator ready in " + Duration.between(t, Instant.now()));
+                      calculateButton.setText("Calculate Odds");
                       calculateButton.setEnabled(true);
                       calculateButton.requestFocusInWindow();
                     }));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -30,6 +30,8 @@ import java.awt.Insets;
 import java.awt.Window;
 import java.awt.event.WindowEvent;
 import java.text.DecimalFormat;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -1052,12 +1054,13 @@ class BattleCalculatorPanel extends JPanel {
     }
     setupAttackerAndDefender();
 
+    Instant t = Instant.now();
     calculator =
         new ConcurrentBattleCalculator(
             () ->
                 SwingUtilities.invokeLater(
                     () -> {
-                      calculateButton.setText("Calculate Odds");
+                      calculateButton.setText("Calculate Odds " + Duration.between(t, Instant.now()));
                       calculateButton.setEnabled(true);
                       calculateButton.requestFocusInWindow();
                     }));


### PR DESCRIPTION
## Change Summary & Additional Notes
Intern attachment-related strings to minimize memory and speed up cloning.

Java's String.intern() function returns a canonical String object for the given string,
such that Strings that share content can use the same instance.

This is very relevant for triggers properties, where lots of triggers end up having the same properties set, either via variable expansion or even in older maps, where this was done manually.

This also helps tremendously with GameData cloning, since there's much fewer String objects to clone, since the same String instance is pointed to by multiple objects.

With this change, bringing up the Battle Calculator on "270BC Wars" goes from ~1.5s to ~0.7s on my machine (the 1.5s is already after many other improvements I landed).

Additionally, save game size goes to 860k (from 1.1MB), which is already after compression.
RAM use after GC goes to 129M from 192M.
These two are both after starting an all-human "270BC Wars" game at the start of the first human turn (after all the barbarian combats).

This change also cleans up some unnecessary null checks on attachment setters.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
