### PR TITLE
Make unitImageFactory.getIcon() always return an icon.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -356,7 +356,7 @@ public class UnitImageFactory {
     return highlightedImage;
   }
 
-  /** Return a icon image for a unit. */
+  /** Return an icon image for a unit. */
   public ImageIcon getIcon(final ImageKey imageKey) {
     final String fullName = imageKey.getFullName();
     return icons.computeIfAbsent(fullName, key -> new ImageIcon(getImage(imageKey)));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -357,19 +357,9 @@ public class UnitImageFactory {
   }
 
   /** Return a icon image for a unit. */
-  public Optional<ImageIcon> getIcon(final ImageKey imageKey) {
+  public ImageIcon getIcon(final ImageKey imageKey) {
     final String fullName = imageKey.getFullName();
-    if (icons.containsKey(fullName)) {
-      return Optional.of(icons.get(fullName));
-    }
-    final Optional<Image> image = getTransformedImage(imageKey);
-    if (image.isEmpty()) {
-      return Optional.empty();
-    }
-
-    final ImageIcon icon = new ImageIcon(image.get());
-    icons.put(fullName, icon);
-    return Optional.of(icon);
+    return icons.computeIfAbsent(fullName, key -> new ImageIcon(getImage(imageKey)));
   }
 
   public Dimension getImageDimensions(final ImageKey imageKey) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -278,20 +277,15 @@ class OrderOfLossesInputPanel extends JPanel {
                 + TooltipProperties.getInstance()
                     .getTooltip(category.getType(), category.getOwner())
                 + "</html>";
-        final Optional<ImageIcon> img =
-            uiContext.getUnitImageFactory().getIcon(ImageKey.of(category));
-        if (img.isPresent()) {
-          final JButton button = new JButton(img.get());
-          button.setToolTipText(toolTipText);
-          button.addActionListener(
-              e ->
-                  textField.setText(
-                      (textField.getText().length() > 0
-                              ? (textField.getText() + OOL_SEPARATOR)
-                              : "")
-                          + unitName));
-          panel.add(button);
-        }
+        final ImageIcon img = uiContext.getUnitImageFactory().getIcon(ImageKey.of(category));
+        final JButton button = new JButton(img);
+        button.setToolTipText(toolTipText);
+        button.addActionListener(
+            e ->
+                textField.setText(
+                    (textField.getText().length() > 0 ? (textField.getText() + OOL_SEPARATOR) : "")
+                        + unitName));
+        panel.add(button);
         typesUsed.add(category.getType());
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
@@ -44,12 +44,7 @@ public class UnitPanel extends JPanel {
     setCount(category.getUnits().size());
     setLayout(new GridBagLayout());
 
-    final JLabel label =
-        uiContext
-            .getUnitImageFactory()
-            .getIcon(ImageKey.of(category))
-            .map(JLabel::new)
-            .orElseGet(JLabel::new);
+    final JLabel label = new JLabel(uiContext.getUnitImageFactory().getIcon(ImageKey.of(category)));
     label.setToolTipText(toolTipText);
     add(
         label,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
@@ -122,15 +121,13 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     final Collection<UnitCategory> unitCategories = UnitSeparator.categorize(move.getUnits());
     final Dimension buttonSize = new Dimension(80, 22);
     for (final UnitCategory category : unitCategories) {
-      final Optional<ImageIcon> icon =
+      final ImageIcon icon =
           movePanel.getMap().getUiContext().getUnitImageFactory().getIcon(ImageKey.of(category));
-      if (icon.isPresent()) {
-        final JLabel label =
-            new JLabel("x" + category.getUnits().size() + " ", icon.get(), SwingConstants.LEFT);
-        unitsBox.add(label);
-        MapUnitTooltipManager.setUnitTooltip(
-            label, category.getType(), category.getOwner(), category.getUnits().size());
-      }
+      final JLabel label =
+          new JLabel("x" + category.getUnits().size() + " ", icon, SwingConstants.LEFT);
+      unitsBox.add(label);
+      MapUnitTooltipManager.setUnitTooltip(
+          label, category.getType(), category.getOwner(), category.getUnits().size());
     }
     unitsBox.add(Box.createHorizontalGlue());
     final JLabel text = new JLabel(move.getMoveLabel());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -222,11 +222,9 @@ public class BattleDisplay extends JPanel {
       }
     }
     final Map<Unit, Collection<Unit>> dependentsMap;
-    gameData.acquireReadLock();
-    try {
+
+    try (GameData.Unlocker ignored = gameData.acquireReadLock()) {
       dependentsMap = CasualtyUtil.getDependents(killedUnits);
-    } finally {
-      gameData.releaseReadLock();
     }
     final Collection<Unit> dependentUnitsReturned = new ArrayList<>();
     for (final Collection<Unit> dependentCollection : dependentsMap.values()) {
@@ -779,7 +777,7 @@ public class BattleDisplay extends JPanel {
         final Iterable<UnitCategory> categoryIter, final boolean damaged, final boolean disabled) {
       for (final UnitCategory category : categoryIter) {
         final JPanel panel = new JPanel();
-        final Optional<ImageIcon> unitImage =
+        final ImageIcon unitImage =
             uiContext
                 .getUnitImageFactory()
                 .getIcon(
@@ -789,7 +787,7 @@ public class BattleDisplay extends JPanel {
                         .damaged(damaged && category.hasDamageOrBombingUnitDamage())
                         .disabled(disabled && category.getDisabled())
                         .build());
-        final JLabel unit = unitImage.map(JLabel::new).orElseGet(JLabel::new);
+        final JLabel unit = new JLabel(unitImage);
         panel.add(unit);
         // Add a tooltip, with a count of 1 so that the tooltip doesn't have a number label (so it
         // won't get out of date

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import javax.swing.Action;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
@@ -301,18 +302,14 @@ class ProductionRepairPanel extends JPanel {
             "Rule unit type "
                 + type.getName()
                 + " does not match "
-                + repairUnit.toString()
+                + repairUnit
                 + ".  Please make sure your maps are up to date!");
       }
       repairResults = rule.getResults().getInt(type);
       final String text = "<html> x " + ResourceCollection.toStringForHtml(cost, data) + "</html>";
 
-      final JLabel label =
-          uiContext
-              .getUnitImageFactory()
-              .getIcon(ImageKey.of(repairUnit))
-              .map(imageIcon -> new JLabel(text, imageIcon, SwingConstants.LEFT))
-              .orElseGet(() -> new JLabel(text, SwingConstants.LEFT));
+      final ImageIcon icon = uiContext.getUnitImageFactory().getIcon(ImageKey.of(repairUnit));
+      final JLabel label = new JLabel(text, icon, SwingConstants.LEFT);
       final JLabel info = new JLabel(territoryUnitIsIn.getName());
       maxRepairAmount = repairUnit.getHowMuchCanThisUnitBeRepaired(territoryUnitIsIn);
       final JLabel remaining = new JLabel("Damage left to repair: " + maxRepairAmount);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -24,12 +24,10 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.WrapLayout;
 
-/** A Simple panel that displays a list of units. */
-@Slf4j
+/** A simple panel that displays a list of units. */
 public class SimpleUnitPanel extends JPanel {
   private static final long serialVersionUID = -3768796793775300770L;
   private final UiContext uiContext;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -16,7 +16,6 @@ import games.strategy.triplea.util.UnitCategory;
 import java.awt.Image;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.swing.Box;
@@ -152,13 +151,8 @@ public class SimpleUnitPanel extends JPanel {
               .damaged(damaged)
               .disabled(disabled)
               .build();
-      Optional<ImageIcon> icon = uiContext.getUnitImageFactory().getIcon(imageKey);
-      if (icon.isPresent()) {
-        label.setIcon(scaleIcon(icon.get(), scaleFactor));
-      } else if (!uiContext.isShutDown()) {
-        final String imageName = imageKey.getFullName();
-        log.error("missing unit icon (won't be displayed): " + imageName + ", " + imageKey);
-      }
+      ImageIcon icon = uiContext.getUnitImageFactory().getIcon(imageKey);
+      label.setIcon(scaleIcon(icon, scaleFactor));
       MapUnitTooltipManager.setUnitTooltip(label, unitType, player, quantity);
     } else if (unit instanceof Resource) {
       ImageIcon icon =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.ui.OverlayIcon;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -202,29 +201,23 @@ public class TerritoryDetailPanel extends JPanel {
         currentPlayer = item.getOwner();
         panel.add(Box.createVerticalStrut(15));
       }
-      final Optional<ImageIcon> unitIcon =
-          uiContext.getUnitImageFactory().getIcon(ImageKey.of(item));
-      if (unitIcon.isPresent()) {
-        // overlay flag onto upper-right of icon
-        final ImageIcon flagIcon =
-            new ImageIcon(uiContext.getFlagImageFactory().getSmallFlag(item.getOwner()));
-        final Icon flaggedUnitIcon =
-            new OverlayIcon(
-                unitIcon.get(),
-                flagIcon,
-                unitIcon.get().getIconWidth() - (flagIcon.getIconWidth() / 2),
-                0);
-        final JLabel label =
-            new JLabel("x" + item.getUnits().size(), flaggedUnitIcon, SwingConstants.LEFT);
-        final String toolTipText =
-            "<html>"
-                + item.getType().getName()
-                + ": "
-                + TooltipProperties.getInstance().getTooltip(item.getType(), currentPlayer)
-                + "</html>";
-        label.setToolTipText(toolTipText);
-        panel.add(label);
-      }
+      final ImageIcon unitIcon = uiContext.getUnitImageFactory().getIcon(ImageKey.of(item));
+      // overlay flag onto upper-right of icon
+      final ImageIcon flagIcon =
+          new ImageIcon(uiContext.getFlagImageFactory().getSmallFlag(item.getOwner()));
+      final Icon flaggedUnitIcon =
+          new OverlayIcon(
+              unitIcon, flagIcon, unitIcon.getIconWidth() - (flagIcon.getIconWidth() / 2), 0);
+      final JLabel label =
+          new JLabel("x" + item.getUnits().size(), flaggedUnitIcon, SwingConstants.LEFT);
+      final String toolTipText =
+          "<html>"
+              + item.getType().getName()
+              + ": "
+              + TooltipProperties.getInstance().getTooltip(item.getType(), currentPlayer)
+              + "</html>";
+      label.setToolTipText(toolTipText);
+      panel.add(label);
     }
     return panel;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -60,19 +60,22 @@ public class UiContext {
   private static final String SHOW_TRIGGERED_CHANCE_SUCCESSFUL = "ShowTriggeredChanceSuccessful";
   private static final String SHOW_TRIGGERED_CHANCE_FAILURE = "ShowTriggeredChanceFailure";
 
-  protected MapData mapData;
+  @Getter protected MapData mapData;
   @Getter @Setter protected LocalPlayers localPlayers;
 
   @Getter protected double scale;
-  private final TileImageFactory tileImageFactory = new TileImageFactory();
-  private UnitImageFactory unitImageFactory;
-  private final ResourceImageFactory resourceImageFactory = new ResourceImageFactory();
+  @Getter private final TileImageFactory tileImageFactory = new TileImageFactory();
+  @Getter private UnitImageFactory unitImageFactory;
+  @Getter private final ResourceImageFactory resourceImageFactory = new ResourceImageFactory();
+
+  @Getter
   private final TerritoryEffectImageFactory territoryEffectImageFactory =
       new TerritoryEffectImageFactory();
-  private final MapImage mapImage;
-  private final FlagIconImageFactory flagIconImageFactory = new FlagIconImageFactory();
-  private final DiceImageFactory diceImageFactory;
-  private final PuImageFactory puImageFactory = new PuImageFactory();
+
+  @Getter private final MapImage mapImage;
+  @Getter private final FlagIconImageFactory flagImageFactory = new FlagIconImageFactory();
+  @Getter private final DiceImageFactory diceImageFactory;
+  @Getter private final PuImageFactory puImageFactory = new PuImageFactory();
   private boolean drawUnits = true;
   @Getter @Setter private boolean showUnitsInStatusBar = true;
   private boolean drawTerritoryEffects;
@@ -133,7 +136,7 @@ public class UiContext {
     unitImageFactory = new UnitImageFactory(resourceLoader, unitScale, mapData);
     resourceImageFactory.setResourceLoader(resourceLoader);
     territoryEffectImageFactory.setResourceLoader(resourceLoader);
-    flagIconImageFactory.setResourceLoader(resourceLoader);
+    flagImageFactory.setResourceLoader(resourceLoader);
     puImageFactory.setResourceLoader(resourceLoader);
     tileImageFactory.setResourceLoader(resourceLoader);
     mapImage = new MapImage(resourceLoader);
@@ -160,52 +163,14 @@ public class UiContext {
     }
   }
 
-  public MapData getMapData() {
-    return mapData;
-  }
-
-  public TileImageFactory getTileImageFactory() {
-    return tileImageFactory;
-  }
-
-  public UnitImageFactory getUnitImageFactory() {
-    return unitImageFactory;
-  }
-
   public JLabel newUnitImageLabel(final ImageKey imageKey) {
-    final JLabel label =
-        getUnitImageFactory().getIcon(imageKey).map(JLabel::new).orElseGet(JLabel::new);
-
+    final JLabel label = new JLabel(getUnitImageFactory().getIcon(imageKey));
     MapUnitTooltipManager.setUnitTooltip(label, imageKey.getType(), imageKey.getPlayer(), 1);
     return label;
   }
 
   JLabel newUnitImageLabel(final UnitType type, final GamePlayer player) {
     return newUnitImageLabel(ImageKey.builder().type(type).player(player).build());
-  }
-
-  public ResourceImageFactory getResourceImageFactory() {
-    return resourceImageFactory;
-  }
-
-  public TerritoryEffectImageFactory getTerritoryEffectImageFactory() {
-    return territoryEffectImageFactory;
-  }
-
-  public MapImage getMapImage() {
-    return mapImage;
-  }
-
-  public FlagIconImageFactory getFlagImageFactory() {
-    return flagIconImageFactory;
-  }
-
-  public PuImageFactory getPuImageFactory() {
-    return puImageFactory;
-  }
-
-  public DiceImageFactory getDiceImageFactory() {
-    return diceImageFactory;
   }
 
   public void shutDown() {


### PR DESCRIPTION
## Change Summary & Additional Notes
Make unitImageFactory.getIcon() always return an icon, by making use of the "missing unit" icon for missing units. This reduces complexity by callers not having to have extra logic to handle missing icons and brings consistency with other places that show images.

This fixes the "missing image" error in SimpleUnitPanel.

Also some small clean ups in files being changed.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
