### PR TITLE
Teach ProAI how to buy units that consume other units.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -15,8 +15,10 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import org.triplea.java.collections.CollectionUtils;
@@ -34,6 +36,7 @@ public final class ProData {
   private Map<Unit, Territory> unitTerritoryMap = new HashMap<>();
   private IntegerMap<UnitType> unitValueMap = new IntegerMap<>();
   private @Nullable ProPurchaseOptionMap purchaseOptions = null;
+  private Set<Unit> unitsToBeConsumed = new HashSet<>();
   private double minCostPerHitPoint = Double.MAX_VALUE;
 
   private AbstractProAi proAi;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -36,6 +36,9 @@ public final class ProData {
   private Map<Unit, Territory> unitTerritoryMap = new HashMap<>();
   private IntegerMap<UnitType> unitValueMap = new IntegerMap<>();
   private @Nullable ProPurchaseOptionMap purchaseOptions = null;
+  // If we purchased units this turn that consume other units, these are the units selected to be
+  // consumed. These are already located at the factory locations, so should not be moved. In the
+  // future, we could add logic about moving such units to factory territories from elsewhere.
   private Set<Unit> unitsToBeConsumed = new HashSet<>();
   private double minCostPerHitPoint = Double.MAX_VALUE;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -239,14 +239,18 @@ class ProNonCombatMoveAi {
 
     // Add all units that can't move (allied units, 0 move units, etc)
     for (final Territory t : moveMap.keySet()) {
-      moveMap
-          .get(t)
-          .getCantMoveUnits()
-          .addAll(
-              t.getUnitCollection()
-                  .getMatches(
-                      ProMatches.unitCantBeMovedAndIsAlliedDefender(
-                          player, data.getRelationshipTracker(), t)));
+      final ProTerritory proTerritory = moveMap.get(t);
+      final Collection<Unit> alliedDefenders =
+          t.getUnitCollection()
+              .getMatches(
+                  ProMatches.unitCantBeMovedAndIsAlliedDefender(
+                      player, data.getRelationshipTracker(), t));
+      proTerritory.getCantMoveUnits().addAll(alliedDefenders);
+
+      // Also mark any any units that will be consumed as "can't move".
+      final Collection<Unit> toBeConsumedHere =
+          CollectionUtils.intersection(t.getUnits(), proData.getUnitsToBeConsumed());
+      proTerritory.getCantMoveUnits().addAll(toBeConsumedHere);
     }
 
     // Add all units that only have 1 move option and can't be transported

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -244,19 +244,13 @@ class ProNonCombatMoveAi {
     for (final Territory t : moveMap.keySet()) {
       final ProTerritory proTerritory = moveMap.get(t);
       Preconditions.checkState(proTerritory.getCantMoveUnits().isEmpty());
-
-      // Mark any any units that will be consumed as "can't move".
-      final Collection<Unit> toBeConsumedHere =
-          CollectionUtils.intersection(t.getUnits(), proData.getUnitsToBeConsumed());
-      proTerritory.addCantMoveUnits(toBeConsumedHere);
-
-      final Collection<Unit> alliedDefenders =
+      final Collection<Unit> cantMoveUnits =
           t.getUnitCollection()
               .getMatches(
                   ProMatches.unitCantBeMovedAndIsAlliedDefender(
                           player, data.getRelationshipTracker(), t)
-                      .and(not(toBeConsumedHere::contains)));
-      proTerritory.addCantMoveUnits(alliedDefenders);
+                      .or(proData.getUnitsToBeConsumed()::contains));
+      proTerritory.addCantMoveUnits(cantMoveUnits);
     }
 
     // Add all units that only have 1 move option and can't be transported

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -991,9 +991,7 @@ class ProPurchaseAi {
       resourceTracker.purchase(bestAaOption);
       final List<Unit> unitsToPlace =
           bestAaOption.getUnitType().createTemp(bestAaOption.getQuantity(), player);
-      placeTerritory.getPlaceUnits().addAll(unitsToPlace);
-      reserveUnitsThatNeedToBeConsumed(t, unitsToPlace);
-      ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
+      addUnitsToPlace(placeTerritory, unitsToPlace);
     }
   }
 
@@ -1156,9 +1154,7 @@ class ProPurchaseAi {
       }
 
       // Add units to place territory
-      placeTerritory.getPlaceUnits().addAll(unitsToPlace);
-      reserveUnitsThatNeedToBeConsumed(t, unitsToPlace);
-      ProLogger.debug(t + ", placedUnits=" + unitsToPlace);
+      addUnitsToPlace(placeTerritory, unitsToPlace);
     }
   }
 
@@ -1365,8 +1361,7 @@ class ProPurchaseAi {
           if (ppt.getTerritory().equals(maxTerritory)) {
             final List<Unit> factory =
                 bestFactoryOption.getUnitType().createTemp(bestFactoryOption.getQuantity(), player);
-            ppt.getPlaceUnits().addAll(factory);
-            reserveUnitsThatNeedToBeConsumed(ppt.getTerritory(), factory);
+            addUnitsToPlace(ppt, factory);
             if (resourceTracker.hasEnough(bestFactoryOption)) {
               resourceTracker.purchase(bestFactoryOption);
               ProLogger.debug(maxTerritory + ", placedFactory=" + factory);
@@ -2056,11 +2051,9 @@ class ProPurchaseAi {
         // Add transport units to sea place territory and amphib units to land place territory
         for (final ProPlaceTerritory ppt : purchaseTerritory.getCanPlaceTerritories()) {
           if (landTerritory.equals(ppt.getTerritory())) {
-            ppt.getPlaceUnits().addAll(amphibUnitsToPlace);
-            reserveUnitsThatNeedToBeConsumed(ppt.getTerritory(), amphibUnitsToPlace);
+            addUnitsToPlace(ppt, amphibUnitsToPlace);
           } else if (placeTerritory.equals(ppt)) {
-            ppt.getPlaceUnits().addAll(transportUnitsToPlace);
-            reserveUnitsThatNeedToBeConsumed(ppt.getTerritory(), transportUnitsToPlace);
+            addUnitsToPlace(ppt, transportUnitsToPlace);
           }
         }
         ProLogger.trace(
@@ -2161,9 +2154,7 @@ class ProPurchaseAi {
         remainingUnitProduction -= bestAttackOption.getQuantity();
         final List<Unit> newUnits =
             bestAttackOption.getUnitType().createTemp(bestAttackOption.getQuantity(), player);
-        placeTerritory.getPlaceUnits().addAll(newUnits);
-        reserveUnitsThatNeedToBeConsumed(t, newUnits);
-        ProLogger.trace(t + ", newUnits=" + newUnits);
+        addUnitsToPlace(placeTerritory, newUnits);
       }
     }
 
@@ -2223,9 +2214,7 @@ class ProPurchaseAi {
         remainingUnitProduction -= selectedOption.getQuantity();
         final List<Unit> newUnits =
             selectedOption.getUnitType().createTemp(selectedOption.getQuantity(), player);
-        placeTerritory.getPlaceUnits().addAll(newUnits);
-        reserveUnitsThatNeedToBeConsumed(t, newUnits);
-        ProLogger.trace(t + ", newUnits=" + newUnits);
+        addUnitsToPlace(placeTerritory, newUnits);
       }
     }
   }
@@ -2364,9 +2353,7 @@ class ProPurchaseAi {
             resourceTracker.purchase(bestUpgradeOption);
             final List<Unit> newUnits =
                 bestUpgradeOption.getUnitType().createTemp(bestUpgradeOption.getQuantity(), player);
-            placeTerritory.getPlaceUnits().addAll(newUnits);
-            reserveUnitsThatNeedToBeConsumed(t, newUnits);
-            ProLogger.trace(t + ", newUnits=" + newUnits);
+            addUnitsToPlace(placeTerritory, newUnits);
           }
         }
       }
@@ -2564,27 +2551,27 @@ class ProPurchaseAi {
           final List<Unit> constructions =
               CollectionUtils.getMatches(unitsToPlace, Matches.unitIsConstruction());
           unitsToPlace.removeAll(constructions);
-          ppt.getPlaceUnits().addAll(constructions);
-          reserveUnitsThatNeedToBeConsumed(ppt.getTerritory(), constructions);
+          addUnitsToPlace(ppt, constructions);
           final int numUnits =
               Math.min(purchaseTerritory.getRemainingUnitProduction(), unitsToPlace.size());
           final List<Unit> units = unitsToPlace.subList(0, numUnits);
           ppt.getPlaceUnits().addAll(units);
-          reserveUnitsThatNeedToBeConsumed(ppt.getTerritory(), units);
+          addUnitsToPlace(ppt, units);
           units.clear();
         }
       }
     }
   }
 
-  private void reserveUnitsThatNeedToBeConsumed(
-      final Territory t, final Collection<Unit> unitsToPlace) {
+  private void addUnitsToPlace(ProPlaceTerritory ppt, Collection<Unit> unitsToPlace) {
+    ppt.getPlaceUnits().addAll(unitsToPlace);
     // TODO: If consumed units can come from the place territory, this will need to change.
     Collection<Unit> existingUnits =
-        CollectionUtils.difference(t.getUnits(), proData.getUnitsToBeConsumed());
+        CollectionUtils.difference(ppt.getTerritory().getUnits(), proData.getUnitsToBeConsumed());
     proData
         .getUnitsToBeConsumed()
         .addAll(ProPurchaseUtils.getUnitsToConsume(player, existingUnits, unitsToPlace));
+    ProLogger.trace(ppt.getTerritory() + ", placedUnits=" + unitsToPlace);
   }
 
   private static void setCantHoldPlaceTerritory(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -389,6 +389,7 @@ class ProPurchaseAi {
     player = proData.getPlayer();
     territoryManager = new ProTerritoryManager(calc, proData);
 
+    // Clear list of units to be consumed, since we only used for movement phase.
     proData.getUnitsToBeConsumed().clear();
 
     if (purchaseTerritories != null) {
@@ -2555,7 +2556,6 @@ class ProPurchaseAi {
           final int numUnits =
               Math.min(purchaseTerritory.getRemainingUnitProduction(), unitsToPlace.size());
           final List<Unit> units = unitsToPlace.subList(0, numUnits);
-          ppt.getPlaceUnits().addAll(units);
           addUnitsToPlace(ppt, units);
           units.clear();
         }
@@ -2565,13 +2565,16 @@ class ProPurchaseAi {
 
   private void addUnitsToPlace(ProPlaceTerritory ppt, Collection<Unit> unitsToPlace) {
     ppt.getPlaceUnits().addAll(unitsToPlace);
-    // TODO: If consumed units can come from the place territory, this will need to change.
-    Collection<Unit> existingUnits =
-        CollectionUtils.difference(ppt.getTerritory().getUnits(), proData.getUnitsToBeConsumed());
-    proData
-        .getUnitsToBeConsumed()
-        .addAll(ProPurchaseUtils.getUnitsToConsume(player, existingUnits, unitsToPlace));
     ProLogger.trace(ppt.getTerritory() + ", placedUnits=" + unitsToPlace);
+    // TODO: If consumed units can come from a different territory, this will need to change.
+    Collection<Unit> candidateUnitsToConsume =
+        CollectionUtils.difference(ppt.getTerritory().getUnits(), proData.getUnitsToBeConsumed());
+    Collection<Unit> toConsume =
+        ProPurchaseUtils.getUnitsToConsume(player, candidateUnitsToConsume, unitsToPlace);
+    if (!toConsume.isEmpty()) {
+      ProLogger.trace(" toConsume=" + toConsume);
+      proData.getUnitsToBeConsumed().addAll(toConsume);
+    }
   }
 
   private static void setCantHoldPlaceTerritory(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -390,6 +390,8 @@ class ProPurchaseAi {
     territoryManager = new ProTerritoryManager(calc, proData);
 
     // Clear list of units to be consumed, since we only used for movement phase.
+    // Additionally, we omit units in this list when checking for eligible units to consume, so
+    // we need to clear it before we actually do placement.
     proData.getUnitsToBeConsumed().clear();
 
     if (purchaseTerritories != null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -1070,14 +1070,17 @@ class ProPurchaseAi {
 
       // Check for unplaced units
       final List<Unit> unitsToPlace = new ArrayList<>();
-      for (final Iterator<Unit> it = unplacedUnits.iterator(); it.hasNext(); ) {
+      for (final Iterator<Unit> it = unplacedUnits.iterator();
+          it.hasNext() && remainingUnitProduction > 0; ) {
         final Unit u = it.next();
-        if (remainingUnitProduction > 0
-            && ProPurchaseValidationUtils.canUnitBePlaced(proData, u, player, t, isBid)) {
+        unitsToPlace.add(u);
+        if (ProPurchaseValidationUtils.canUnitsBePlaced(
+            proData, unitsToPlace, player, t, t, isBid)) {
           remainingUnitProduction--;
-          unitsToPlace.add(u);
           it.remove();
           ProLogger.trace("Selected unplaced unit=" + u);
+        } else {
+          unitsToPlace.remove(unitsToPlace.size() - 1);
         }
       }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -2582,7 +2582,6 @@ class ProPurchaseAi {
       return;
     }
     ppt.getPlaceUnits().addAll(unitsToPlace);
-    System.err.println(ppt.getTerritory() + ", placedUnits=" + unitsToPlace);
     ProLogger.trace(ppt.getTerritory() + ", placedUnits=" + unitsToPlace);
     // TODO: If consumed units can come from a different territory, this will need to change.
     Collection<Unit> candidateUnitsToConsume =
@@ -2591,7 +2590,6 @@ class ProPurchaseAi {
         ProPurchaseUtils.getUnitsToConsume(player, candidateUnitsToConsume, unitsToPlace);
     if (!toConsume.isEmpty()) {
       ProLogger.trace(" toConsume=" + toConsume);
-      System.err.println("Planning to consume: " + toConsume + " in " + ppt.getTerritory());
       proData.getUnitsToBeConsumed().addAll(toConsume);
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -739,6 +739,7 @@ class ProPurchaseAi {
         while (true) {
           // Select purchase option
           ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+              proData,
               player,
               startOfTurnData,
               purchaseOptionsForTerritory,
@@ -782,8 +783,7 @@ class ProPurchaseAi {
           } else {
             remainingUnitProduction -= selectedOption.getQuantity();
           }
-          unitsToPlace.addAll(
-              selectedOption.getUnitType().createTemp(selectedOption.getQuantity(), player));
+          unitsToPlace.addAll(selectedOption.createTempUnits());
           if (selectedOption.isCarrier() || selectedOption.isAir()) {
             unusedCarrierCapacity =
                 ProTransportUtils.getUnusedCarrierCapacity(player, t, unitsToPlace);
@@ -959,13 +959,16 @@ class ProPurchaseAi {
           ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, specialPurchaseOptions, t, isBid);
       ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+          proData,
           player,
           startOfTurnData,
           purchaseOptionsForTerritory,
           resourceTracker,
           remainingUnitProduction,
-          new ArrayList<>(),
-          purchaseTerritories);
+          List.of(),
+          purchaseTerritories,
+          0,
+          t);
       if (purchaseOptionsForTerritory.isEmpty()) {
         continue;
       }
@@ -992,9 +995,7 @@ class ProPurchaseAi {
 
       // Create new temp units
       resourceTracker.purchase(bestAaOption);
-      final List<Unit> unitsToPlace =
-          bestAaOption.getUnitType().createTemp(bestAaOption.getQuantity(), player);
-      addUnitsToPlace(placeTerritory, unitsToPlace);
+      addUnitsToPlace(placeTerritory, bestAaOption.createTempUnits());
     }
   }
 
@@ -1087,29 +1088,38 @@ class ProPurchaseAi {
       while (true) {
         // Remove options that cost too much PUs or production
         ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+            proData,
             player,
             startOfTurnData,
             landFodderOptions,
             resourceTracker,
             remainingUnitProduction,
             unitsToPlace,
-            purchaseTerritories);
+            purchaseTerritories,
+            0,
+            t);
         ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+            proData,
             player,
             startOfTurnData,
             landAttackOptions,
             resourceTracker,
             remainingUnitProduction,
             unitsToPlace,
-            purchaseTerritories);
+            purchaseTerritories,
+            0,
+            t);
         ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+            proData,
             player,
             startOfTurnData,
             landDefenseOptions,
             resourceTracker,
             remainingUnitProduction,
             unitsToPlace,
-            purchaseTerritories);
+            purchaseTerritories,
+            0,
+            t);
 
         // Select purchase option
         Optional<ProPurchaseOption> optionalSelectedOption = Optional.empty();
@@ -1149,8 +1159,7 @@ class ProPurchaseAi {
         // Create new temp units
         resourceTracker.purchase(selectedOption);
         remainingUnitProduction -= selectedOption.getQuantity();
-        unitsToPlace.addAll(
-            selectedOption.getUnitType().createTemp(selectedOption.getQuantity(), player));
+        unitsToPlace.addAll(selectedOption.createTempUnits());
         attackAndDefenseDifference += (selectedOption.getAttack() - selectedOption.getDefense());
         selectFodderUnit = ((double) addedFodderUnits / unitsToPlace.size() * 100) <= fodderPercent;
         ProLogger.trace("Selected unit=" + selectedOption.getUnitType().getName());
@@ -1333,12 +1342,13 @@ class ProPurchaseAi {
               proData, player, purchaseOptions.getFactoryOptions(), maxTerritory, isBid);
       resourceTracker.removeTempPurchase(maxPlacedOption);
       ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+          proData,
           player,
           startOfTurnData,
           purchaseOptionsForTerritory,
           resourceTracker,
           0,
-          new ArrayList<>(),
+          List.of(),
           purchaseTerritories,
           1,
           maxTerritory);
@@ -1362,8 +1372,7 @@ class ProPurchaseAi {
         factoryPurchaseTerritories.put(maxTerritory, factoryPurchaseTerritory);
         for (final ProPlaceTerritory ppt : factoryPurchaseTerritory.getCanPlaceTerritories()) {
           if (ppt.getTerritory().equals(maxTerritory)) {
-            final List<Unit> factory =
-                bestFactoryOption.getUnitType().createTemp(bestFactoryOption.getQuantity(), player);
+            final List<Unit> factory = bestFactoryOption.createTempUnits();
             addUnitsToPlace(ppt, factory);
             if (resourceTracker.hasEnough(bestFactoryOption)) {
               resourceTracker.purchase(bestFactoryOption);
@@ -1573,13 +1582,16 @@ class ProPurchaseAi {
 
             // Select purchase option
             ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+                proData,
                 player,
                 startOfTurnData,
                 seaPurchaseOptionsForTerritory,
                 resourceTracker,
                 remainingUnitProduction,
                 unitsToPlace,
-                purchaseTerritories);
+                purchaseTerritories,
+                0,
+                t);
             final Map<ProPurchaseOption, Double> defenseEfficiencies = new HashMap<>();
             for (final ProPurchaseOption ppo : seaPurchaseOptionsForTerritory) {
               defenseEfficiencies.put(
@@ -1605,8 +1617,7 @@ class ProPurchaseAi {
             // Create new temp defenders
             resourceTracker.tempPurchase(selectedOption);
             remainingUnitProduction -= selectedOption.getQuantity();
-            unitsToPlace.addAll(
-                selectedOption.getUnitType().createTemp(selectedOption.getQuantity(), player));
+            unitsToPlace.addAll(selectedOption.createTempUnits());
             if (selectedOption.isCarrier() || selectedOption.isAir()) {
               unusedCarrierCapacity =
                   ProTransportUtils.getUnusedCarrierCapacity(player, t, unitsToPlace);
@@ -1798,13 +1809,16 @@ class ProPurchaseAi {
 
           // Select purchase option
           ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+              proData,
               player,
               startOfTurnData,
               seaPurchaseOptionsForTerritory,
               resourceTracker,
               remainingUnitProduction,
               unitsToPlace,
-              purchaseTerritories);
+              purchaseTerritories,
+              0,
+              t);
           final Map<ProPurchaseOption, Double> defenseEfficiencies = new HashMap<>();
           for (final ProPurchaseOption ppo : seaPurchaseOptionsForTerritory) {
             defenseEfficiencies.put(
@@ -1830,8 +1844,7 @@ class ProPurchaseAi {
           // Create new temp units
           resourceTracker.purchase(selectedOption);
           remainingUnitProduction -= selectedOption.getQuantity();
-          unitsToPlace.addAll(
-              selectedOption.getUnitType().createTemp(selectedOption.getQuantity(), player));
+          unitsToPlace.addAll(selectedOption.createTempUnits());
           if (selectedOption.isCarrier() || selectedOption.isAir()) {
             unusedCarrierCapacity =
                 ProTransportUtils.getUnusedCarrierCapacity(player, t, unitsToPlace);
@@ -1978,16 +1991,18 @@ class ProPurchaseAi {
 
             // Purchase units until transport is full
             while (transportCapacity > 0) {
-
               // Select amphib purchase option and add units
               ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+                  proData,
                   player,
                   startOfTurnData,
                   amphibPurchaseOptionsForTerritory,
                   resourceTracker,
                   remainingUnitProduction,
                   amphibUnitsToPlace,
-                  purchaseTerritories);
+                  purchaseTerritories,
+                  0,
+                  t);
               final Map<ProPurchaseOption, Double> amphibEfficiencies = new HashMap<>();
               for (final ProPurchaseOption ppo : amphibPurchaseOptionsForTerritory) {
                 if (ppo.getTransportCost() <= transportCapacity) {
@@ -2004,9 +2019,7 @@ class ProPurchaseAi {
               final ProPurchaseOption ppo = optionalSelectedOption.get();
 
               // Add amphib unit
-              final List<Unit> amphibUnits =
-                  ppo.getUnitType().createTemp(ppo.getQuantity(), player);
-              amphibUnitsToPlace.addAll(amphibUnits);
+              amphibUnitsToPlace.addAll(ppo.createTempUnits());
               resourceTracker.purchase(ppo);
               remainingUnitProduction -= ppo.getQuantity();
               transportCapacity -= ppo.getTransportCost();
@@ -2014,16 +2027,18 @@ class ProPurchaseAi {
             }
             transportsThatNeedUnits.remove(transport);
           } else {
-
             // Select purchase option
             ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+                proData,
                 player,
                 startOfTurnData,
                 seaTransportPurchaseOptionsForTerritory,
                 resourceTracker,
                 remainingUnitProduction,
                 transportUnitsToPlace,
-                purchaseTerritories);
+                purchaseTerritories,
+                0,
+                t);
             final Map<ProPurchaseOption, Double> transportEfficiencies = new HashMap<>();
             for (final ProPurchaseOption ppo : seaTransportPurchaseOptionsForTerritory) {
               transportEfficiencies.put(ppo, ppo.getTransportEfficiencyRatio());
@@ -2036,7 +2051,7 @@ class ProPurchaseAi {
             final ProPurchaseOption ppo = optionalSelectedOption.get();
 
             // Add transports
-            final List<Unit> transports = ppo.getUnitType().createTemp(ppo.getQuantity(), player);
+            final List<Unit> transports = ppo.createTempUnits();
             transportUnitsToPlace.addAll(transports);
             resourceTracker.purchase(ppo);
             remainingUnitProduction -= ppo.getQuantity();
@@ -2120,16 +2135,18 @@ class ProPurchaseAi {
       // Purchase long range attack units for any remaining production
       int remainingUnitProduction = purchaseTerritories.get(t).getRemainingUnitProduction();
       while (true) {
-
         // Remove options that cost too much PUs or production
         ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+            proData,
             player,
             startOfTurnData,
             purchaseOptionsForTerritory,
             resourceTracker,
             remainingUnitProduction,
             List.of(),
-            purchaseTerritories);
+            purchaseTerritories,
+            0,
+            t);
         if (purchaseOptionsForTerritory.isEmpty()) {
           break;
         }
@@ -2155,9 +2172,7 @@ class ProPurchaseAi {
         // Purchase unit
         resourceTracker.purchase(bestAttackOption);
         remainingUnitProduction -= bestAttackOption.getQuantity();
-        final List<Unit> newUnits =
-            bestAttackOption.getUnitType().createTemp(bestAttackOption.getQuantity(), player);
-        addUnitsToPlace(placeTerritory, newUnits);
+        addUnitsToPlace(placeTerritory, bestAttackOption.createTempUnits());
       }
     }
 
@@ -2187,16 +2202,18 @@ class ProPurchaseAi {
       // Purchase defense units for any remaining production
       int remainingUnitProduction = purchaseTerritories.get(t).getRemainingUnitProduction();
       while (true) {
-
         // Select purchase option
         ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+            proData,
             player,
             startOfTurnData,
             purchaseOptionsForTerritory,
             resourceTracker,
             remainingUnitProduction,
-            new ArrayList<>(),
-            purchaseTerritories);
+            List.of(),
+            purchaseTerritories,
+            0,
+            t);
         final Map<ProPurchaseOption, Double> defenseEfficiencies = new HashMap<>();
         for (final ProPurchaseOption ppo : purchaseOptionsForTerritory) {
           defenseEfficiencies.put(
@@ -2215,9 +2232,7 @@ class ProPurchaseAi {
         // Purchase unit
         resourceTracker.purchase(selectedOption);
         remainingUnitProduction -= selectedOption.getQuantity();
-        final List<Unit> newUnits =
-            selectedOption.getUnitType().createTemp(selectedOption.getQuantity(), player);
-        addUnitsToPlace(placeTerritory, newUnits);
+        addUnitsToPlace(placeTerritory, selectedOption.createTempUnits());
       }
     }
   }
@@ -2284,13 +2299,16 @@ class ProPurchaseAi {
         // Remove options that cost too much PUs or production
         resourceTracker.removeTempPurchase(minPurchaseOption);
         ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+            proData,
             player,
             startOfTurnData,
             purchaseOptionsForTerritory,
             resourceTracker,
             1,
-            new ArrayList<>(),
-            purchaseTerritories);
+            List.of(),
+            purchaseTerritories,
+            0,
+            t);
         resourceTracker.clearTempPurchases();
         if (purchaseOptionsForTerritory.isEmpty()) {
           break;
@@ -2354,9 +2372,7 @@ class ProPurchaseAi {
         for (int i = 0; i < unitsToRemove.size(); i++) {
           if (resourceTracker.hasEnough(bestUpgradeOption)) {
             resourceTracker.purchase(bestUpgradeOption);
-            final List<Unit> newUnits =
-                bestUpgradeOption.getUnitType().createTemp(bestUpgradeOption.getQuantity(), player);
-            addUnitsToPlace(placeTerritory, newUnits);
+            addUnitsToPlace(placeTerritory, bestUpgradeOption.createTempUnits());
           }
         }
       }
@@ -2406,7 +2422,6 @@ class ProPurchaseAi {
       final Map<Territory, ProPurchaseTerritory> placeNonConstructionTerritories,
       final List<ProPlaceTerritory> needToDefendTerritories,
       final IAbstractPlaceDelegate placeDelegate) {
-
     ProLogger.info("Place defenders with units=" + player.getUnits());
 
     final ProOtherMoveOptions enemyAttackOptions = territoryManager.getEnemyAttackOptions();
@@ -2446,7 +2461,6 @@ class ProPurchaseAi {
       final List<Unit> unitsToPlace = new ArrayList<>();
       ProBattleResult finalResult = new ProBattleResult();
       for (int i = 0; i < landPlaceCount; i++) {
-
         // Add defender
         unitsToPlace.add(unitsThatCanBePlaced.get(i));
 
@@ -2500,7 +2514,6 @@ class ProPurchaseAi {
       final List<ProPlaceTerritory> prioritizedTerritories,
       final IAbstractPlaceDelegate placeDelegate,
       final Predicate<Unit> unitMatch) {
-
     ProLogger.info("Place units=" + player.getUnits());
 
     // Loop through prioritized territories and place units
@@ -2536,7 +2549,6 @@ class ProPurchaseAi {
       final ProPlaceTerritory placeTerritory,
       final List<Unit> unitsToPlace,
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {
-
     // Add units to place territory
     for (final ProPurchaseTerritory purchaseTerritory : purchaseTerritories.values()) {
       for (final ProPlaceTerritory ppt : purchaseTerritory.getCanPlaceTerritories()) {
@@ -2566,7 +2578,11 @@ class ProPurchaseAi {
   }
 
   private void addUnitsToPlace(ProPlaceTerritory ppt, Collection<Unit> unitsToPlace) {
+    if (unitsToPlace.isEmpty()) {
+      return;
+    }
     ppt.getPlaceUnits().addAll(unitsToPlace);
+    System.err.println(ppt.getTerritory() + ", placedUnits=" + unitsToPlace);
     ProLogger.trace(ppt.getTerritory() + ", placedUnits=" + unitsToPlace);
     // TODO: If consumed units can come from a different territory, this will need to change.
     Collection<Unit> candidateUnitsToConsume =
@@ -2575,6 +2591,7 @@ class ProPurchaseAi {
         ProPurchaseUtils.getUnitsToConsume(player, candidateUnitsToConsume, unitsToPlace);
     if (!toConsume.isEmpty()) {
       ProLogger.trace(" toConsume=" + toConsume);
+      System.err.println("Planning to consume: " + toConsume + " in " + ppt.getTerritory());
       proData.getUnitsToBeConsumed().addAll(toConsume);
     }
   }
@@ -2598,10 +2615,8 @@ class ProPurchaseAi {
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {
     final List<ProPurchaseTerritory> territories = new ArrayList<>();
     for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
-      for (final ProPlaceTerritory ppt : t.getCanPlaceTerritories()) {
-        if (placeTerritory.equals(ppt)) {
-          territories.add(t);
-        }
+      if (t.getCanPlaceTerritories().contains(placeTerritory)) {
+        territories.add(t);
       }
     }
     return territories;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -399,4 +399,8 @@ public class ProPurchaseOption {
             30)
         / quantity;
   }
+
+  public List<Unit> createTempUnits() {
+    return getUnitType().createTemp(getQuantity(), player);
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -285,7 +285,7 @@ public class ProPurchaseOption {
     final List<Unit> units = new ArrayList<>();
     units.addAll(unitsToPlace);
     units.addAll(unitType.createTemp(1, player));
-    // Omit any units that will be consumed by the placed units here.
+    // Omit units that will be consumed by placing units here.
     Collection<Unit> toConsume = ProPurchaseUtils.getUnitsToConsume(player, ownedLocalUnits, units);
     units.addAll(CollectionUtils.difference(ownedLocalUnits, toConsume));
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
+import games.strategy.triplea.ai.pro.util.ProPurchaseUtils;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Matches;
@@ -16,6 +17,7 @@ import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.SupportCalculator;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -59,6 +61,7 @@ public class ProPurchaseOption {
   private final Set<UnitSupportAttachment> unitSupportAttachments;
   @Getter private boolean isAttackSupport;
   @Getter private boolean isDefenseSupport;
+  @Getter private final boolean consumesUnits;
 
   ProPurchaseOption(
       final ProductionRule productionRule,
@@ -132,6 +135,7 @@ public class ProPurchaseOption {
         isDefenseSupport = true;
       }
     }
+    consumesUnits = !unitAttachment.getConsumesUnits().isEmpty();
   }
 
   @Override
@@ -274,14 +278,17 @@ public class ProPurchaseOption {
       final List<Unit> unitsToPlace,
       final GameData data,
       final boolean defense) {
-
     if ((!isAttackSupport && !defense) || (!isDefenseSupport && defense)) {
       return 0;
     }
 
-    final List<Unit> units = new ArrayList<>(ownedLocalUnits);
+    final List<Unit> units = new ArrayList<>();
     units.addAll(unitsToPlace);
     units.addAll(unitType.createTemp(1, player));
+    // Omit any units that will be consumed by the placed units here.
+    Collection<Unit> toConsume = ProPurchaseUtils.getUnitsToConsume(player, ownedLocalUnits, units);
+    units.addAll(CollectionUtils.difference(ownedLocalUnits, toConsume));
+
     final SupportCalculator availableSupports =
         new SupportCalculator(
             units,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
@@ -66,8 +66,7 @@ public class ProPurchaseOptionMap {
       final UnitType unitType = (UnitType) resourceOrUnit;
 
       // Add rule to appropriate purchase option list
-      if (Matches.unitTypeConsumesUnitsOnCreation().test(unitType)
-          || UnitAttachment.get(unitType).getIsSuicideOnHit()
+      if (UnitAttachment.get(unitType).getIsSuicideOnHit()
           || canUnitTypeSuicide(unitType, player)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         specialOptions.add(ppo);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
@@ -66,7 +66,7 @@ public class ProResourceTracker {
 
   @Override
   public String toString() {
-    return getRemaining().toString();
+    return getRemaining().toString().replaceAll("\n", " ");
   }
 
   private IntegerMap<Resource> getRemaining() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -12,6 +12,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TransportTracker;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -319,11 +320,15 @@ public class ProTerritory {
   }
 
   public List<Unit> getCantMoveUnits() {
-    return cantMoveUnits;
+    return Collections.unmodifiableList(cantMoveUnits);
   }
 
   public void addCantMoveUnit(final Unit unit) {
     this.cantMoveUnits.add(unit);
+  }
+
+  public void addCantMoveUnits(final Collection<Unit> units) {
+    this.cantMoveUnits.addAll(units);
   }
 
   public void setMaxEnemyUnits(final List<Unit> maxEnemyUnits) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -344,7 +344,8 @@ public final class ProPurchaseUtils {
         int neededCount = needed.getInt(neededType);
         Collection<Unit> found = CollectionUtils.getNMatches(existingUnits, neededCount, matcher);
         // The caller should have already validated that the required units are present.
-        Preconditions.checkState(found.size() == neededCount);
+        Preconditions.checkState(found.size() == neededCount,
+            "Not found: " + neededCount + " of " + neededType + " for " + unitsToPlace);
         unitsToConsume.addAll(found);
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.ai.pro.util;
 
+import com.google.common.base.Preconditions;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
@@ -18,6 +19,7 @@ import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TransportTracker;
 import java.util.ArrayList;
@@ -327,5 +329,27 @@ public final class ProPurchaseUtils {
       }
     }
     return placeUnits;
+  }
+
+  public static Collection<Unit> getUnitsToConsume(
+      GamePlayer player, Collection<Unit> existingUnits, Collection<Unit> unitsToPlace) {
+    Collection<Unit> unitsThatConsume =
+        CollectionUtils.getMatches(unitsToPlace, Matches.unitConsumesUnitsOnCreation());
+    Set<Unit> unitsToConsume = new HashSet<>();
+    for (Unit unitThatConsumes : unitsThatConsume) {
+      final UnitType unitThatConsumesType = unitThatConsumes.getType();
+      IntegerMap<UnitType> needed = UnitAttachment.get(unitThatConsumesType).getConsumesUnits();
+      for (UnitType neededUnitType : needed.keySet()) {
+        final Predicate<Unit> matcher =
+            Matches.eligibleUnitToConsume(player, neededUnitType)
+                .and(u -> !unitsToConsume.contains(u));
+        int neededCount = needed.getInt(neededUnitType);
+        Collection<Unit> found = CollectionUtils.getNMatches(existingUnits, neededCount, matcher);
+        // The caller should have already validated that the required units are present.
+        Preconditions.checkState(found.size() == neededCount);
+        unitsToConsume.addAll(found);
+      }
+    }
+    return unitsToConsume;
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -344,7 +344,8 @@ public final class ProPurchaseUtils {
         int neededCount = needed.getInt(neededType);
         Collection<Unit> found = CollectionUtils.getNMatches(existingUnits, neededCount, matcher);
         // The caller should have already validated that the required units are present.
-        Preconditions.checkState(found.size() == neededCount,
+        Preconditions.checkState(
+            found.size() == neededCount,
             "Not found: " + neededCount + " of " + neededType + " for " + unitsToPlace);
         unitsToConsume.addAll(found);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -336,14 +336,12 @@ public final class ProPurchaseUtils {
     Collection<Unit> unitsThatConsume =
         CollectionUtils.getMatches(unitsToPlace, Matches.unitConsumesUnitsOnCreation());
     Set<Unit> unitsToConsume = new HashSet<>();
-    for (Unit unitThatConsumes : unitsThatConsume) {
-      final UnitType unitThatConsumesType = unitThatConsumes.getType();
-      IntegerMap<UnitType> needed = UnitAttachment.get(unitThatConsumesType).getConsumesUnits();
-      for (UnitType neededUnitType : needed.keySet()) {
+    for (Unit unitToBuild : unitsThatConsume) {
+      IntegerMap<UnitType> needed = UnitAttachment.get(unitToBuild.getType()).getConsumesUnits();
+      for (UnitType neededType : needed.keySet()) {
         final Predicate<Unit> matcher =
-            Matches.eligibleUnitToConsume(player, neededUnitType)
-                .and(u -> !unitsToConsume.contains(u));
-        int neededCount = needed.getInt(neededUnitType);
+            Matches.eligibleUnitToConsume(player, neededType).and(u -> !unitsToConsume.contains(u));
+        int neededCount = needed.getInt(neededType);
         Collection<Unit> found = CollectionUtils.getNMatches(existingUnits, neededCount, matcher);
         // The caller should have already validated that the required units are present.
         Preconditions.checkState(found.size() == neededCount);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
@@ -158,7 +158,11 @@ public final class ProPurchaseValidationUtils {
                     purchaseOption, player, data, unitsToPlace, purchaseTerritories)
                 || hasReachedConstructionLimits(
                     purchaseOption, data, unitsToPlace, purchaseTerritories, territory)
-    || !unitsToConsumeAreAllPresent(proData, player, territory, combineLists(unitsToPlace, purchaseOption.createTempUnits())));
+                || !unitsToConsumeAreAllPresent(
+                    proData,
+                    player,
+                    territory,
+                    combineLists(unitsToPlace, purchaseOption.createTempUnits())));
   }
 
   private List<Unit> combineLists(List<Unit> l1, List<Unit> l2) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
@@ -101,19 +101,16 @@ public final class ProPurchaseValidationUtils {
     if (error != null) {
       return false;
     }
-    return allRequiredUnitsPresent(proData, player, t, units);
+    return unitsToConsumeAreAllPresent(proData, player, t, units);
   }
 
-  private boolean allRequiredUnitsPresent(
-      ProData proData, GamePlayer player, Territory t, Collection<Unit> units) {
+  private boolean unitsToConsumeAreAllPresent(
+      ProData proData, GamePlayer player, Territory t, Collection<Unit> unitsToBuild) {
     // Check if units that must be consumed are all present, taking into account units that we
     // are already planning to consume.
     IntegerMap<UnitType> requiredUnits = new IntegerMap<>();
-    for (Unit unitToBuild : units) {
-      final UnitAttachment ua = UnitAttachment.get(unitToBuild.getType());
-      if (ua != null) {
-        requiredUnits.add(ua.getConsumesUnits());
-      }
+    for (Unit unitToBuild : unitsToBuild) {
+      requiredUnits.add(UnitAttachment.get(unitToBuild.getType()).getConsumesUnits());
     }
     if (requiredUnits.isEmpty()) {
       return true;
@@ -121,6 +118,7 @@ public final class ProPurchaseValidationUtils {
     IntegerMap<UnitType> eligibleTerritoryUnits = new IntegerMap<>();
     // TODO: This will need to change if consumed units may come from other territories.
     for (Unit u : t.getUnits()) {
+      // Don't consider units that we've already marked for use.
       if (!proData.getUnitsToBeConsumed().contains(u)
           && Matches.eligibleUnitToConsume(player, u.getType()).test(u)) {
         eligibleTerritoryUnits.add(u.getType(), 1);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1722,14 +1722,14 @@ public final class Matches {
   public static Predicate<UnitType> unitTypeConsumesUnitsOnCreation() {
     return unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit);
-      return ua != null && ua.getConsumesUnits() != null && !ua.getConsumesUnits().isEmpty();
+      return ua != null && !ua.getConsumesUnits().isEmpty();
     };
   }
 
-  static Predicate<Unit> unitConsumesUnitsOnCreation() {
+  public static Predicate<Unit> unitConsumesUnitsOnCreation() {
     return unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua != null && ua.getConsumesUnits() != null && !ua.getConsumesUnits().isEmpty();
+      return ua != null && !ua.getConsumesUnits().isEmpty();
     };
   }
 
@@ -1744,16 +1744,11 @@ public final class Matches {
       final Collection<UnitType> requiredUnits = requiredUnitsMap.keySet();
       boolean canBuild = true;
       for (final UnitType ut : requiredUnits) {
-        final Predicate<Unit> unitIsOwnedByAndOfTypeAndNotDamaged =
-            unitIsOwnedBy(unitWhichRequiresUnits.getOwner())
-                .and(unitIsOfType(ut))
-                .and(unitHasNotTakenAnyBombingUnitDamage())
-                .and(unitHasNotTakenAnyDamage())
-                .and(unitIsNotDisabled());
         final int requiredNumber = requiredUnitsMap.getInt(ut);
         final int numberInTerritory =
             CollectionUtils.countMatches(
-                unitsInTerritoryAtStartOfTurn, unitIsOwnedByAndOfTypeAndNotDamaged);
+                unitsInTerritoryAtStartOfTurn,
+                eligibleUnitToConsume(unitWhichRequiresUnits.getOwner(), ut));
         if (numberInTerritory < requiredNumber) {
           canBuild = false;
         }
@@ -1763,6 +1758,14 @@ public final class Matches {
       }
       return canBuild;
     };
+  }
+
+  public static Predicate<Unit> eligibleUnitToConsume(GamePlayer owner, UnitType ut) {
+    return unitIsOwnedBy(owner)
+        .and(unitIsOfType(ut))
+        .and(unitHasNotTakenAnyBombingUnitDamage())
+        .and(unitHasNotTakenAnyDamage())
+        .and(unitIsNotDisabled());
   }
 
   public static Predicate<Unit> unitRequiresUnitsOnCreation() {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtilsTest.java
@@ -1,0 +1,66 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static games.strategy.triplea.delegate.GameDataTestUtil.britain;
+import static games.strategy.triplea.delegate.GameDataTestUtil.unitType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.GameState;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ProPurchaseUtilsTest {
+  final GameState gameData = TestMapGameData.TWW.getGameData();
+  final GamePlayer british = checkNotNull(britain(gameData));
+  final UnitType trenchType = checkNotNull(unitType("britishEntrenchment", gameData));
+  final UnitType materialType = checkNotNull(unitType("Material", gameData));
+  final UnitType fortType = checkNotNull(unitType("britishFortification", gameData));
+  final Unit trench1 = trenchType.create(british);
+  final Unit trench2 = trenchType.create(british);
+  final Unit material1 = materialType.create(british);
+  final Unit material2 = materialType.create(british);
+  final Unit fort1 = fortType.create(british);
+  final Unit fort2 = fortType.create(british);
+
+  @Test
+  void getUnitsToConsumeBasic() {
+    // Fort requires 1 trench and 1 material.
+    assertThat(
+        getUnitsToConsume(List.of(trench1, material1), List.of(fort1)),
+        containsInAnyOrder(trench1, material1));
+  }
+
+  @Test
+  void getUnitsToConsumeTwoUnits() {
+    assertThat(
+        getUnitsToConsume(List.of(trench1, trench2, material1, material2), List.of(fort1, fort2)),
+        containsInAnyOrder(trench1, trench2, material1, material2));
+  }
+
+  @Test
+  void getUnitsToConsumeMultipleTypes() {
+    // Trench requires 1 material.
+    assertThat(
+        getUnitsToConsume(List.of(fort2, material1, material2, trench2), List.of(trench1, fort1)),
+        containsInAnyOrder(material1, material2, trench2));
+  }
+
+  @Test
+  void getUnitsToConsumeNotEnough() {
+    /// An exception should be thrown if insufficient units.
+    assertThrows(
+        IllegalStateException.class,
+        () -> getUnitsToConsume(List.of(material1, material2), List.of(fort1)));
+  }
+
+  private Collection<Unit> getUnitsToConsume(Collection<Unit> existing, Collection<Unit> toBuild) {
+    return ProPurchaseUtils.getUnitsToConsume(british, existing, toBuild);
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtilsTest.java
@@ -46,7 +46,7 @@ public class ProPurchaseUtilsTest {
 
   @Test
   void getUnitsToConsumeMultipleTypes() {
-    // Trench requires 1 material.
+    // Trench requires 1 material + fort requires 1 trench and 1 material.
     assertThat(
         getUnitsToConsume(List.of(fort2, material1, material2, trench2), List.of(trench1, fort1)),
         containsInAnyOrder(material1, material2, trench2));
@@ -54,7 +54,7 @@ public class ProPurchaseUtilsTest {
 
   @Test
   void getUnitsToConsumeNotEnough() {
-    /// An exception should be thrown if insufficient units.
+    // An exception should be thrown if insufficient units.
     assertThrows(
         IllegalStateException.class,
         () -> getUnitsToConsume(List.of(material1, material2), List.of(fort1)));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -336,7 +336,7 @@ public final class GameDataTestUtil {
   /**
    * Returns a UnitType object matching the given name for the specified GameData object if present.
    */
-  static UnitType unitType(final String name, final GameState data) {
+  public static UnitType unitType(final String name, final GameState data) {
     return data.getUnitTypeList().getUnitType(name);
   }
 

--- a/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -35,7 +34,7 @@ public class CollectionUtils {
     checkNotNull(collection);
     checkNotNull(predicate);
 
-    return (int) collection.stream().filter(predicate).count();
+    return (int) ImmutableList.copyOf(collection).stream().filter(predicate).count();
   }
 
   /**
@@ -50,7 +49,7 @@ public class CollectionUtils {
     checkNotNull(collection);
     checkNotNull(predicate);
 
-    return collection.stream().filter(predicate).collect(Collectors.toList());
+    return ImmutableList.copyOf(collection).stream().filter(predicate).collect(Collectors.toList());
   }
 
   /**
@@ -69,21 +68,22 @@ public class CollectionUtils {
     checkArgument(max >= 0, "max must not be negative");
     checkNotNull(predicate);
 
-    return collection.stream().filter(predicate).limit(max).collect(Collectors.toList());
+    return ImmutableList.copyOf(collection).stream()
+        .filter(predicate)
+        .limit(max)
+        .collect(Collectors.toList());
   }
 
   /** return a such that a exists in c1 and a exists in c2. always returns a new collection. */
   public static <T> List<T> intersection(
       final Collection<T> collection1, final Collection<T> collection2) {
-    if (collection1 == null
-        || collection2 == null
-        || collection1.isEmpty()
-        || collection2.isEmpty()) {
+    if (collection1 == null || collection2 == null) {
       return new ArrayList<>();
     }
-    final Collection<T> c2 =
-        (collection2 instanceof Set) ? collection2 : ImmutableSet.copyOf(collection2);
-    return collection1.stream().distinct().filter(c2::contains).collect(Collectors.toList());
+    final Collection<T> c1 = ImmutableSet.copyOf(collection1);
+    final Collection<T> c2 = ImmutableSet.copyOf(collection2);
+
+    return c1.stream().filter(c2::contains).collect(Collectors.toList());
   }
 
   /** Returns a such that a exists in c1 but not in c2. Always returns a new collection. */
@@ -96,9 +96,10 @@ public class CollectionUtils {
       return new ArrayList<>(collection1);
     }
 
-    final Collection<T> c2 =
-        (collection2 instanceof Set) ? collection2 : ImmutableSet.copyOf(collection2);
-    return collection1.stream().distinct().filter(not(c2::contains)).collect(Collectors.toList());
+    final Collection<T> c1 = ImmutableSet.copyOf(collection1);
+    final Collection<T> c2 = ImmutableSet.copyOf(collection2);
+
+    return ImmutableList.copyOf(c1).stream().filter(not(c2::contains)).collect(Collectors.toList());
   }
 
   /**


### PR DESCRIPTION
## Change Summary & Additional Notes

Teach ProAI how to buy units that consume other units.

This is done by not treating these units as 'special' buy options that are ignored and instead to consider them normally, except:
 - Track units that will be consumed.
 - Don't move such units during move phases.
 - When doing combat simulation that include the placed units, omit the ones that will be consumed.

Tested multiple all-AI rounds on the following maps:
  - Imperialism 1974
  - Civil War: A House Divided

Observed AI purchasing and successfully placing units that require consumption of other units. Quite a lot of these on the Civil War map!

I also checked a few other maps that have such units, such as TWW and "270BC Wars", these ran without errors but I didn't notice AI buying units that consume units. Of note, the AI still uses all its current logic to decide which units it should buy, but now can also consider units that consume others units too in the possible options.


## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->NEW|Hard AI can now purchase and place units that consume other units.<!--END_RELEASE_NOTE-->
