### PR TITLE
Don't include 1-player alliances in players and resource tabs.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.ui;
 
+import games.strategy.engine.data.AllianceTracker;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -11,7 +12,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.AbstractEndTurnDelegate;
 import java.awt.GridLayout;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +111,7 @@ class EconomyPanel extends JPanel implements GameDataChangeListener {
       final GameData gameData = EconomyPanel.this.gameData;
       try (GameData.Unlocker ignored = gameData.acquireReadLock()) {
         final List<GamePlayer> players = gameData.getPlayerList().getSortedPlayers();
-        final Collection<String> alliances = gameData.getAllianceTracker().getAlliances();
+        final List<String> alliances = getAlliancesToShow(gameData.getAllianceTracker());
         collectedData = new String[players.size() + alliances.size()][resourceStats.size() + 1];
         int row = 0;
         final Map<GamePlayer, IntegerMap<Resource>> resourceIncomeMap = new HashMap<>();
@@ -128,7 +128,7 @@ class EconomyPanel extends JPanel implements GameDataChangeListener {
           }
           row++;
         }
-        for (final String alliance : alliances.stream().sorted().collect(Collectors.toList())) {
+        for (final String alliance : alliances) {
           collectedData[row][0] = "<html><b>" + alliance;
           for (int i = 0; i < resourceStats.size(); i++) {
             final ResourceStat resourceStat = resourceStats.get(i);
@@ -142,6 +142,13 @@ class EconomyPanel extends JPanel implements GameDataChangeListener {
           row++;
         }
       }
+    }
+
+    private List<String> getAlliancesToShow(AllianceTracker tracker) {
+      return tracker.getAlliances().stream()
+          .filter(a -> tracker.getPlayersInAlliance(a).size() > 1)
+          .sorted()
+          .collect(Collectors.toList());
     }
 
     private String getResourceAmountAndIncome(final double amount, final int income) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.ui;
 
+import games.strategy.engine.data.AllianceTracker;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -22,7 +23,6 @@ import java.awt.GridLayout;
 import java.awt.Image;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +196,7 @@ class StatPanel extends JPanel implements GameDataChangeListener {
       final GameData gameData = StatPanel.this.gameData;
       try (GameData.Unlocker ignored = gameData.acquireReadLock()) {
         final List<GamePlayer> players = gameData.getPlayerList().getSortedPlayers();
-        final Collection<String> alliances = gameData.getAllianceTracker().getAlliances();
+        final List<String> alliances = getAlliancesToShow(gameData.getAllianceTracker());
         collectedData = new String[players.size() + alliances.size()][stats.length + 1];
         int row = 0;
         for (final GamePlayer player : players) {
@@ -207,7 +207,7 @@ class StatPanel extends JPanel implements GameDataChangeListener {
           }
           row++;
         }
-        for (final String alliance : alliances.stream().sorted().collect(Collectors.toList())) {
+        for (final String alliance : alliances) {
           collectedData[row][0] = "<html><b>" + alliance;
           for (int i = 0; i < stats.length; i++) {
             double value = stats[i].getValue(alliance, gameData, uiContext.getMapData());
@@ -216,6 +216,13 @@ class StatPanel extends JPanel implements GameDataChangeListener {
           row++;
         }
       }
+    }
+
+    private List<String> getAlliancesToShow(AllianceTracker tracker) {
+      return tracker.getAlliances().stream()
+          .filter(a -> tracker.getPlayersInAlliance(a).size() > 1)
+          .sorted()
+          .collect(Collectors.toList());
     }
 
     /*


### PR DESCRIPTION
## Change Summary & Additional Notes
This fixes a 2.6 regression as previously this logic was in AbstractStatPanel.getAllianceMap().

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
