### PR TITLE
Fix unit chooser missing "All" button.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -80,22 +80,13 @@ public final class UnitChooser extends JPanel {
 
   UnitChooser(
       final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> dependent,
-      final boolean allowTwoHit,
-      final UiContext uiContext) {
-    this(units, List.of(), dependent, allowTwoHit, uiContext);
-  }
-
-  private UnitChooser(
-      final Collection<Unit> units,
-      final Collection<Unit> defaultSelections,
-      final Map<Unit, Collection<Unit>> dependent,
+      final @Nullable Map<Unit, Collection<Unit>> dependents,
       final boolean allowTwoHit,
       final UiContext uiContext) {
     this(
         units,
-        defaultSelections,
-        dependent,
+        List.of(),
+        dependents,
         UnitSeparator.SeparatorCategories.builder().build(),
         allowTwoHit,
         uiContext);
@@ -343,8 +334,6 @@ public final class UnitChooser extends JPanel {
             0,
             0));
     if (match != null) {
-      autoSelectButton.setVisible(false);
-      selectNoneButton.setVisible(false);
       checkMatches();
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -62,7 +62,6 @@ public final class UnitChooser extends JPanel {
   private final JLabel leftToSelect = new JLabel();
   private final boolean allowMultipleHits;
   private JButton autoSelectButton;
-  private JButton selectNoneButton;
   private final Predicate<Collection<Unit>> match;
   private final ScrollableTextFieldListener textFieldListener =
       new ScrollableTextFieldListener() {
@@ -158,13 +157,16 @@ public final class UnitChooser extends JPanel {
     total = max;
     textFieldListener.changedValue(null);
     autoSelectButton.setVisible(false);
-    selectNoneButton.setVisible(false);
   }
 
   void setMaxAndShowMaxButton(final int max) {
     total = max;
     textFieldListener.changedValue(null);
     autoSelectButton.setText("Max");
+  }
+
+  public void setAllButtonVisible(boolean visible) {
+    autoSelectButton.setVisible(visible);
   }
 
   public void setTitle(final String title) {
@@ -279,8 +281,6 @@ public final class UnitChooser extends JPanel {
     title.setVisible(false);
     final Insets emptyInsets = new Insets(0, 0, 0, 0);
     final Dimension buttonSize = new Dimension(80, 20);
-    selectNoneButton = new JButton("None");
-    selectNoneButton.setPreferredSize(buttonSize);
     autoSelectButton = new JButton("All");
     autoSelectButton.setPreferredSize(buttonSize);
     add(
@@ -297,7 +297,6 @@ public final class UnitChooser extends JPanel {
             emptyInsets,
             0,
             0));
-    selectNoneButton.addActionListener(e -> selectNone());
     autoSelectButton.addActionListener(e -> autoSelect());
     int rowIndex = 1;
     for (final ChooserEntry entry : entries) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -314,6 +314,7 @@ public class MovePanel extends AbstractMovePanel {
                   false,
                   getMap().getUiContext(),
                   transportsToLoadMatch);
+          chooser.setAllButtonVisible(false);
           chooser.setTitle("Select air transports to load");
           if (!confirmUnitChooserDialog(chooser, "What transports do you want to load")) {
             return List.of();
@@ -861,6 +862,7 @@ public class MovePanel extends AbstractMovePanel {
             false,
             getMap().getUiContext(),
             transportsToUnloadMatch);
+    chooser.setAllButtonVisible(false);
     if (!confirmUnitChooserDialog(chooser, "Select transports to unload")) {
       return List.of();
     }
@@ -1273,6 +1275,7 @@ public class MovePanel extends AbstractMovePanel {
             false,
             getMap().getUiContext(),
             transportsToLoadMatch);
+    chooser.setAllButtonVisible(false);
     if (!confirmUnitChooserDialog(chooser, "Select transports to load")) {
       return List.of();
     }
@@ -1345,6 +1348,7 @@ public class MovePanel extends AbstractMovePanel {
               false,
               getMap().getUiContext(),
               matchCriteria);
+      chooser.setAllButtonVisible(false);
       final String text = "Select units to move from " + getFirstSelectedTerritory() + ".";
       if (!confirmUnitChooserDialog(chooser, text)) {
         units.clear();
@@ -1398,7 +1402,6 @@ public class MovePanel extends AbstractMovePanel {
       final Set<Unit> defaultSelections,
       final Predicate<Collection<Unit>> unitsToLoadMatch,
       final List<Unit> unitsToLoad) {
-
     // Allow player to select which to load.
     final UnitChooser chooser =
         new UnitChooser(
@@ -1409,6 +1412,7 @@ public class MovePanel extends AbstractMovePanel {
             false,
             getMap().getUiContext(),
             unitsToLoadMatch);
+    chooser.setAllButtonVisible(false);
     chooser.setTitle("Load air transports");
     if (!confirmUnitChooserDialog(chooser, "What units do you want to load")) {
       return List.of();


### PR DESCRIPTION
## Change Summary & Additional Notes

A 2.6 change resulted in a Predicate being passed to the UnitChooser, which caused the All button to be hidden. That was not intentional and this PR makes the visibility of that button get set explicitly, converting call sites that want that button hidden to specify so.

Additionally, code for the None button, which was never shown, is cleaned up.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
