### PR TITLE
Fix an error that could happen when going back in the history tree.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/CompositeChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/CompositeChange.java
@@ -61,9 +61,10 @@ public class CompositeChange extends Change {
 
   @Override
   public Change invert() {
-    // Important: We can't invert all the sub-changes in reverse order, because some revert()
-    // implementations, like RemoveUnits.invert() which calls new AddUnits(), rely on the GameData
-    // state and will cause errors if revert() is called while at a different node.
+    // Important: We can't invert the sub-changes upfront, because some revert() implementations,
+    // like RemoveUnits.invert() which calls new AddUnits(), rely on the GameData state and will
+    // cause errors if revert() is called while at a different node.
+    // Instead, we construct a CompositeChange with inverted set to true.
     return new CompositeChange(changes, true);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
@@ -49,7 +49,9 @@ class PlayerOwnerChange extends Change {
       final Unit unit = data.getUnits().get(id);
       if (!oldOwnerNamesByUnitId.get(id).equals(unit.getOwner().getName())) {
         throw new IllegalStateException(
-            "Wrong owner, expecting"
+            "Wrong "
+                + unit.getType().getName()
+                + " owner, expecting "
                 + oldOwnerNamesByUnitId.get(id)
                 + " but got "
                 + unit.getOwner());

--- a/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ui.history.HistoryPanel;
 import games.strategy.ui.Util;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
@@ -81,7 +82,7 @@ public class History extends DefaultTreeModel {
     return getLastChildInternal((HistoryNode) node.getLastChild());
   }
 
-  private int getLastChange(final HistoryNode node) {
+  private int getNextChange(final HistoryNode node) {
     int lastChangeIndex;
     if (node == getRoot()) {
       lastChangeIndex = 0;
@@ -94,7 +95,7 @@ public class History extends DefaultTreeModel {
       // If this node is still current, or comes from an old save game where we didn't set it, get
       // the last change index from its last child node.
       if (lastChangeIndex == -1 && node.getChildCount() > 0) {
-        lastChangeIndex = getLastChange((HistoryNode) node.getLastChild());
+        lastChangeIndex = getNextChange((HistoryNode) node.getLastChild());
       }
     } else {
       lastChangeIndex = 0;
@@ -119,7 +120,7 @@ public class History extends DefaultTreeModel {
     Preconditions.checkNotNull(node);
     Preconditions.checkState(seekingEnabled);
     try (GameData.Unlocker ignored = gameData.acquireWriteLock()) {
-      final int nodeChangeIndex = getLastChange(node);
+      final int nodeChangeIndex = getNextChange(node);
       if (nodeChangeIndex != nextChangeIndex) {
         gameData.performChange(getDeltaTo(nodeChangeIndex));
         nextChangeIndex = nodeChangeIndex;
@@ -185,7 +186,7 @@ public class History extends DefaultTreeModel {
   }
 
   List<Change> getChanges() {
-    return changes;
+    return Collections.unmodifiableList(changes);
   }
 
   GameData getGameData() {


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix an error that could happen when going back in the history tree.

Going back in the history tree creates a CompositeChange and called invert() on it, which inverted all the children.
However, it turns out that some invert() implementations, like RemoveUnits.invert() which calls new AddUnits(), read the current GameData state and so are invalid to be called when that state is at a different point in time.

The fix is to have CompositeChange.invert() simply construct a new CompositeChange with a boolean set that indicates its inverted and to do the inversion of the children when the inverted change is performed.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
