### PR TITLE
Hard AI: Don't send units that can't participate in combat on attacks.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -914,8 +914,8 @@ public class ProTerritoryManager {
       return false;
     }
 
-    // Skip units that can't participate in combat during combat moves.
-    if (isCombatMove) {
+    // Skip units that can't participate in combat during combat moves except for land transports.
+    if (isCombatMove && !Matches.unitIsLandTransport().test(u)) {
       Collection<Unit> enemyUnits =
           CollectionUtils.getMatches(to.getUnits(), Matches.unitIsEnemyOf(player));
       if (!Matches.unitCanParticipateInCombat(true, player, to, 1, enemyUnits).test(u)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -869,8 +869,7 @@ public class ProTerritoryManager {
                     player, u, startTerritory, isCombatMove, enemyTerritories);
         for (final Territory t : potentialTerritories) {
           // Find route over land checking whether unit can blitz
-          if (!isLandMoveOption(
-              isCombatMove, player, u, myUnitTerritory, t, range, canMove)) {
+          if (!isLandMoveOption(isCombatMove, player, u, myUnitTerritory, t, range, canMove)) {
             continue;
           }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -236,6 +236,8 @@ public final class Matches {
       if (!landBattle && Matches.unitIsLand().test(u)) {
         return false;
       }
+      // still allow infrastructure type units that can provide support have combat abilities
+      // remove infrastructure units that can't take part in combat (air/naval bases, etc...)
       if (!Matches.unitCanBeInBattle(attack, landBattle, battleRound, false, enemyUnitTypes)
           .test(u)) {
         return false;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -223,6 +223,39 @@ public final class Matches {
     };
   }
 
+  public static Predicate<Unit> unitCanParticipateInCombat(
+      boolean attack,
+      GamePlayer attacker,
+      Territory battleSite,
+      int battleRound,
+      Collection<Unit> enemyUnits) {
+    final Set<UnitType> enemyUnitTypes =
+        enemyUnits.stream().map(Unit::getType).collect(Collectors.toSet());
+    return u -> {
+      final boolean landBattle = !battleSite.isWater();
+      if (!landBattle && Matches.unitIsLand().test(u)) {
+        return false;
+      }
+      if (!Matches.unitCanBeInBattle(attack, landBattle, battleRound, false, enemyUnitTypes)
+          .test(u)) {
+        return false;
+      }
+      // remove capturableOnEntering units (veqryn)
+      if (Matches.unitCanBeCapturedOnEnteringThisTerritory(attacker, battleSite).test(u)) {
+        return false;
+      }
+      // remove any allied air units that are stuck on damaged carriers (veqryn)
+      if (Matches.unitIsBeingTransported()
+          .and(Matches.unitIsAir())
+          .and(Matches.unitCanLandOnCarrier())
+          .test(u)) {
+        return false;
+      }
+      // remove any units that were in air combat (veqryn)
+      return !Matches.unitWasInAirBattle().test(u);
+    };
+  }
+
   public static Predicate<Unit> unitHasAttackValueOfAtLeast(final int attackValue) {
     return unit -> UnitAttachment.get(unit.getType()).getAttack(unit.getOwner()) >= attackValue;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1273,36 +1273,11 @@ public class MustFightBattle extends DependentBattle
       final Collection<Unit> enemyUnits,
       final boolean attacking,
       final boolean removeForNextRound) {
-    final List<Unit> unitList = new ArrayList<>(units);
-    if (battleSite.isWater()) {
-      unitList.removeAll(CollectionUtils.getMatches(unitList, Matches.unitIsLand()));
-    }
-    // still allow infrastructure type units that can provide support have combat abilities
-    // remove infrastructure units that can't take part in combat (air/naval bases, etc...)
-    unitList.removeAll(
-        CollectionUtils.getMatches(
-            unitList,
-            Matches.unitCanBeInBattle(
-                    attacking,
-                    !battleSite.isWater(),
-                    (removeForNextRound ? round + 1 : round),
-                    false,
-                    enemyUnits.stream().map(Unit::getType).collect(Collectors.toSet()))
-                .negate()));
-    // remove capturableOnEntering units (veqryn)
-    unitList.removeAll(
-        CollectionUtils.getMatches(
-            unitList, Matches.unitCanBeCapturedOnEnteringThisTerritory(attacker, battleSite)));
-    // remove any allied air units that are stuck on damaged carriers (veqryn)
-    unitList.removeAll(
-        CollectionUtils.getMatches(
-            unitList,
-            Matches.unitIsBeingTransported()
-                .and(Matches.unitIsAir())
-                .and(Matches.unitCanLandOnCarrier())));
-    // remove any units that were in air combat (veqryn)
-    unitList.removeAll(CollectionUtils.getMatches(unitList, Matches.unitWasInAirBattle()));
-    return unitList;
+    int battleRound = (removeForNextRound ? round + 1 : round);
+    return CollectionUtils.getMatches(
+        units,
+        Matches.unitCanParticipateInCombat(
+            attacking, attacker, battleSite, battleRound, enemyUnits));
   }
 
   private void addRoundResetStep(final List<IExecutable> steps) {


### PR DESCRIPTION
## Change Summary & Additional Notes
Hard AI: Don't send units that can't participate in combat on attacks.

This is done by moving the logic for combat participation to a new matcher which is then re-used both from the battle code and by Pro AI when deciding attack options.

With this change, AI playing Imperialism 1974 won't send wealth units along with attacks. This paves way for a future change of mine about moving consumable units towards factories.

One other benefit of this change is reducing the number of collection copies when deciding which units can participate in a battle.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
