### PR TITLE
Fix errors with map resources being not found in 2.6.

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -94,6 +95,9 @@ public final class FileUtils {
     try (Stream<Path> files = Files.walk(searchRoot, maxDepth)) {
       return files
           .filter(f -> f.getFileName().toString().equals(fileName))
+          // Sort by path name, so that the ordering is deterministic and paths closer to the root
+          // are earlier in the list.
+          .sorted(Comparator.comparingInt(f -> f.toAbsolutePath().toString().length()))
           .collect(Collectors.toList());
     } catch (final IOException e) {
       log.error(


### PR DESCRIPTION
## Change Summary & Additional Notes

Fix errors with map resources being not found in 2.6.

This was caused by some maps having duplicate files (e.g. a polygon.txt file in baseTiles folder). Before this change, it's undefined which of these files will be found first and all other files will be expected to be alongside it.

With this change, the search returns files in a deterministic order, sorted by path length. So files closer to the root will be first in the list. This makes the behavior deterministic across platforms and the map to use the file closest to the map root.

Tested:
  Loading WW2 Oil and Snow on Windows, both starting the game and viewing the images in the game notes. Without this change, that map exhibited https://github.com/triplea-game/triplea/issues/10417.


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
