### PR TITLE
Add an end-to-end test that executes an all-AI game to completion.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -84,6 +84,7 @@ public class ServerGame extends AbstractGame {
   /** Has the delegate signaled that delegate execution should stop. */
   private volatile boolean delegateExecutionStopped = false;
 
+  // If true, setting delegateExecutionStopped to true will stop the game (return from startGame()).
   @Setter private boolean stopGameOnDelegateExecutionStop = false;
 
   public ServerGame(
@@ -424,7 +425,8 @@ public class ServerGame extends AbstractGame {
       return;
     }
     // save after the step has advanced otherwise, the delegate will execute again.
-    if (shouldAutoSaveAfterEnd(currentDelegate) && currentStep.getName().endsWith("Move")) {
+    boolean isMoveStep = GameStep.isMoveStep(currentStep.getName());
+    if (isMoveStep && shouldAutoSaveAfterEnd(currentDelegate)) {
       final String stepName = currentStep.getName();
       // If we are headless we don't want to include the nation in the save game because that would
       // make it too difficult to load later.
@@ -441,7 +443,7 @@ public class ServerGame extends AbstractGame {
               ? launchAction.getAutoSaveFileUtils().getEvenRoundAutoSaveFile()
               : launchAction.getAutoSaveFileUtils().getOddRoundAutoSaveFile());
     }
-    if (shouldAutoSaveAfterEnd(currentDelegate) && !currentStep.getName().endsWith("Move")) {
+    if (!isMoveStep && shouldAutoSaveAfterEnd(currentDelegate)) {
       autoSaveAfter(currentDelegate);
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.Interruptibles;
@@ -69,7 +70,7 @@ public class ServerGame extends AbstractGame {
   private IRandomSource randomSource = new PlainRandomSource();
   private IRandomSource delegateRandomSource;
   private final DelegateExecutionManager delegateExecutionManager = new DelegateExecutionManager();
-  private InGameLobbyWatcherWrapper inGameLobbyWatcher;
+  @Getter @Setter private InGameLobbyWatcherWrapper inGameLobbyWatcher;
   private boolean needToInitialize = true;
   private final LaunchAction launchAction;
   private final ClientNetworkBridge clientNetworkBridge;
@@ -675,14 +676,6 @@ public class ServerGame extends AbstractGame {
   public void setRandomSource(final IRandomSource randomSource) {
     this.randomSource = randomSource;
     delegateRandomSource = null;
-  }
-
-  public InGameLobbyWatcherWrapper getInGameLobbyWatcher() {
-    return inGameLobbyWatcher;
-  }
-
-  public void setInGameLobbyWatcher(final InGameLobbyWatcherWrapper inGameLobbyWatcher) {
-    this.inGameLobbyWatcher = inGameLobbyWatcher;
   }
 
   public void stopGameSequence() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -427,10 +427,7 @@ public class ServerGame extends AbstractGame {
     // save after the step has advanced otherwise, the delegate will execute again.
     boolean isMoveStep = GameStep.isMoveStep(currentStep.getName());
     if (isMoveStep && shouldAutoSaveAfterEnd(currentDelegate)) {
-      final String stepName = currentStep.getName();
-      // If we are headless we don't want to include the nation in the save game because that would
-      // make it too difficult to load later.
-      autoSaveAfter(stepName);
+      autoSaveAfter(currentStep.getName());
     }
     endStep();
     if (isGameOver) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -316,8 +316,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       final boolean stopGame;
       if (HeadlessGameServer.headless()) {
         // a terrible dirty hack, but I can't think of a better way to do it right now. If we are
-        // headless, end the
-        // game.
+        // headless, end the game.
         stopGame = true;
       } else {
         // now tell the HOST, and see if they want to continue the game.
@@ -331,8 +330,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
           displayMessage = displayMessage + "</br><p>Do you want to continue?</p>";
         }
         // this is currently the ONLY instance of JOptionPane that is allowed outside of the UI
-        // classes. maybe there is
-        // a better way?
+        // classes. maybe there is a better way?
         stopGame =
             !EventThreadJOptionPane.showConfirmDialog(
                 null,

--- a/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -1,0 +1,46 @@
+package games.strategy.engine.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+
+import games.strategy.engine.framework.ServerGame;
+import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
+import games.strategy.triplea.delegate.EndRoundDelegate;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * End-to-end test that starts all-AI games on a selected set of maps and verifies they conclude
+ * with a victory for one of the sides. This ensures the AI code doesn't run into errors and can
+ * make progress towards victory conditions.
+ */
+@Slf4j
+public class AiGameTest {
+  @BeforeAll
+  public static void setUp() throws IOException {
+    GameTestUtils.setUp();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "map_making_tutorial,map/games/Test1.xml",
+  })
+  void testAiGame(String mapName, String mapXmlPath) throws Exception {
+    GameSelectorModel gameSelector = GameTestUtils.loadGameFromURI(mapName, mapXmlPath);
+    ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
+    game.setStopGameOnDelegateExecutionStop(true);
+    game.startGame();
+    assertThat(game.isGameOver(), is(true));
+    assertThat(game.getData().getSequence().getRound(), greaterThan(2));
+    EndRoundDelegate endDelegate = (EndRoundDelegate) game.getData().getDelegate("endRound");
+    assertThat(endDelegate.getWinners(), not(empty()));
+    log.info("Game completed at round: " + game.getData().getSequence().getRound());
+    log.info("Game winners: " + endDelegate.getWinners());
+  }
+}

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -5,33 +5,15 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.aFileWithSize;
 
-import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.ServerGame;
-import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
-import games.strategy.engine.framework.startup.ui.PlayerTypes;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
-import games.strategy.engine.player.Player;
-import games.strategy.net.LocalNoOpMessenger;
-import games.strategy.net.Messengers;
-import games.strategy.net.websocket.ClientNetworkBridge;
-import games.strategy.triplea.settings.ClientSetting;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.triplea.config.product.ProductVersionReader;
-import org.triplea.game.server.HeadlessLaunchAction;
-import org.triplea.injection.Injections;
-import org.triplea.io.ContentDownloader;
-import org.triplea.io.FileUtils;
 
 /**
  * Checks that no error is encountered when saving a game on several different maps. This test
@@ -42,67 +24,24 @@ import org.triplea.io.FileUtils;
  * example, if there's a non-null reference to a non-serializable object.
  */
 class GameSaveTest {
-
   @BeforeAll
   public static void setUp() throws IOException {
-    Injections.init(
-        Injections.builder()
-            .engineVersion(new ProductVersionReader().getVersion())
-            .playerTypes(PlayerTypes.getBuiltInPlayerTypes())
-            .build());
-    ClientSetting.initialize();
-    final Path tempFolder = FileUtils.newTempFolder();
-    FileUtils.writeToFile(tempFolder.resolve(".triplea-root"), "");
-    Files.createDirectory(tempFolder.resolve("assets"));
-    ClientFileSystemHelper.setCodeSourceFolder(tempFolder);
+    GameTestUtils.setUp();
   }
 
   @ParameterizedTest
   @CsvSource({
+    "map_making_tutorial,map/games/Test1.xml",
+    "minimap,map/games/minimap.xml",
     "world_war_ii_revised,map/games/ww2v2.xml",
-    "pacific_challenge,map/games/Pacific_Theater_Solo_Challenge.xml"
+    "pacific_challenge,map/games/Pacific_Theater_Solo_Challenge.xml",
+    "imperialism_1974_board_game,map/games/imperialism_1974_board_game.xml",
   })
-  void testSaveGame(final String mapName, final String mapXmlPath) throws Exception {
-    final Path mapFolderPath = downloadMap(getMapDownloadURI(mapName));
-    final GameSelectorModel gameSelector = new GameSelectorModel();
-    gameSelector.load(mapFolderPath.resolve(mapXmlPath));
-    final ServerGame game = startGameWithAis(gameSelector);
-    final Path saveFile = Files.createTempFile("save", GameDataFileUtils.getExtension());
+  void testSaveGame(String mapName, String mapXmlPath) throws Exception {
+    GameSelectorModel gameSelector = GameTestUtils.loadGameFromURI(mapName, mapXmlPath);
+    ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
+    Path saveFile = Files.createTempFile("save", GameDataFileUtils.getExtension());
     game.saveGame(saveFile);
     assertThat(saveFile.toFile(), is(not(aFileWithSize(0))));
-  }
-
-  private static Path downloadMap(final URI uri) throws IOException {
-    final Path targetTempFileToDownloadTo = FileUtils.newTempFolder().resolve("map.zip");
-    try (ContentDownloader downloader = new ContentDownloader(uri)) {
-      Files.copy(downloader.getStream(), targetTempFileToDownloadTo);
-    }
-    return ZippedMapsExtractor.unzipMap(targetTempFileToDownloadTo).get();
-  }
-
-  private static URI getMapDownloadURI(final String mapName) throws URISyntaxException {
-    return new URI(String.format("https://github.com/triplea-maps/%s/archive/master.zip", mapName));
-  }
-
-  private static ServerGame startGameWithAis(final GameSelectorModel gameSelector) {
-    final GameData gameData = gameSelector.getGameData();
-    final Map<String, PlayerTypes.Type> playerTypes = new HashMap<>();
-    for (var player : gameData.getPlayerList().getPlayers()) {
-      playerTypes.put(player.getName(), PlayerTypes.PRO_AI);
-    }
-    final Set<Player> gamePlayers = gameData.getGameLoader().newPlayers(playerTypes);
-    final HeadlessLaunchAction launchAction = new HeadlessLaunchAction();
-    final Messengers messengers = new Messengers(new LocalNoOpMessenger());
-    final ServerGame game =
-        new ServerGame(
-            gameData,
-            gamePlayers,
-            new HashMap<>(),
-            messengers,
-            ClientNetworkBridge.NO_OP_SENDER,
-            launchAction);
-    // Note: This doesn't actually start the AI players' turns. For that, call game.startGame().
-    gameData.getGameLoader().startGame(game, gamePlayers, launchAction, null);
-    return game;
   }
 }

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
@@ -1,0 +1,89 @@
+package games.strategy.engine.data;
+
+import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.engine.framework.GameRunner;
+import games.strategy.engine.framework.ServerGame;
+import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
+import games.strategy.engine.framework.startup.ui.PlayerTypes;
+import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
+import games.strategy.engine.player.Player;
+import games.strategy.net.LocalNoOpMessenger;
+import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
+import games.strategy.triplea.settings.ClientSetting;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.config.product.ProductVersionReader;
+import org.triplea.game.server.HeadlessLaunchAction;
+import org.triplea.injection.Injections;
+import org.triplea.io.ContentDownloader;
+import org.triplea.io.FileUtils;
+
+@UtilityClass
+@Slf4j
+public class GameTestUtils {
+  public static void setUp() throws IOException {
+    System.setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
+    Injections.init(
+        Injections.builder()
+            .engineVersion(new ProductVersionReader().getVersion())
+            .playerTypes(PlayerTypes.getBuiltInPlayerTypes())
+            .build());
+    ClientSetting.initialize();
+    final Path tempFolder = FileUtils.newTempFolder();
+    FileUtils.writeToFile(tempFolder.resolve(".triplea-root"), "");
+    Files.createDirectory(tempFolder.resolve("assets"));
+    ClientFileSystemHelper.setCodeSourceFolder(tempFolder);
+  }
+
+  public static GameSelectorModel loadGameFromURI(String mapName, String mapXmlPath)
+      throws Exception {
+    GameSelectorModel gameSelector = new GameSelectorModel();
+    gameSelector.load(downloadMap(getMapDownloadURI(mapName)).resolve(mapXmlPath));
+    return gameSelector;
+  }
+
+  private static Path downloadMap(URI uri) throws IOException {
+    Path targetTempFileToDownloadTo = FileUtils.newTempFolder().resolve("map.zip");
+    log.info("Downloading from: " + uri);
+    try (ContentDownloader downloader = new ContentDownloader(uri)) {
+      Files.copy(downloader.getStream(), targetTempFileToDownloadTo);
+    }
+    return ZippedMapsExtractor.unzipMap(targetTempFileToDownloadTo).orElseThrow();
+  }
+
+  private static URI getMapDownloadURI(String mapName) throws URISyntaxException {
+    return new URI(String.format("https://github.com/triplea-maps/%s/archive/master.zip", mapName));
+  }
+
+  public static ServerGame setUpGameWithAis(GameSelectorModel gameSelector) {
+    GameData gameData = gameSelector.getGameData();
+    Map<String, PlayerTypes.Type> playerTypes = new HashMap<>();
+    for (var player : gameData.getPlayerList().getPlayers()) {
+      playerTypes.put(player.getName(), PlayerTypes.PRO_AI);
+    }
+    Set<Player> gamePlayers = gameData.getGameLoader().newPlayers(playerTypes);
+    HeadlessLaunchAction launchAction = new HeadlessLaunchAction();
+    Messengers messengers = new Messengers(new LocalNoOpMessenger());
+    ServerGame game =
+        new ServerGame(
+            gameData,
+            gamePlayers,
+            new HashMap<>(),
+            messengers,
+            ClientNetworkBridge.NO_OP_SENDER,
+            launchAction);
+    game.setDelegateAutosavesEnabled(false);
+    // Note: This doesn't actually start the AI players' turns. For that, call game.startGame().
+    gameData.getGameLoader().startGame(game, gamePlayers, launchAction, null);
+    return game;
+  }
+}

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
@@ -32,11 +32,13 @@ import org.triplea.io.FileUtils;
 public class GameTestUtils {
   public static void setUp() throws IOException {
     System.setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
-    Injections.init(
-        Injections.builder()
-            .engineVersion(new ProductVersionReader().getVersion())
-            .playerTypes(PlayerTypes.getBuiltInPlayerTypes())
-            .build());
+    if (Injections.getInstance() == null) {
+      Injections.init(
+          Injections.builder()
+              .engineVersion(new ProductVersionReader().getVersion())
+              .playerTypes(PlayerTypes.getBuiltInPlayerTypes())
+              .build());
+    }
     ClientSetting.initialize();
     final Path tempFolder = FileUtils.newTempFolder();
     FileUtils.writeToFile(tempFolder.resolve(".triplea-root"), "");


### PR DESCRIPTION
## Change Summary & Additional Notes
Add an end-to-end test that executes an all-AI (hard AI) game to completion.

Currently, only doing this on the very simple "mapmaking tutorial map", which exercises sea zones and amphib invasions. In my testing, this takes 1 min to run and a game completes in 24 rounds.

Also adds a few more maps to GameSaveTest.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
