### PR TITLE
Fix game history and add Options class specifying what to include.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -25,7 +25,7 @@ public final class GameDataUtils {
    * before calling this method</strong>
    */
   public static Optional<GameData> cloneGameData(
-      final GameData data, GameDataManager.Options options, final Version engineVersion) {
+      GameData data, GameDataManager.Options options, Version engineVersion) {
     final byte[] bytes = gameDataToBytes(data, options, engineVersion).orElse(null);
     if (bytes != null) {
       return createGameDataFromBytes(bytes, engineVersion);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameDataUtils;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.ai.AbstractBuiltInAi;
@@ -180,8 +181,10 @@ public abstract class AbstractProAi extends AbstractBuiltInAi {
       try {
         data.acquireWriteLock();
         dataCopy =
-            GameDataUtils.cloneGameDataWithoutHistory(
-                    data, true, Injections.getInstance().getEngineVersion())
+            GameDataUtils.cloneGameData(
+                    data,
+                    GameDataManager.Options.builder().withDelegates(true).build(),
+                    Injections.getInstance().getEngineVersion())
                 .orElse(null);
         if (dataCopy == null) {
           return;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameDataUtils;
 import games.strategy.triplea.delegate.GameDelegateBridge;
 import games.strategy.triplea.delegate.battle.BattleResults;
@@ -38,7 +39,10 @@ class BattleCalculator implements IBattleCalculator {
   }
 
   BattleCalculator(GameData data, Version engineVersion) {
-    this(GameDataUtils.cloneGameData(data, false, engineVersion).orElse(null));
+    this(
+        GameDataUtils.cloneGameData(
+                data, GameDataManager.Options.forBattleCalculator(), engineVersion)
+            .orElse(null));
   }
 
   BattleCalculator(byte[] data, Version engineVersion) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -6,6 +6,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameDataUtils;
 import java.util.Collection;
 import java.util.List;
@@ -127,7 +128,10 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
         // Serialize the data, then release lock on it so game can continue (ie: we don't want to
         // lock on it while we copy it 16 times).
         data.acquireWriteLock();
-        serializedData = GameDataUtils.gameDataToBytes(data, false, engineVersion).orElse(null);
+        serializedData =
+            GameDataUtils.gameDataToBytes(
+                    data, GameDataManager.Options.forBattleCalculator(), engineVersion)
+                .orElse(null);
         if (serializedData == null) {
           return;
         }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1763,7 +1763,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     try {
       // we want to use a clone of the data, so we can make changes to it as we walk up and down the
       // history
-      final var cloneOptions = GameDataManager.Options.builder().withHistory(true).withDelegates(true).build();
+      final var cloneOptions =
+          GameDataManager.Options.builder().withHistory(true).withDelegates(true).build();
       clonedGameData = GameDataUtils.cloneGameData(data, cloneOptions).orElse(null);
       if (clonedGameData == null) {
         return;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1763,8 +1763,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     try {
       // we want to use a clone of the data, so we can make changes to it as we walk up and down the
       // history
-      final var cloneOptions =
-          GameDataManager.Options.builder().withHistory(true).withDelegates(true).build();
+      final var cloneOptions = GameDataManager.Options.builder().withHistory(true).build();
       clonedGameData = GameDataUtils.cloneGameData(data, cloneOptions).orElse(null);
       if (clonedGameData == null) {
         return;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1763,7 +1763,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     try {
       // we want to use a clone of the data, so we can make changes to it as we walk up and down the
       // history
-      clonedGameData = GameDataUtils.cloneGameData(data).orElse(null);
+      final var cloneOptions = GameDataManager.Options.builder().withHistory(true).withDelegates(true).build();
+      clonedGameData = GameDataUtils.cloneGameData(data, cloneOptions).orElse(null);
       if (clonedGameData == null) {
         return;
       }
@@ -1878,7 +1879,9 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                       try (OutputStream fileOutputStream = Files.newOutputStream(f.get())) {
                         final GameData datacopy =
                             GameDataUtils.cloneGameData(
-                                    data, true, Injections.getInstance().getEngineVersion())
+                                    data,
+                                    GameDataManager.Options.withEverything(),
+                                    Injections.getInstance().getEngineVersion())
                                 .orElse(null);
                         if (datacopy != null) {
                           datacopy.getHistory().gotoNode(historyPanel.getCurrentPopupNode());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -168,9 +168,8 @@ final class ExportMenu extends JMenu {
     try (PrintWriter writer =
         new PrintWriter(chooser.getSelectedFile(), StandardCharsets.UTF_8.toString())) {
       gameData.acquireReadLock();
-      final GameData clone =
-          GameDataUtils.cloneGameData(gameData, GameDataManager.Options.withEverything())
-              .orElse(null);
+      final var cloneOptions = GameDataManager.Options.builder().withHistory(true).build();
+      final GameData clone = GameDataUtils.cloneGameData(gameData, cloneOptions).orElse(null);
       if (clone == null) {
         return;
       }
@@ -397,9 +396,8 @@ final class ExportMenu extends JMenu {
     final GameData clonedGameData;
     gameData.acquireReadLock();
     try {
-      clonedGameData =
-          GameDataUtils.cloneGameData(gameData, GameDataManager.Options.withEverything())
-              .orElse(null);
+      final var cloneOptions = GameDataManager.Options.builder().withHistory(true).build();
+      clonedGameData = GameDataUtils.cloneGameData(gameData, cloneOptions).orElse(null);
       if (clonedGameData == null) {
         return;
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.export.GameDataExporter;
+import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameDataUtils;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.history.HistoryNode;
@@ -167,7 +168,9 @@ final class ExportMenu extends JMenu {
     try (PrintWriter writer =
         new PrintWriter(chooser.getSelectedFile(), StandardCharsets.UTF_8.toString())) {
       gameData.acquireReadLock();
-      final GameData clone = GameDataUtils.cloneGameData(gameData).orElse(null);
+      final GameData clone =
+          GameDataUtils.cloneGameData(gameData, GameDataManager.Options.withEverything())
+              .orElse(null);
       if (clone == null) {
         return;
       }
@@ -394,7 +397,9 @@ final class ExportMenu extends JMenu {
     final GameData clonedGameData;
     gameData.acquireReadLock();
     try {
-      clonedGameData = GameDataUtils.cloneGameData(gameData).orElse(null);
+      clonedGameData =
+          GameDataUtils.cloneGameData(gameData, GameDataManager.Options.withEverything())
+              .orElse(null);
       if (clonedGameData == null) {
         return;
       }


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix game history and add Options class specifying what to include.

My previous change resulted in history being omitted in the game copy being used for history view. This change corrects that by introducing an Options class specifying what to include when cloning data.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
