### PR TITLE
ProAI: Consider capturable units when evaluating a territory to attack.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -1116,6 +1116,13 @@ public class ProCombatMoveAi {
         final int isCanHold = canHold ? 1 : 0;
         final int isCantHoldAmphib = !canHold && !patd.getAmphibAttackMap().isEmpty() ? 1 : 0;
         final int isFactory = ProMatches.territoryHasInfraFactoryAndIsLand().test(t) ? 1 : 0;
+        int capturableUnits = 0;
+        if (Matches.territoryIsLand().test(t)) {
+          capturableUnits =
+              CollectionUtils.countMatches(
+                  t.getUnitCollection(),
+                  Matches.unitCanBeCapturedOnEnteringThisTerritory(player, t));
+        }
         final int isFfa = ProUtils.isFfa(data, player) ? 1 : 0;
         final int production = TerritoryAttachment.getProduction(t);
         double capitalValue = 0;
@@ -1128,7 +1135,7 @@ public class ProCombatMoveAi {
                         + isLand
                         - isCantHoldAmphib
                         + isFactory
-                        + isCanHold * (1 + 2.0 * isFfa + 2.0 * isFactory))
+                        + isCanHold * (1 + 2.0 * isFfa + 1.5 * isFactory + 0.5 * capturableUnits))
                     * production
                 + capitalValue;
         double tuvSwing = result.getTuvSwing();


### PR DESCRIPTION
## Change Summary & Additional Notes
ProAI: Consider capturable units when evaluating a territory to attack.

This change will make the Pro AI take into account units it can capture, when choosing a territory to attack. Each capturable unit provides an extra 0.5 multiplier to the score.

Before this change, the presence of a factory was considered for a 2.0 multiplier. This is now reduced to 1.5, but stacks with the capturable modifier, so a capturable factory will still result in 2.0, but a non-capturable one will now be 1.5.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
