### PR TITLE
ProAI: Move consumable infra units towards factories.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -212,7 +212,7 @@ public abstract class AbstractProAi extends AbstractBuiltInAi {
         ProLogger.info("Simulating phase: " + stepName);
         if (GameStep.isNonCombatMoveStep(stepName)) {
           proData.initializeSimulation(this, dataCopy, playerCopy);
-          Map<Territory, ProTerritory> factoryMoveMap =
+          final Map<Territory, ProTerritory> factoryMoveMap =
               nonCombatMoveAi.simulateNonCombatMove(moveDel);
           if (storedFactoryMoveMap == null) {
             storedFactoryMoveMap =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -38,6 +38,8 @@ import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.delegate.remote.ITechDelegate;
 import games.strategy.triplea.odds.calculator.IBattleCalculator;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -122,13 +124,16 @@ public abstract class AbstractProAi extends AbstractBuiltInAi {
       final IMoveDelegate moveDel,
       final GameData data,
       final GamePlayer player) {
-    final long start = System.currentTimeMillis();
+    final Instant start = Instant.now();
     ProLogUi.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
     prepareData(data);
+    boolean didCombatMove = false;
+    boolean didNonCombatMove = false;
     if (nonCombat) {
       nonCombatMoveAi.doNonCombatMove(storedFactoryMoveMap, storedPurchaseTerritories, moveDel);
       storedFactoryMoveMap = null;
+      didNonCombatMove = true;
     } else {
       if (storedCombatMoveMap == null) {
         combatMoveAi.doCombatMove(moveDel);
@@ -136,13 +141,21 @@ public abstract class AbstractProAi extends AbstractBuiltInAi {
         combatMoveAi.doMove(storedCombatMoveMap, moveDel, data, player);
         storedCombatMoveMap = null;
       }
+      didCombatMove = true;
+      // Some maps only have a single "combat" move phase. For these, do "non-combat" moves too,
+      // after combat moves.
+      if (!hasNonCombatMove(getGameStepsForPlayer(data, player, 0))) {
+        nonCombatMoveAi.doNonCombatMove(storedFactoryMoveMap, storedPurchaseTerritories, moveDel);
+        storedFactoryMoveMap = null;
+        didNonCombatMove = true;
+      }
     }
+
+    Duration delta = Duration.between(start, Instant.now());
     ProLogger.info(
-        player.getName()
-            + " time for nonCombat="
-            + nonCombat
-            + " time="
-            + (System.currentTimeMillis() - start));
+        String.format(
+            "%s move (didCombatMove=%s  didNonCombatMove=%s) time=%s",
+            player.getName(), didCombatMove, didNonCombatMove, delta.toMillis()));
   }
 
   @Override
@@ -162,7 +175,6 @@ public abstract class AbstractProAi extends AbstractBuiltInAi {
       prepareData(data);
       storedPurchaseTerritories = purchaseAi.bid(pusToSpend, purchaseDelegate, data);
     } else {
-
       // Repair factories
       purchaseAi.repair(pusToSpend, purchaseDelegate, data, player);
 
@@ -200,7 +212,7 @@ public abstract class AbstractProAi extends AbstractBuiltInAi {
         ProLogger.info("Simulating phase: " + stepName);
         if (GameStep.isNonCombatMoveStep(stepName)) {
           proData.initializeSimulation(this, dataCopy, playerCopy);
-          final Map<Territory, ProTerritory> factoryMoveMap =
+          Map<Territory, ProTerritory> factoryMoveMap =
               nonCombatMoveAi.simulateNonCombatMove(moveDel);
           if (storedFactoryMoveMap == null) {
             storedFactoryMoveMap =
@@ -213,6 +225,25 @@ public abstract class AbstractProAi extends AbstractBuiltInAi {
           if (storedCombatMoveMap == null) {
             storedCombatMoveMap =
                 ProSimulateTurnUtils.transferMoveMap(proData, moveMap, data, player);
+          }
+          // Some maps only have a combat move. For these, do both types of moves during this phase.
+          if (!hasNonCombatMove(gameSteps)) {
+            // Copy the data so we can simulate battles on it, in order to choose our "non combat"
+            // moves based on that (estimated) board state.
+            final GameData dataCopy2 = copyData(data);
+            if (dataCopy2 == null) {
+              return;
+            }
+            final GamePlayer playerCopy2 = dataCopy2.getPlayerList().getPlayerId(player.getName());
+            proData.initializeSimulation(this, dataCopy2, playerCopy2);
+            ProSimulateTurnUtils.simulateBattles(proData, dataCopy2, playerCopy2, bridge, calc);
+            proData.initializeSimulation(this, dataCopy2, playerCopy2);
+            Map<Territory, ProTerritory> factoryMoveMap =
+                nonCombatMoveAi.simulateNonCombatMove(moveDel);
+            if (storedFactoryMoveMap == null) {
+              storedFactoryMoveMap =
+                  ProSimulateTurnUtils.transferMoveMap(proData, factoryMoveMap, data, player);
+            }
           }
         } else if (GameStep.isBattleStep(stepName)) {
           proData.initializeSimulation(this, dataCopy, playerCopy);
@@ -260,6 +291,10 @@ public abstract class AbstractProAi extends AbstractBuiltInAi {
       stepIndex++;
     }
     return gameSteps;
+  }
+
+  private boolean hasNonCombatMove(Collection<GameStep> steps) {
+    return steps.stream().anyMatch(s -> GameStep.isNonCombatMoveStep(s.getName()));
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2506,11 +2506,7 @@ class ProNonCombatMoveAi {
           ProMatches.territoryCanMoveLandUnitsThrough(player, u, from, isCombatMove, List.of());
       Territory to =
           findDestinationOrSafeTerritoryOnTheWay(
-                  u,
-                  infraUnitMoveMap.get(u),
-                  validateMove,
-                  canMoveThrough,
-                  desiredDestination)
+                  u, infraUnitMoveMap.get(u), validateMove, canMoveThrough, desiredDestination)
               .orElse(null);
       if (to != null) {
         if (!to.equals(from)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2507,7 +2507,6 @@ class ProNonCombatMoveAi {
       Territory to =
           findDestinationOrSafeTerritoryOnTheWay(
                   u,
-                  from,
                   infraUnitMoveMap.get(u),
                   validateMove,
                   canMoveThrough,
@@ -2528,11 +2527,11 @@ class ProNonCombatMoveAi {
 
   private Optional<Territory> findDestinationOrSafeTerritoryOnTheWay(
       Unit unit,
-      Territory from,
       Collection<Territory> possibleMoves,
       Predicate<Route> validateMove,
       Predicate<Territory> canMoveThrough,
       Predicate<Territory> finalDestinationTest) {
+    Territory from = unitTerritoryMap.get(unit);
     if (finalDestinationTest.test(from)) {
       // Already at a desired destination, no need to move.
       return Optional.of(from);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -427,7 +427,7 @@ public final class ProMatches {
     return hasOwnedFactoryNeighbor.and(territoryCanMoveSeaUnits(player, true));
   }
 
-  private static Predicate<Unit> unitCanBeMovedAndIsOwned(final GamePlayer player) {
+  public static Predicate<Unit> unitCanBeMovedAndIsOwned(final GamePlayer player) {
     return Matches.unitIsOwnedBy(player).and(Matches.unitHasMovementLeft());
   }
 
@@ -466,12 +466,6 @@ public final class ProMatches {
     return u ->
         !Matches.unitCanNotMoveDuringCombatMove().test(u)
             && unitCanBeMovedAndIsOwned(player).and(Matches.unitCanBombard(player)).test(u);
-  }
-
-  public static Predicate<Unit> unitCanBeMovedAndIsOwnedNonCombatInfra(final GamePlayer player) {
-    return unitCanBeMovedAndIsOwned(player)
-        .and(Matches.unitCanNotMoveDuringCombatMove())
-        .and(Matches.unitIsInfrastructure());
   }
 
   public static Predicate<Unit> unitCantBeMovedAndIsAlliedDefender(


### PR DESCRIPTION
## Change Summary & Additional Notes
ProAI: Move consumable infra units towards factories.

With this change, the Hard AI will move consumable infra units towards factories, either getting there in one turn or choosing a safe multi-turn path.

Additionally, this change makes the AI be able to handle maps where there is only a single move (combat) phase, doing all of its moves in that phase. (Maps with both phases work as before.)

Adds a smoke test covering this functionality.

Tested:
  - On Imperialism 1974, run a game with one Hard AI and all other players disabled and observe that the AI is able to conquer all territories in the old world and move any produced wealth units towards its factory to build units.
  - Running all-AI games on several maps and ensuring no errors.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
