### PR TITLE
Remove redundant threads

### DIFF
--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -49,9 +49,9 @@ public final class HeadlessGameRunner {
         .unzipMapFiles();
 
     try {
-      HeadlessGameServer.initializeHeadlessGameServerInstance();
+      HeadlessGameServer.runHeadlessGameServer();
     } catch (final Exception e) {
-      log.error("Failed to start game server", e);
+      log.error("Failed to run game server", e);
     }
   }
 

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.game.chat.ChatModel;
+import org.triplea.java.ThreadRunner;
 import org.triplea.sound.HeadlessSoundChannel;
 import org.triplea.sound.ISound;
 
@@ -52,8 +53,11 @@ public class HeadlessLaunchAction implements LaunchAction {
 
   @Override
   public void onGameInterrupt() {
-    // tell headless server to wait for new connections:
-    headlessGameServer.waitForUsers();
+    // tell headless server to wait for new connections
+    // technically no new thread is strictly required here, but this
+    // ensures consistent behaviour with the headed counterpart
+    // of this class that queues an event for the EDT.
+    ThreadRunner.runInNewThread(headlessGameServer::waitForUsers);
   }
 
   @Override


### PR DESCRIPTION
This avoids spawning of new threads when no thread is required and the existing thread can just get reused.