### PR TITLE
ProAI: Only consider consumable units for non-construction purchases.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2472,7 +2472,8 @@ class ProNonCombatMoveAi {
     // First, determine which unit types can be consumed during purchase phase.
     Set<UnitType> consumables = new HashSet<>();
     for (ProPurchaseOption option : proData.getPurchaseOptions().getAllOptions()) {
-      if (option.isConsumesUnits()) {
+      // Skip construction purchase options, since these can be placed without factory.
+      if (option.isConsumesUnits() && !option.isConstruction()) {
         consumables.addAll(UnitAttachment.get(option.getUnitType()).getConsumesUnits().keySet());
       }
     }


### PR DESCRIPTION
## Change Summary & Additional Notes
ProAI: Only consider consumable units for non-construction purchases.

IsConstruction purchases can be placed without factory, so their consumable units don't need to be moved to factories.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
