### PR TITLE
Bottom bar: Remove space reserved for status text when no present.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -72,6 +72,7 @@ public class BottomBar extends JPanel {
         territoryInfo,
         gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.CENTER).build());
 
+    statusMessage.setVisible(false);
     statusMessage.setPreferredSize(new Dimension(0, 0));
     statusMessage.setBorder(new EtchedBorder(EtchedBorder.RAISED));
     centerPanel.add(
@@ -99,6 +100,7 @@ public class BottomBar extends JPanel {
   }
 
   public void setStatus(final String msg, final Optional<Image> image) {
+    statusMessage.setVisible(!msg.isEmpty());
     statusMessage.setText(msg);
 
     if (!msg.isEmpty() && image.isPresent()) {


### PR DESCRIPTION
## Change Summary & Additional Notes
Bottom bar: Remove space reserved for status text when no present.

This change complements the recent unit bar change by hiding the status message area when there is no status message displayed. When the area is hidden, more space is available for the other parts, such as the unit bar.

Screenshot without status text:
![status_bar_hidden](https://user-images.githubusercontent.com/17648/170514732-96547297-6080-4472-ba76-14c649e2bff4.png)

Screenshot with status text:
![status_bar_visible](https://user-images.githubusercontent.com/17648/170514730-bdfe58a6-78ca-47a0-97e7-629fdbb0fa2d.png)


## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
