### PR TITLE
Trivial: Update DTD to specify it's OK not to have resourceGiven nodes.

### DIFF
--- a/game-app/game-core/src/main/resources/games/strategy/engine/xml/game.dtd
+++ b/game-app/game-core/src/main/resources/games/strategy/engine/xml/game.dtd
@@ -237,7 +237,7 @@
 			player IDREF #REQUIRED
 			quantity CDATA #REQUIRED
 		>
-	<!ELEMENT resourceInitialize (resourceGiven+) >
+	<!ELEMENT resourceInitialize (resourceGiven*) >
 		<!ELEMENT resourceGiven EMPTY>
 		<!ATTLIST resourceGiven
 			player IDREF #REQUIRED


### PR DESCRIPTION
## Change Summary & Additional Notes

Trivial: Update DTD to specify it's OK not to have resourceGiven nodes.
The DTD isn't used for validate by the engine, but IntelliJ and other tools can use it to validate maps. It was being overzealous here.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
