### PR TITLE
Bump default mem size to 2G for smoke tests.

### DIFF
--- a/smoke-testing/build.gradle
+++ b/smoke-testing/build.gradle
@@ -21,6 +21,11 @@ shadowJar {
     archiveClassifier.set ''
 }
 
+test {
+    // AiGameTest is memory intensive due to ConcurrentBattleCalculator threads deserializing GameData concurrently.
+    maxHeapSize = "2G"
+}
+
 tasks.test.dependsOn("downloadXmls", "downloadSaveGames")
 
 task downloadXmls {


### PR DESCRIPTION
## Change Summary & Additional Notes
Bump default mem size to 2G for smoke tests.

They seem to default to 512M which on one of my machines runs into OOMs when running AiGameTest.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
