### PR TITLE
Speed up node selection in history tree.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.ui.panels.map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.Sets;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.ChangeAttachmentChange;
 import games.strategy.engine.data.CompositeChange;
@@ -594,7 +593,7 @@ public class MapPanel extends ImageScrollerLargeView {
       countriesToUpdate.addAll(countries);
     }
     if (!scheduleUpdate) {
-      return;  // An update is already scheduled.
+      return; // An update is already scheduled.
     }
     AsyncRunner.runAsync(
             () -> {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -171,8 +171,7 @@ public class TileManager {
 
   /** Re-renders all tiles. */
   public void resetTiles(final GameData data, final MapData mapData) {
-    data.acquireReadLock();
-    try {
+    try (GameData.Unlocker ignored = data.acquireReadLock()) {
       synchronized (mutex) {
         for (final Tile tile : tiles) {
           tile.clear();
@@ -199,39 +198,28 @@ public class TileManager {
           }
         }
       }
-    } finally {
-      data.releaseReadLock();
     }
   }
 
   /** Re-renders all tiles that intersect any of the specified territories. */
   public void updateTerritories(
       final Collection<Territory> territories, final GameData data, final MapData mapData) {
-    data.acquireReadLock();
-    try {
+    try (GameData.Unlocker ignored = data.acquireReadLock()) {
       synchronized (mutex) {
-        if (territories == null) {
-          return;
-        }
         for (final Territory territory : territories) {
           updateTerritory(territory, data, mapData);
         }
       }
-    } finally {
-      data.releaseReadLock();
     }
   }
 
   private void updateTerritory(
       final Territory territory, final GameData data, final MapData mapData) {
-    data.acquireReadLock();
-    try {
+    try (GameData.Unlocker ignored = data.acquireReadLock()) {
       synchronized (mutex) {
         clearTerritory(territory);
         drawTerritory(territory, data, mapData);
       }
-    } finally {
-      data.releaseReadLock();
     }
   }
 
@@ -502,8 +490,7 @@ public class TileManager {
     if (units.isEmpty()) {
       return null;
     }
-    data.acquireReadLock();
-    try {
+    try (GameData.Unlocker ignored = data.acquireReadLock()) {
       synchronized (mutex) {
         for (final UnitsDrawer drawer : allUnitDrawables) {
           final List<Unit> drawerUnits = drawer.getUnits(data);
@@ -513,8 +500,6 @@ public class TileManager {
         }
         return null;
       }
-    } finally {
-      data.releaseReadLock();
     }
   }
 
@@ -524,8 +509,7 @@ public class TileManager {
    */
   public @Nullable Tuple<Territory, List<Unit>> getUnitsAtPoint(
       final double x, final double y, final GameData gameData) {
-    gameData.acquireReadLock();
-    try {
+    try (GameData.Unlocker ignored = gameData.acquireReadLock()) {
       synchronized (mutex) {
         for (final UnitsDrawer drawer : allUnitDrawables) {
           if (drawer.getPlacementRectangle().contains(x, y)) {
@@ -534,8 +518,6 @@ public class TileManager {
         }
         return null;
       }
-    } finally {
-      gameData.releaseReadLock();
     }
   }
 

--- a/lib/java-extras/src/main/java/org/triplea/java/concurrency/AsyncRunner.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/concurrency/AsyncRunner.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,12 +23,14 @@ import lombok.experimental.UtilityClass;
  */
 @UtilityClass
 public class AsyncRunner {
-  /** Runs a task using a default threadpool. */
+  /** Runs a task using a default threadpool. Call exceptionally() on the result to execute. */
+  @CheckReturnValue
   public static ExceptionHandler runAsync(final Runnable runnable) {
     return new ExceptionHandler(runnable, null);
   }
 
-  /** Runs a task using the provided threadpool. */
+  /** Runs a task using the provided threadpool. Call exceptionally() on the result to execute. */
+  @CheckReturnValue
   public static ExceptionHandler runAsync(final Runnable runnable, final Executor executor) {
     return new ExceptionHandler(runnable, executor);
   }


### PR DESCRIPTION
## Change Summary & Additional Notes
Speed up node selection in history tree.

Turns out, most of the time was going to repeatedly redrawing the map. This change batches operations.

With this change, using the save game on https://github.com/triplea-game/triplea/pull/10551, selecting the first turn in history goes from 1.2s execution time to 0.3s.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Selecting nodes in the history tree has been sped up<!--END_RELEASE_NOTE-->
