### PR TITLE
Stop using hardcoded territory name prefixes to handle islands.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/IslandTerritoryFinder.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/IslandTerritoryFinder.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.ui.mapdata;
 
-import games.strategy.ui.Util;
 import java.awt.Polygon;
 import java.util.List;
 import java.util.Map;
@@ -10,6 +9,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.CollectionUtils;
+import tools.util.ToolsUtil;
 
 @UtilityClass
 class IslandTerritoryFinder {
@@ -40,11 +40,12 @@ class IslandTerritoryFinder {
   }
 
   private static Set<String> filterSeaTerritories(final Set<String> territoryNames) {
-    return filterTerritories(territoryNames, Util::isTerritoryNameIndicatingWater);
+    return filterTerritories(territoryNames, ToolsUtil::isTerritoryNameIndicatingWater);
   }
 
   private static Set<String> filterNotSeaTerritories(final Set<String> territoryNames) {
-    return filterTerritories(territoryNames, Predicate.not(Util::isTerritoryNameIndicatingWater));
+    return filterTerritories(
+        territoryNames, Predicate.not(ToolsUtil::isTerritoryNameIndicatingWater));
   }
 
   /** Returns a subset of territories matching a given filter. */

--- a/game-app/game-core/src/main/java/games/strategy/ui/Util.java
+++ b/game-app/game-core/src/main/java/games/strategy/ui/Util.java
@@ -22,7 +22,6 @@ import lombok.experimental.UtilityClass;
 /** A collection of methods useful for rendering the UI. */
 @UtilityClass
 public final class Util {
-  public static final String TERRITORY_SEA_ZONE_INFIX = "Sea Zone";
 
   private static final Component component =
       new Component() {
@@ -112,17 +111,6 @@ public final class Util {
     final float loginStringX = w * .05f;
     g2.drawString(text, loginStringX, loginStringY);
     return img;
-  }
-
-  /**
-   * Checks whether name indicates water or not (meaning name starts or ends with default text).
-   *
-   * @param territoryName - territory name
-   * @return true if yes, false otherwise
-   */
-  public static boolean isTerritoryNameIndicatingWater(final String territoryName) {
-    return territoryName.endsWith(TERRITORY_SEA_ZONE_INFIX)
-        || territoryName.startsWith(TERRITORY_SEA_ZONE_INFIX);
   }
 
   /**

--- a/game-app/game-core/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/game-app/game-core/src/main/java/tools/map/making/ConnectionFinder.java
@@ -2,7 +2,6 @@ package tools.map.making;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import games.strategy.ui.Util;
 import java.awt.Dimension;
 import java.awt.Polygon;
 import java.awt.Shape;
@@ -35,6 +34,7 @@ import org.triplea.util.PointFileReaderWriter;
 import tools.image.FileOpen;
 import tools.image.FileSave;
 import tools.image.MapFolderLocationSystemProperty;
+import tools.util.ToolsUtil;
 
 /**
  * Utility to find connections between polygons Not pretty, meant only for one time use. Inputs - a
@@ -209,9 +209,9 @@ public final class ConnectionFinder {
           JOptionPane.showInputDialog(
               null,
               "Enter a string or regex that determines if the territory is Water? \r\n(e.g.: "
-                  + Util.TERRITORY_SEA_ZONE_INFIX
+                  + ToolsUtil.TERRITORY_SEA_ZONE_INFIX
                   + ")",
-              Util.TERRITORY_SEA_ZONE_INFIX);
+              ToolsUtil.TERRITORY_SEA_ZONE_INFIX);
       territoryDefinitions = doTerritoryDefinitions(allTerritories, waterString);
     }
     try {

--- a/game-app/game-core/src/main/java/tools/util/ToolsUtil.java
+++ b/game-app/game-core/src/main/java/tools/util/ToolsUtil.java
@@ -1,6 +1,5 @@
 package tools.util;
 
-import games.strategy.ui.Util;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.util.Collection;
@@ -11,6 +10,8 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class ToolsUtil {
+  public static final String TERRITORY_SEA_ZONE_INFIX = "Sea Zone";
+
   /**
    * Finds a land territory name or some sea zone name where the point is contained in according to
    * the territory name -> polygons map.
@@ -42,7 +43,7 @@ public class ToolsUtil {
       final Collection<Polygon> polygons = terrPolygons.get(terrName);
       for (final Polygon poly : polygons) {
         if (poly.contains(p)) {
-          if (Util.isTerritoryNameIndicatingWater(terrName)) {
+          if (isTerritoryNameIndicatingWater(terrName)) {
             lastWaterTerrName = terrName;
           } else {
             return terrName;
@@ -51,5 +52,16 @@ public class ToolsUtil {
       } // polygons collection loop
     } // terrPolygons map loop
     return lastWaterTerrName;
+  }
+
+  /**
+   * Checks whether name indicates water or not (meaning name starts or ends with default text).
+   *
+   * @param territoryName - territory name
+   * @return true if yes, false otherwise
+   */
+  public static boolean isTerritoryNameIndicatingWater(final String territoryName) {
+    return territoryName.endsWith(TERRITORY_SEA_ZONE_INFIX)
+        || territoryName.startsWith(TERRITORY_SEA_ZONE_INFIX);
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ui/mapdata/IslandTerritoryFinderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ui/mapdata/IslandTerritoryFinderTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.hamcrest.core.Is.is;
 
-import games.strategy.ui.Util;
 import java.awt.Polygon;
 import java.util.List;
 import java.util.Map;
@@ -13,11 +12,12 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.util.ToolsUtil;
 
 final class IslandTerritoryFinderTest {
 
-  private static final String SEA_TERR = Util.TERRITORY_SEA_ZONE_INFIX;
-  private static final String SEA_TERR_1 = Util.TERRITORY_SEA_ZONE_INFIX + " 1";
+  private static final String SEA_TERR = ToolsUtil.TERRITORY_SEA_ZONE_INFIX;
+  private static final String SEA_TERR_1 = ToolsUtil.TERRITORY_SEA_ZONE_INFIX + " 1";
   private static final String LAND_TERR = "Land";
   private static final String LAND_TERR_1 = "Land 1";
 


### PR DESCRIPTION
## Change Summary & Additional Notes
Stop using hardcoded territory name prefixes to handle islands.

The engine checked for "Sea Zone" as a prefix or suffix in the territory name to determine which territory should be considered "on top" to handle islands. This didn't work for maps where the sea zones didn't following the naming convention and also didn't support land territories fully surrounding other land territories.

This PR updates the logic to be based on the size of the polygon being matched instead, with the smallest polygon taking precedence.

The old logic is moved to mapmaking tool code only and no longer the main engine code.

Tested:
  - Mouse-overing Corsica on "Cold War" map works correctly.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Sea zones no longer need to have special names for islands to work correctly<!--END_RELEASE_NOTE-->
