### PR TITLE
Add a smoke test for AI functionality to consume units when purchasing.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -500,8 +500,7 @@ public class GameData implements Serializable, GameState {
 
   /**
    * Call this before starting the game and before the game data has been sent to the clients in
-   * order to make any final modifications to the game data. For example, this method will remove
-   * player delegates for players who have been disabled.
+   * order to remove player delegates for players who have been disabled.
    */
   public void preGameDisablePlayers(final Predicate<GamePlayer> shouldDisablePlayer) {
     final Set<GamePlayer> playersWhoShouldBeRemoved = new HashSet<>();

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.IGameLoader;
-import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.history.History;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleA;
@@ -35,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Predicate;
 import lombok.Getter;
 import org.triplea.injection.Injections;
 import org.triplea.io.FileUtils;
@@ -503,11 +503,10 @@ public class GameData implements Serializable, GameState {
    * order to make any final modifications to the game data. For example, this method will remove
    * player delegates for players who have been disabled.
    */
-  public void doPreGameStartDataModifications(final PlayerListing playerListing) {
+  public void preGameDisablePlayers(final Predicate<GamePlayer> shouldDisablePlayer) {
     final Set<GamePlayer> playersWhoShouldBeRemoved = new HashSet<>();
-    final Map<String, Boolean> playersEnabledListing = playerListing.getPlayersEnabledListing();
     playerList.getPlayers().stream()
-        .filter(p -> (p.getCanBeDisabled() && !playersEnabledListing.get(p.getName())))
+        .filter(p -> (p.getCanBeDisabled() && shouldDisablePlayer.test(p)))
         .forEach(
             p -> {
               p.setIsDisabled(true);

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework.message;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
 import games.strategy.triplea.NetworkData;
 import java.io.Serializable;
@@ -109,5 +110,9 @@ public class PlayerListing implements Serializable {
   public Map<String, PlayerTypes.Type> getLocalPlayerTypeMap(final PlayerTypes playerTypes) {
     return localPlayerTypes.entrySet().stream()
         .collect(Collectors.toMap(Entry::getKey, e -> playerTypes.fromLabel(e.getValue())));
+  }
+
+  public void doPreGameStartDataModifications(final GameData gameData) {
+    gameData.preGameDisablePlayers(p -> !playersEnabledListing.get(p.getName()));
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -63,7 +63,7 @@ public class LocalLauncher implements ILauncher {
 
   private Optional<ServerGame> loadGame() {
     try {
-      gameData.doPreGameStartDataModifications(playerListing);
+      playerListing.doPreGameStartDataModifications(gameData);
       final Messengers messengers = new Messengers(new LocalNoOpMessenger());
       final Set<Player> gamePlayers =
           gameData.getGameLoader().newPlayers(playerListing.getLocalPlayerTypeMap(playerTypes));

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -116,7 +116,7 @@ public class ServerLauncher implements ILauncher {
       serverModel.allowRemoveConnections();
       log.info("Game Status: Launching");
       messengers.registerRemote(serverReady, ClientModel.CLIENT_READY_CHANNEL);
-      gameData.doPreGameStartDataModifications(playerListing);
+      playerListing.doPreGameStartDataModifications(gameData);
       abortLaunch = testShouldWeAbort();
       final byte[] gameDataAsBytes = gameData.toBytes();
       final Set<Player> localPlayerSet =

--- a/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -56,8 +56,8 @@ public class AiGameTest {
             "imperialism_1974_board_game", "map/games/imperialism_1974_board_game.xml");
     ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
     game.getData().preGameDisablePlayers(p -> !p.getName().equals("Blue"));
-    game.setStopGameOnDelegateExecutionStop(true);
     game.setUpGameForRunningSteps();
+
     GamePlayer blue = game.getData().getPlayerList().getPlayerId("Blue");
     assertThat(blue.isNull(), is(false));
     // Check that after wealth place, we have 1 wealth and 10 armies.

--- a/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -4,16 +4,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.triplea.delegate.EndRoundDelegate;
+import games.strategy.triplea.delegate.Matches;
 import java.io.IOException;
+import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.triplea.java.collections.CollectionUtils;
 
 /**
  * End-to-end test that starts all-AI games on a selected set of maps and verifies they conclude
@@ -42,5 +47,52 @@ public class AiGameTest {
     assertThat(endDelegate.getWinners(), not(empty()));
     log.info("Game completed at round: " + game.getData().getSequence().getRound());
     log.info("Game winners: " + endDelegate.getWinners());
+  }
+
+  @Test
+  void testAiGameWithConsumedUnits() throws Exception {
+    GameSelectorModel gameSelector =
+        GameTestUtils.loadGameFromURI(
+            "imperialism_1974_board_game", "map/games/imperialism_1974_board_game.xml");
+    ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
+    game.getData().preGameDisablePlayers(p -> !p.getName().equals("Blue"));
+    game.setStopGameOnDelegateExecutionStop(true);
+    game.setUpGameForRunningSteps();
+    GamePlayer blue = game.getData().getPlayerList().getPlayerId("Blue");
+    assertThat(blue.isNull(), is(false));
+    // Check that after wealth place, we have 1 wealth and 10 armies.
+    runStepsUntil(game, "BlueWealthPlace");
+    assertThat(countUnitsOfType(game.getData(), blue, "wealth"), is(1));
+    assertThat(countUnitsOfType(game.getData(), blue, "new_army"), is(0));
+    assertThat(countUnitsOfType(game.getData(), blue, "army"), is(10));
+    // Now, execute steps until Place, which includes Purchase.
+    runStepsUntil(game, "BluePlace");
+    // Check that the AI has built a new army using a wealth unit.
+    assertThat(countUnitsOfType(game.getData(), blue, "wealth"), is(0));
+    assertThat(countUnitsOfType(game.getData(), blue, "new_army"), is(1));
+    assertThat(countUnitsOfType(game.getData(), blue, "army"), is(10));
+  }
+
+  private void runStepsUntil(ServerGame game, String stopAfterStepName) {
+    while (true) {
+      boolean stop = game.getData().getSequence().getStep().getName().equals(stopAfterStepName);
+      game.runNextStep();
+      if (stop) {
+        return;
+      }
+    }
+  }
+
+  private int countUnitsOfType(GameData data, GamePlayer player, String unitTypeName) {
+    UnitType unitType = data.getUnitTypeList().getUnitType(unitTypeName);
+    assertThat(unitType, notNullValue());
+    Predicate<Unit> matcher = Matches.unitIsOwnedBy(player).and(Matches.unitIsOfType(unitType));
+    // Note: We don't use game.getUnits() because units are never removed from there.
+    // We also don't use player.getUnits() because those are just the units-to-place.
+    int count = 0;
+    for (Territory t : data.getMap().getTerritories()) {
+      count += CollectionUtils.countMatches(t.getUnits(), matcher);
+    }
+    return count;
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes
The test uses the Imperlaism 1974 map and verifies that the Blue player is able to buy and place an army using (consuming) the wealth unit.

Along the way, some production code is refactored, in particular:
  - ServerGame's startGame() is broken up into two methods that can be called in a more granular way, allowing us to execute turns one at a time.
  - Removes GameData's dependency on PlayerListing and inverts the relationship, such that PlayerListing has a method to configure the GameData based on its properties. The method to disable players on GameData now just takes a Predicate.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
