### PR TITLE
Fix neutral logic causing AI to ignore safe attacks on Imperialism 1974.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2209,7 +2209,8 @@ class ProNonCombatMoveAi {
                     t, range / 2, ProMatches.territoryCanMoveAirUnits(data, player, true));
         final int numEnemyAttackTerritories =
             CollectionUtils.countMatches(
-                possibleAttackTerritories, ProMatches.territoryIsEnemyNotNeutralLand(player));
+                possibleAttackTerritories,
+                ProMatches.territoryIsEnemyNotPassiveNeutralLand(player));
         final int numLandAttackTerritories =
             CollectionUtils.countMatches(
                 possibleAttackTerritories,
@@ -2227,7 +2228,7 @@ class ProNonCombatMoveAi {
                 .getNeighbors(t, range, ProMatches.territoryCanMoveAirUnits(data, player, true));
         final int numNearbyEnemyTerritories =
             CollectionUtils.countMatches(
-                possibleMoveTerritories, ProMatches.territoryIsEnemyNotNeutralLand(player));
+                possibleMoveTerritories, ProMatches.territoryIsEnemyNotPassiveNeutralLand(player));
 
         // Check if number of attack territories and value are max
         final int isntFactory = ProMatches.territoryHasInfraFactoryAndIsLand().test(t) ? 0 : 1;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -343,7 +343,7 @@ public final class ProMatches {
         territoryCanMoveLandUnits(player, false).and(Matches.isTerritoryAllied(player));
     final Predicate<Territory> hasNoEnemyNeighbors =
         Matches.territoryHasNeighborMatching(
-                player.getData().getMap(), territoryIsEnemyNotNeutralLand(player))
+                player.getData().getMap(), territoryIsEnemyNotPassiveNeutralLand(player))
             .negate();
     return alliedLand.and(hasNoEnemyNeighbors);
   }
@@ -352,10 +352,17 @@ public final class ProMatches {
     return territoryCanMoveLandUnits(player, false).and(Matches.isTerritoryEnemy(player));
   }
 
-  public static Predicate<Territory> territoryIsEnemyNotNeutralLand(final GamePlayer player) {
+  public static Predicate<Territory> territoryIsEnemyNotPassiveNeutralLand(
+      final GamePlayer player) {
     return territoryIsEnemyLand(player)
         .and(Matches.territoryIsNeutralButNotWater().negate())
         .and(t -> !ProUtils.isPassiveNeutralPlayer(t.getOwner()));
+  }
+
+  public static Predicate<Territory> territoryIsEnemyNotNeutralLand(final GamePlayer player) {
+    return territoryIsEnemyLand(player)
+        .and(Matches.territoryIsNeutralButNotWater().negate())
+        .and(t -> !ProUtils.isNeutralPlayer(t.getOwner()));
   }
 
   public static Predicate<Territory> territoryIsOrAdjacentToEnemyNotNeutralLand(
@@ -370,8 +377,9 @@ public final class ProMatches {
     return isMatch.or(adjacentMatch);
   }
 
-  public static Predicate<Territory> territoryIsEnemyNotNeutralOrAllied(final GamePlayer player) {
-    return territoryIsEnemyNotNeutralLand(player)
+  public static Predicate<Territory> territoryIsEnemyNotPassiveNeutralOrAllied(
+      final GamePlayer player) {
+    return territoryIsEnemyNotPassiveNeutralLand(player)
         .or(Matches.territoryIsLand().and(Matches.isTerritoryAllied(player)));
   }
 


### PR DESCRIPTION
## Change Summary & Additional Notes

Fix neutral logic causing AI to ignore safe attacks on Imperialism 1974.

The AI logic for "Removing neutral territory that has attackers that are adjacent to enemies" had a consistency issue where it used two different ways to check for neutrality when considering "is the territory being attacked neutral" and "are there non-neutral adjacent territories?".

The result was that the AI was very hesitant to attack neutrals if multiple neutrals are adjacent (whereas it was meant to be only if enemies are adjacent). This was seen on AI moves on Imperialism 1974, where the AI would take many turns to build up a lot of force to start attacking Neutral surrounding territory, even when no enemies were close.

Tested:
  1. Start a game with two Hard AI players on Imperialism 1974, all other players unchecked.
  2. Assuming they start non-adjacent, observe them making attacks on the first round.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
