### PR TITLE
Cleanup: UnitAttachment.get(u.getType()) -> u.getUnitAttachment().

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -452,7 +452,7 @@ public class Route implements Serializable, Iterable<Territory> {
     if (Matches.unitIsBeingTransported().test(unit)) {
       return Tuple.of(resources, false);
     }
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    final UnitAttachment ua = unit.getUnitAttachment();
     resources.add(ua.getFuelCost());
     resources.multiply(getMovementCost(unit).setScale(0, RoundingMode.CEILING).intValue());
     boolean chargedFlatFuelCost = false;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -112,7 +112,7 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     setOwner(owner);
   }
 
-  public final UnitAttachment getUnitAttachment() {
+  public UnitAttachment getUnitAttachment() {
     return (UnitAttachment) type.getAttachment("unitAttachment");
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -112,7 +112,7 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     setOwner(owner);
   }
 
-  public UnitAttachment getUnitAttachment() {
+  public final UnitAttachment getUnitAttachment() {
     return (UnitAttachment) type.getAttachment("unitAttachment");
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
@@ -118,7 +118,7 @@ public class UnitUtils {
     if (!Matches.unitCanProduceUnits().test(unit)) {
       return 0;
     }
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    final UnitAttachment ua = unit.getUnitAttachment();
     final TerritoryAttachment ta = TerritoryAttachment.get(producer);
     int territoryProduction = 0;
     int territoryUnitProduction = 0;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
@@ -11,7 +11,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
@@ -308,7 +307,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
         final int num =
             Math.min(
                 attackTokens.getInt(resource),
-                (UnitAttachment.get(u.getType()).getHitPoints()
+                (u.getUnitAttachment().getHitPoints()
                     * (Math.random() < .3 ? 1 : (Math.random() < .5 ? 2 : 3))));
         resourceMap.put(resource, num);
         kamikazeSuicideAttacks.computeIfAbsent(t, key -> new HashMap<>()).put(u, resourceMap);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AiUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AiUtils.java
@@ -70,7 +70,7 @@ public final class AiUtils {
       final Collection<Unit> units, final boolean attacking, final boolean sea) {
     float strength = 0;
     for (final Unit u : units) {
-      final UnitAttachment unitAttachment = UnitAttachment.get(u.getType());
+      final UnitAttachment unitAttachment = u.getUnitAttachment();
       if (!unitAttachment.getIsInfrastructure() && unitAttachment.getIsSea() == sea) {
         // 2 points since we can absorb a hit
         strength += 2;
@@ -132,7 +132,7 @@ public final class AiUtils {
     // Loop through all units, starting from the right, and rearrange units
     for (int i = result.size() - 1; i >= 0; i--) {
       final Unit unit = result.get(i);
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       // If this is a plane
       if (ua.getCarrierCost() > 0) {
         // If this is the first carrier seek
@@ -149,8 +149,7 @@ public final class AiUtils {
           seekedCarrier = result.get(seekedCarrierIndex);
           // Tell the code to insert carrier to the right of this plane
           indexToPlaceCarrierAt = i + 1;
-          spaceLeftOnSeekedCarrier =
-              UnitAttachment.get(seekedCarrier.getType()).getCarrierCapacity();
+          spaceLeftOnSeekedCarrier = seekedCarrier.getUnitAttachment().getCarrierCapacity();
         }
         spaceLeftOnSeekedCarrier -= ua.getCarrierCost();
         // If the carrier has been filled or overflowed
@@ -183,8 +182,7 @@ public final class AiUtils {
             // Place next carrier right before this plane (which just filled the old carrier that
             // was just moved)
             indexToPlaceCarrierAt = i;
-            spaceLeftOnSeekedCarrier =
-                UnitAttachment.get(seekedCarrier.getType()).getCarrierCapacity();
+            spaceLeftOnSeekedCarrier = seekedCarrier.getUnitAttachment().getCarrierCapacity();
           } else { // If it's later in the list
             final int oldIndex = result.indexOf(seekedCarrier);
             int carrierPlaceLocation = indexToPlaceCarrierAt;
@@ -199,7 +197,7 @@ public final class AiUtils {
             final List<Unit> planesBetweenHereAndCarrier = new ArrayList<>();
             for (int i2 = i; i2 < carrierPlaceLocation; i2++) {
               final Unit unit2 = result.get(i2);
-              final UnitAttachment ua2 = UnitAttachment.get(unit2.getType());
+              final UnitAttachment ua2 = unit2.getUnitAttachment();
               if (ua2.getCarrierCost() > 0) {
                 planesBetweenHereAndCarrier.add(unit2);
               }
@@ -227,8 +225,7 @@ public final class AiUtils {
             // Since we only moved planes up, just reduce next carrier place index by plane move
             // count
             indexToPlaceCarrierAt = carrierPlaceLocation - planeMoveCount;
-            spaceLeftOnSeekedCarrier =
-                UnitAttachment.get(seekedCarrier.getType()).getCarrierCapacity();
+            spaceLeftOnSeekedCarrier = seekedCarrier.getUnitAttachment().getCarrierCapacity();
           }
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -22,7 +22,6 @@ import games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils;
 import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.ai.pro.util.ProUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.battle.AirBattle;
@@ -925,7 +924,7 @@ public class ProCombatMoveAi {
 
       // Set air units in any territory with no AA (don't move planes to empty territories)
       for (final Unit unit : sortedUnitAttackOptions.keySet()) {
-        final boolean isAirUnit = UnitAttachment.get(unit.getType()).getIsAir();
+        final boolean isAirUnit = unit.getUnitAttachment().getIsAir();
         if (!isAirUnit) {
           continue; // skip non-air units
         }
@@ -1013,7 +1012,7 @@ public class ProCombatMoveAi {
 
       // Add sea units to any territory that significantly increases TUV gain
       for (final Unit unit : sortedUnitAttackOptions.keySet()) {
-        final boolean isSeaUnit = UnitAttachment.get(unit.getType()).getIsSea();
+        final boolean isSeaUnit = unit.getUnitAttachment().getIsSea();
         if (!isSeaUnit) {
           continue; // skip non-sea units
         }
@@ -1248,7 +1247,7 @@ public class ProCombatMoveAi {
 
     // Try to set at least one destroyer in each sea territory with subs
     for (final Unit unit : sortedUnitAttackOptions.keySet()) {
-      final boolean isDestroyerUnit = UnitAttachment.get(unit.getType()).getIsDestroyer();
+      final boolean isDestroyerUnit = unit.getUnitAttachment().getIsDestroyer();
       if (!isDestroyerUnit) {
         continue; // skip non-destroyer units
       }
@@ -1268,7 +1267,7 @@ public class ProCombatMoveAi {
 
     // Set enough land and sea units in territories to have at least a chance of winning
     for (final Unit unit : sortedUnitAttackOptions.keySet()) {
-      final boolean isAirUnit = UnitAttachment.get(unit.getType()).getIsAir();
+      final boolean isAirUnit = unit.getUnitAttachment().getIsAir();
       final boolean isExpensiveLandUnit =
           Matches.unitIsLand().test(unit)
               && proData.getUnitValue(unit.getType()) > 2 * proData.getMinCostPerHitPoint();
@@ -1308,7 +1307,7 @@ public class ProCombatMoveAi {
 
     // Set non-air units in territories that can be held
     for (final Unit unit : sortedUnitAttackOptions.keySet()) {
-      final boolean isAirUnit = UnitAttachment.get(unit.getType()).getIsAir();
+      final boolean isAirUnit = unit.getUnitAttachment().getIsAir();
       if (isAirUnit || addedUnits.contains(unit)) {
         continue; // skip air units
       }
@@ -1345,7 +1344,7 @@ public class ProCombatMoveAi {
 
     // Set air units in territories that can't be held (don't move planes to empty territories)
     for (final Unit unit : sortedUnitAttackOptions.keySet()) {
-      final boolean isAirUnit = UnitAttachment.get(unit.getType()).getIsAir();
+      final boolean isAirUnit = unit.getUnitAttachment().getIsAir();
       if (!isAirUnit) {
         continue; // skip non-air units
       }
@@ -1417,7 +1416,7 @@ public class ProCombatMoveAi {
       if (addedUnits.contains(unit)) {
         continue;
       }
-      final boolean isAirUnit = UnitAttachment.get(unit.getType()).getIsAir();
+      final boolean isAirUnit = unit.getUnitAttachment().getIsAir();
       Territory minWinTerritory = null;
       double minWinPercentage = proData.getWinPercentage();
       for (final Territory t : sortedUnitAttackOptions.get(unit)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -764,7 +764,7 @@ class ProNonCombatMoveAi {
 
       // Set enough units in territories to have at least a chance of winning
       for (final Unit unit : sortedUnitMoveOptions.keySet()) {
-        final boolean isAirUnit = UnitAttachment.get(unit.getType()).getIsAir();
+        final boolean isAirUnit = unit.getUnitAttachment().getIsAir();
         if (isAirUnit || Matches.unitIsCarrier().test(unit) || addedUnits.contains(unit)) {
           continue; // skip air and carrier units
         }
@@ -1982,7 +1982,7 @@ class ProNonCombatMoveAi {
             }
             int transportCapacity1 = 0;
             for (final Unit transport : transports1) {
-              transportCapacity1 += UnitAttachment.get(transport.getType()).getTransportCapacity();
+              transportCapacity1 += transport.getUnitAttachment().getTransportCapacity();
             }
 
             // Find transport capacity of nearby (distance 2) transports
@@ -2000,7 +2000,7 @@ class ProNonCombatMoveAi {
             }
             int transportCapacity2 = 0;
             for (final Unit transport : transports2) {
-              transportCapacity2 += UnitAttachment.get(transport.getType()).getTransportCapacity();
+              transportCapacity2 += transport.getUnitAttachment().getTransportCapacity();
             }
             final List<Unit> unitsToTransport =
                 CollectionUtils.getMatches(
@@ -2010,7 +2010,7 @@ class ProNonCombatMoveAi {
             // Find transport cost of potential amphib units
             int transportCost = 0;
             for (final Unit unit : unitsToTransport) {
-              transportCost += UnitAttachment.get(unit.getType()).getTransportCost();
+              transportCost += unit.getUnitAttachment().getTransportCost();
             }
 
             // Find territory that needs amphib units that most

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -1599,8 +1599,8 @@ class ProNonCombatMoveAi {
         }
         // If transporting units then unload to safe territory
         // TODO: consider which is 'safest'
-        if (TransportTracker.isTransporting(transport)) {
-          final List<Unit> amphibUnits = transport.getTransporting();
+        final List<Unit> amphibUnits = transport.getTransporting();
+        if (!amphibUnits.isEmpty()) {
           final Set<Territory> possibleUnloadTerritories =
               data.getMap()
                   .getNeighbors(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -30,7 +30,6 @@ import games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils;
 import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.ai.pro.util.ProUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
@@ -1958,7 +1957,7 @@ class ProPurchaseAi {
 
             // Get next empty transport and find its capacity
             final Unit transport = transportsThatNeedUnits.get(0);
-            int transportCapacity = UnitAttachment.get(transport.getType()).getTransportCapacity();
+            int transportCapacity = transport.getUnitAttachment().getTransportCapacity();
 
             // Find any existing units that can be transported
             final List<Unit> selectedUnits =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -317,7 +317,7 @@ final class ProTechAi {
       return strength;
     }
     for (final Unit u : units) {
-      final UnitAttachment unitAttachment = UnitAttachment.get(u.getType());
+      final UnitAttachment unitAttachment = u.getUnitAttachment();
       if (unitAttachment.getIsInfrastructure()) {
         if (unitAttachment.getIsSea() == sea) {
           final int unitAttack = unitAttachment.getAttack(u.getOwner());
@@ -533,7 +533,7 @@ final class ProTechAi {
   private static float allAirStrength(final Collection<Unit> units) {
     float airStrength = 0.0F;
     for (final Unit u : units) {
-      final UnitAttachment unitAttachment = UnitAttachment.get(u.getType());
+      final UnitAttachment unitAttachment = u.getUnitAttachment();
       airStrength += 1.00F;
       airStrength += unitAttachment.getAttack(u.getOwner());
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -16,7 +16,6 @@ import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.ai.pro.util.ProUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.TransportTracker;
@@ -1131,8 +1130,8 @@ public class ProTerritoryManager {
                                 : ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(
                                     player, myTransport, isCombatMove));
                 for (final Unit possibleUnit : possibleUnits) {
-                  if (UnitAttachment.get(possibleUnit.getType()).getTransportCost()
-                      <= UnitAttachment.get(myTransport.getType()).getTransportCapacity()) {
+                  if (possibleUnit.getUnitAttachment().getTransportCost()
+                      <= myTransport.getUnitAttachment().getTransportCapacity()) {
                     units.add(possibleUnit);
                     myUnitsToLoadTerritories.add(possibleLoadTerritory);
                   }
@@ -1318,8 +1317,7 @@ public class ProTerritoryManager {
       final GamePlayer player,
       final boolean isCheckingEnemyAttacks) {
     if (isCheckingEnemyAttacks) {
-      final BigDecimal range =
-          new BigDecimal(UnitAttachment.get(unit.getType()).getMovement(player));
+      final BigDecimal range = new BigDecimal(unit.getUnitAttachment().getMovement(player));
       if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(unitTerritory, player)
           .test(unit)) {
         return range.add(BigDecimal.ONE); // assumes bonus of +1 for now

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -18,7 +18,6 @@ import games.strategy.triplea.ai.pro.util.ProUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
-import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.battle.ScrambleLogic;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
 import java.math.BigDecimal;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1116,8 +1116,9 @@ public class ProTerritoryManager {
             // present
             final List<Unit> units = new ArrayList<>();
             final Set<Territory> myUnitsToLoadTerritories = new HashSet<>();
-            if (TransportTracker.isTransporting(myTransport)) {
-              units.addAll(myTransport.getTransporting());
+            final Collection<Unit> transporting = myTransport.getTransporting();
+            if (!transporting.isEmpty()) {
+              units.addAll(transporting);
             } else if (Matches.territoryHasEnemySeaUnits(player).negate().test(currentTerritory)) {
               final Set<Territory> possibleLoadTerritories = gameMap.getNeighbors(currentTerritory);
               for (final Territory possibleLoadTerritory : possibleLoadTerritories) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -11,7 +11,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -546,7 +545,7 @@ public final class ProMatches {
 
   public static Predicate<Unit> unitIsOwnedCarrier(final GamePlayer player) {
     return unit ->
-        UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1
+        unit.getUnitAttachment().getCarrierCapacity() != -1
             && Matches.unitIsOwnedBy(player).test(unit);
   }
 
@@ -574,7 +573,7 @@ public final class ProMatches {
     return u ->
         (!isCombatMove
                 || (!Matches.unitCanNotMoveDuringCombatMove().test(u)
-                    && UnitAttachment.get(u.getType()).canInvadeFrom(transport)))
+                    && u.getUnitAttachment().canInvadeFrom(transport)))
             && unitIsOwnedTransportableUnit(player)
                 .and(Matches.unitHasNotMoved())
                 .and(Matches.unitHasMovementLeft())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -19,7 +19,6 @@ import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TransportTracker;
 import java.util.ArrayList;
@@ -327,7 +326,7 @@ public final class ProPurchaseUtils {
         CollectionUtils.getMatches(unitsToPlace, Matches.unitConsumesUnitsOnCreation());
     Set<Unit> unitsToConsume = new HashSet<>();
     for (Unit unitToBuild : unitsThatConsume) {
-      IntegerMap<UnitType> needed = UnitAttachment.get(unitToBuild.getType()).getConsumesUnits();
+      IntegerMap<UnitType> needed = unitToBuild.getUnitAttachment().getConsumesUnits();
       for (UnitType neededType : needed.keySet()) {
         final Predicate<Unit> matcher =
             Matches.eligibleUnitToConsume(player, neededType).and(u -> !unitsToConsume.contains(u));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
@@ -16,7 +16,6 @@ import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
 import games.strategy.triplea.ai.pro.data.ProResourceTracker;
 import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.AbstractPlaceDelegate;
 import games.strategy.triplea.delegate.Matches;
 import java.util.Collection;
@@ -102,7 +101,7 @@ public final class ProPurchaseValidationUtils {
     // are already planning to consume.
     IntegerMap<UnitType> requiredUnits = new IntegerMap<>();
     for (Unit unitToBuild : unitsToBuild) {
-      requiredUnits.add(UnitAttachment.get(unitToBuild.getType()).getConsumesUnits());
+      requiredUnits.add(unitToBuild.getUnitAttachment().getConsumesUnits());
     }
     if (requiredUnits.isEmpty()) {
       return true;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -228,7 +228,7 @@ public final class ProSortMoveOptionsUtils {
       }
     }
 
-    if (UnitAttachment.get(unit.getType()).getIsAir()) {
+    if (unit.getUnitAttachment().getIsAir()) {
       minPower *= 10;
     }
     return (double) minPower / proData.getUnitValue(unit.getType());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -182,7 +182,7 @@ public class WeakAi extends AbstractBuiltInAi {
         final Iterator<Unit> iter = unitsToLoad.iterator();
         while (iter.hasNext() && free > 0) {
           final Unit current = iter.next();
-          final UnitAttachment ua = UnitAttachment.get(current.getType());
+          final UnitAttachment ua = current.getUnitAttachment();
           if (ua.getIsAir()) {
             continue;
           }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2090,7 +2090,7 @@ public class UnitAttachment extends DefaultAttachment {
     }
     Collection<UnitType> allowedTargets = unitTypeList.getAllUnitTypes();
     for (final Unit u : bombersOrRockets) {
-      final UnitAttachment ua = UnitAttachment.get(u.getType());
+      final UnitAttachment ua = u.getUnitAttachment();
       final Set<UnitType> bombingTargets = ua.getBombingTargets(unitTypeList);
       allowedTargets = CollectionUtils.intersection(allowedTargets, bombingTargets);
     }
@@ -2361,7 +2361,7 @@ public class UnitAttachment extends DefaultAttachment {
   public static List<String> getAllOfTypeAas(final Collection<Unit> aaUnitsAlreadyVerified) {
     final Set<String> aaSet = new HashSet<>();
     for (final Unit u : aaUnitsAlreadyVerified) {
-      aaSet.add(UnitAttachment.get(u.getType()).getTypeAa());
+      aaSet.add(u.getUnitAttachment().getTypeAa());
     }
     final List<String> aaTypes = new ArrayList<>(aaSet);
     Collections.sort(aaTypes);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -96,7 +96,8 @@ class AaInMoveUtil implements Serializable {
       final Collection<Unit> currentPossibleAa =
           CollectionUtils.getMatches(defendingAa, Matches.unitIsAaOfTypeAa(currentTypeAa));
       final Set<UnitType> targetUnitTypesForThisTypeAa =
-          UnitAttachment.get(CollectionUtils.getAny(currentPossibleAa).getType())
+          CollectionUtils.getAny(currentPossibleAa)
+              .getUnitAttachment()
               .getTargetsAa(getData().getUnitTypeList());
       final Set<UnitType> airborneTypesTargettedToo = airborneTechTargetsAllowed.get(currentTypeAa);
       final Collection<Unit> validTargetedUnitsForThisRoll =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -26,7 +26,6 @@ import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.RelationshipTypeAttachment;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.dice.RollDiceFactory;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
@@ -521,7 +520,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
       if (rollDiceForBlockadeDamage) {
         int numberOfDice = 0;
         for (final Unit u : enemies) {
-          numberOfDice += UnitAttachment.get(u.getType()).getBlockade();
+          numberOfDice += u.getUnitAttachment().getBlockade();
         }
         if (numberOfDice > 0) {
           // there is an issue with maps that have lots of rolls without any pause between them:
@@ -550,7 +549,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
         }
       } else {
         for (final Unit u : enemies) {
-          loss += UnitAttachment.get(u.getType()).getBlockade();
+          loss += u.getUnitAttachment().getBlockade();
         }
       }
       if (loss <= 0) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -802,7 +802,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     final IntegerMap<String> constructionMap =
         howManyOfEachConstructionCanPlace(to, to, units, player);
     for (final Unit currentUnit : CollectionUtils.getMatches(units, Matches.unitIsConstruction())) {
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
+      final UnitAttachment ua = currentUnit.getUnitAttachment();
       /*
        * if (ua.getIsFactory() && !ua.getIsConstruction())
        * constructionMap.add("factory", -1);
@@ -877,7 +877,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     }
     // account for any unit placement restrictions by territory
     for (final Unit currentUnit : units) {
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
+      final UnitAttachment ua = currentUnit.getUnitAttachment();
       // Can be null!
       final TerritoryAttachment ta = TerritoryAttachment.get(to);
       if (ua.getCanOnlyBePlacedInTerritoryValuedAtX() != -1
@@ -1024,7 +1024,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     }
     final Collection<Unit> placeableUnits3 = new ArrayList<>();
     for (final Unit currentUnit : placeableUnits2) {
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
+      final UnitAttachment ua = currentUnit.getUnitAttachment();
       // Can be null!
       final TerritoryAttachment ta = TerritoryAttachment.get(to);
       if (ua.getCanOnlyBePlacedInTerritoryValuedAtX() != -1
@@ -1076,7 +1076,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       // remove units which are now consumed, then test the rest of the consuming units on the
       // diminishing pile of units
       // which were in the territory at start of turn
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       final IntegerMap<UnitType> requiredUnitsMap = ua.getConsumesUnits();
       final Collection<UnitType> requiredUnits = requiredUnitsMap.keySet();
       for (final UnitType ut : requiredUnits) {
@@ -1399,7 +1399,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       toProduction = terrAttachment.getProduction();
     }
     for (final Unit currentUnit : CollectionUtils.getMatches(units, Matches.unitIsConstruction())) {
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
+      final UnitAttachment ua = currentUnit.getUnitAttachment();
       // account for any unit placement restrictions by territory
       if (Properties.getUnitPlacementRestrictions(getData().getProperties())) {
         final String[] terrs = ua.getUnitPlacementRestrictions();
@@ -1443,7 +1443,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     if (unitsInTo.stream().anyMatch(Matches.unitIsConstruction())) {
       for (final Unit currentUnit :
           CollectionUtils.getMatches(unitsInTo, Matches.unitIsConstruction())) {
-        final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
+        final UnitAttachment ua = currentUnit.getUnitAttachment();
         /*
          * if (Matches.UnitIsFactory.test(currentUnit) && !ua.getIsConstruction())
          * unitMapTO.add("factory", 1);
@@ -1482,7 +1482,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     // deal with already placed units
     for (final Unit currentUnit :
         CollectionUtils.getMatches(unitsPlacedAlready, Matches.unitIsConstruction())) {
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
+      final UnitAttachment ua = currentUnit.getUnitAttachment();
       unitMapTypePerTurn.add(ua.getConstructionType(), -1);
     }
     // modify this list based on how many we can place per turn
@@ -1503,7 +1503,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
   }
 
   static int howManyOfConstructionUnit(final Unit unit, final IntegerMap<String> constructionsMap) {
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    final UnitAttachment ua = unit.getUnitAttachment();
     if (!ua.getIsConstruction()
         || ua.getConstructionsPerTerrPerTypePerTurn() < 1
         || ua.getMaxConstructionsPerTypePerTerr() < 1) {
@@ -1632,8 +1632,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       if (Objects.equals(u1, u2)) {
         return 0;
       }
-      final UnitAttachment ua1 = UnitAttachment.get(u1.getType());
-      final UnitAttachment ua2 = UnitAttachment.get(u2.getType());
+      final UnitAttachment ua1 = u1.getUnitAttachment();
+      final UnitAttachment ua2 = u2.getUnitAttachment();
       if (ua1 == null && ua2 == null) {
         return 0;
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -68,7 +68,7 @@ public class AirThatCantLandUtil {
           territory.getUnitCollection().getMatches(Matches.alliedUnit(player));
       int capacity = AirMovementValidator.carrierCapacity(carriers, territory);
       for (final Unit unit : airUnits) {
-        final UnitAttachment ua = UnitAttachment.get(unit.getType());
+        final UnitAttachment ua = unit.getUnitAttachment();
         final int cost = ua.getCarrierCost();
         if (cost == -1 || cost > capacity) {
           toRemove.add(unit);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -9,7 +9,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.move.validation.AirMovementValidator;
 import games.strategy.triplea.util.TransportUtils;
 import java.util.ArrayList;
@@ -223,7 +222,7 @@ final class EditValidator {
     }
     for (final Unit u : units) {
       final int dmg = unitDamageMap.getInt(u);
-      if (dmg < 0 || dmg >= UnitAttachment.get(u.getType()).getHitPoints()) {
+      if (dmg < 0 || dmg >= u.getUnitAttachment().getHitPoints()) {
         return "Damage cannot be less than zero or equal to or greater than unit "
             + "hitpoints (if you want to kill the unit, use remove unit)";
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -86,7 +86,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
         final Collection<Unit> toAddSea = new ArrayList<>();
         final Collection<Unit> toAddLand = new ArrayList<>();
         for (final Unit u : myCreators) {
-          final UnitAttachment ua = UnitAttachment.get(u.getType());
+          final UnitAttachment ua = u.getUnitAttachment();
           final IntegerMap<UnitType> createsUnitsMap = ua.getCreatesUnitsList();
           final Collection<UnitType> willBeCreated = createsUnitsMap.keySet();
           for (final UnitType ut : willBeCreated) {
@@ -218,7 +218,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
       final Collection<Unit> myCreators = CollectionUtils.getMatches(t.getUnits(), myCreatorsMatch);
       for (final Unit unit : myCreators) {
         final IntegerMap<Resource> generatedResourcesMap =
-            UnitAttachment.get(unit.getType()).getCreatesResourcesList();
+            unit.getUnitAttachment().getCreatesResourcesList();
         resourceTotalsMap.add(generatedResourcesMap);
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -115,7 +115,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
           CollectionUtils.getMatches(units, Matches.unitIsTransport());
       final Collection<Unit> land = CollectionUtils.getMatches(units, Matches.unitIsLand());
       for (final Unit toLoad : land) {
-        final UnitAttachment ua = UnitAttachment.get(toLoad.getType());
+        final UnitAttachment ua = toLoad.getUnitAttachment();
         final int cost = ua.getTransportCost();
         if (cost == -1) {
           throw new IllegalStateException("Non transportable unit in sea");

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -91,7 +91,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsSea() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsSea();
+    return unit -> unit.getUnitAttachment().getIsSea();
   }
 
   public static Predicate<Unit> unitHasSubBattleAbilities() {
@@ -99,11 +99,11 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanEvade() {
-    return unit -> UnitAttachment.get(unit.getType()).getCanEvade();
+    return unit -> unit.getUnitAttachment().getCanEvade();
   }
 
   public static Predicate<Unit> unitIsFirstStrike() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsFirstStrike();
+    return unit -> unit.getUnitAttachment().getIsFirstStrike();
   }
 
   public static Predicate<Unit> unitIsFirstStrikeOnDefense(final GameProperties properties) {
@@ -125,20 +125,20 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanMoveThroughEnemies() {
-    return unit -> UnitAttachment.get(unit.getType()).getCanMoveThroughEnemies();
+    return unit -> unit.getUnitAttachment().getCanMoveThroughEnemies();
   }
 
   public static Predicate<Unit> unitCanBeMovedThroughByEnemies() {
-    return unit -> UnitAttachment.get(unit.getType()).getCanBeMovedThroughByEnemies();
+    return unit -> unit.getUnitAttachment().getCanBeMovedThroughByEnemies();
   }
 
   public static Predicate<Unit> unitCanNotBeTargetedByAll() {
-    return unit -> !UnitAttachment.get(unit.getType()).getCanNotBeTargetedBy().isEmpty();
+    return unit -> !unit.getUnitAttachment().getCanNotBeTargetedBy().isEmpty();
   }
 
   private static Predicate<Unit> unitIsCombatTransport() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getIsCombatTransport() && ua.getIsSea();
     };
   }
@@ -149,20 +149,20 @@ public final class Matches {
 
   public static Predicate<Unit> unitIsTransportButNotCombatTransport() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport();
     };
   }
 
   public static Predicate<Unit> unitIsNotTransportButCouldBeCombatTransport() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getTransportCapacity() == -1 || (ua.getIsCombatTransport() && ua.getIsSea());
     };
   }
 
   public static Predicate<Unit> unitIsDestroyer() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsDestroyer();
+    return unit -> unit.getUnitAttachment().getIsDestroyer();
   }
 
   public static Predicate<UnitType> unitTypeIsDestroyer() {
@@ -171,7 +171,7 @@ public final class Matches {
 
   public static Predicate<Unit> unitIsTransport() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getTransportCapacity() != -1 && ua.getIsSea();
     };
   }
@@ -182,7 +182,7 @@ public final class Matches {
 
   public static Predicate<Unit> unitIsTransportAndNotDestroyer() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return !unitIsDestroyer().test(unit) && ua.getTransportCapacity() != -1 && ua.getIsSea();
     };
   }
@@ -217,7 +217,7 @@ public final class Matches {
   // TODO: this should really be improved to check more properties like support attachments
   public static Predicate<Unit> unitCanAttack(final GamePlayer gamePlayer) {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getMovement(gamePlayer) > 0
           && (ua.getAttack(gamePlayer) > 0 || ua.getOffensiveAttackAa(gamePlayer) > 0);
     };
@@ -259,11 +259,11 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitHasAttackValueOfAtLeast(final int attackValue) {
-    return unit -> UnitAttachment.get(unit.getType()).getAttack(unit.getOwner()) >= attackValue;
+    return unit -> unit.getUnitAttachment().getAttack(unit.getOwner()) >= attackValue;
   }
 
   public static Predicate<Unit> unitHasDefendValueOfAtLeast(final int defendValue) {
-    return unit -> UnitAttachment.get(unit.getType()).getDefense(unit.getOwner()) >= defendValue;
+    return unit -> unit.getUnitAttachment().getDefense(unit.getOwner()) >= defendValue;
   }
 
   public static Predicate<Unit> unitIsEnemyOf(final GamePlayer player) {
@@ -271,7 +271,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsNotSea() {
-    return unit -> !UnitAttachment.get(unit.getType()).getIsSea();
+    return unit -> !unit.getUnitAttachment().getIsSea();
   }
 
   public static Predicate<UnitType> unitTypeIsSea() {
@@ -290,11 +290,11 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsAir() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsAir();
+    return unit -> unit.getUnitAttachment().getIsAir();
   }
 
   public static Predicate<Unit> unitIsNotAir() {
-    return unit -> !UnitAttachment.get(unit.getType()).getIsAir();
+    return unit -> !unit.getUnitAttachment().getIsAir();
   }
 
   public static Predicate<UnitType> unitTypeCanBombard(final GamePlayer gamePlayer) {
@@ -302,7 +302,7 @@ public final class Matches {
   }
 
   static Predicate<Unit> unitCanBeGivenByTerritoryTo(final GamePlayer player) {
-    return unit -> UnitAttachment.get(unit.getType()).getCanBeGivenByTerritoryTo().contains(player);
+    return unit -> unit.getUnitAttachment().getCanBeGivenByTerritoryTo().contains(player);
   }
 
   public static Predicate<Unit> unitCanBeCapturedOnEnteringThisTerritory(
@@ -312,7 +312,7 @@ public final class Matches {
         return false;
       }
       final GamePlayer unitOwner = unit.getOwner();
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       final boolean unitCanBeCapturedByPlayer = ua.getCanBeCapturedOnEnteringBy().contains(player);
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
       if (ta == null) {
@@ -338,7 +338,7 @@ public final class Matches {
 
   private static Predicate<Unit> unitDestroyedWhenCapturedBy(final GamePlayer playerBy) {
     return u -> {
-      final UnitAttachment ua = UnitAttachment.get(u.getType());
+      final UnitAttachment ua = u.getUnitAttachment();
       if (ua.getDestroyedWhenCapturedBy().isEmpty()) {
         return false;
       }
@@ -353,7 +353,7 @@ public final class Matches {
 
   private static Predicate<Unit> unitDestroyedWhenCapturedFrom() {
     return u -> {
-      final UnitAttachment ua = UnitAttachment.get(u.getType());
+      final UnitAttachment ua = u.getUnitAttachment();
       if (ua.getDestroyedWhenCapturedBy().isEmpty()) {
         return false;
       }
@@ -367,7 +367,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsAirBase() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsAirBase();
+    return unit -> unit.getUnitAttachment().getIsAirBase();
   }
 
   public static Predicate<UnitType> unitTypeCanBeDamaged() {
@@ -380,7 +380,7 @@ public final class Matches {
 
   public static Predicate<Unit> unitIsAtMaxDamageOrNotCanBeDamaged(final Territory t) {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       if (!ua.getCanBeDamaged()) {
         return true;
       }
@@ -394,7 +394,7 @@ public final class Matches {
 
   public static Predicate<Unit> unitIsLegalBombingTargetBy(final Unit bomberOrRocket) {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(bomberOrRocket.getType());
+      final UnitAttachment ua = bomberOrRocket.getUnitAttachment();
       final Set<UnitType> allowedTargets =
           ua.getBombingTargets(bomberOrRocket.getData().getUnitTypeList());
       return allowedTargets.contains(unit.getType());
@@ -418,7 +418,7 @@ public final class Matches {
           unit.getData().getProperties())) {
         return false;
       }
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       if (ua.getMaxOperationalDamage() < 0) {
         // factories may or may not have max operational damage set, so we must still determine here
         // assume that if maxOperationalDamage < 0, then the max damage must be based on the
@@ -439,7 +439,7 @@ public final class Matches {
 
   public static Predicate<Unit> unitCanDieFromReachingMaxDamage() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getCanBeDamaged() && ua.getCanDieFromReachingMaxDamage();
     };
   }
@@ -491,7 +491,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanScramble() {
-    return unit -> UnitAttachment.get(unit.getType()).getCanScramble();
+    return unit -> unit.getUnitAttachment().getCanScramble();
   }
 
   public static Predicate<Unit> unitWasScrambled() {
@@ -503,15 +503,15 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanBombard(final GamePlayer gamePlayer) {
-    return unit -> UnitAttachment.get(unit.getType()).getCanBombard(gamePlayer);
+    return unit -> unit.getUnitAttachment().getCanBombard(gamePlayer);
   }
 
   public static Predicate<Unit> unitCanBlitz() {
-    return unit -> UnitAttachment.get(unit.getType()).getCanBlitz(unit.getOwner());
+    return unit -> unit.getUnitAttachment().getCanBlitz(unit.getOwner());
   }
 
   public static Predicate<Unit> unitIsLandTransport() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsLandTransport();
+    return unit -> unit.getUnitAttachment().getIsLandTransport();
   }
 
   public static Predicate<Unit> unitIsLandTransportWithCapacity() {
@@ -525,7 +525,7 @@ public final class Matches {
   public static Predicate<Unit> unitIsNotInfrastructureAndNotCapturedOnEntering(
       final GamePlayer player, final Territory territory) {
     return unit ->
-        !UnitAttachment.get(unit.getType()).getIsInfrastructure()
+        !unit.getUnitAttachment().getIsInfrastructure()
             && !unitCanBeCapturedOnEnteringThisTerritory(player, territory).test(unit);
   }
 
@@ -538,19 +538,19 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsSuicideOnAttack() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsSuicideOnAttack();
+    return unit -> unit.getUnitAttachment().getIsSuicideOnAttack();
   }
 
   public static Predicate<Unit> unitIsSuicideOnDefense() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsSuicideOnDefense();
+    return unit -> unit.getUnitAttachment().getIsSuicideOnDefense();
   }
 
   public static Predicate<Unit> unitIsSuicideOnHit() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsSuicideOnHit();
+    return unit -> unit.getUnitAttachment().getIsSuicideOnHit();
   }
 
   public static Predicate<Unit> unitIsKamikaze() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsKamikaze();
+    return unit -> unit.getUnitAttachment().getIsKamikaze();
   }
 
   public static Predicate<UnitType> unitTypeIsAir() {
@@ -562,11 +562,11 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanLandOnCarrier() {
-    return unit -> UnitAttachment.get(unit.getType()).getCarrierCost() != -1;
+    return unit -> unit.getUnitAttachment().getCarrierCost() != -1;
   }
 
   public static Predicate<Unit> unitIsCarrier() {
-    return unit -> UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1;
+    return unit -> unit.getUnitAttachment().getCarrierCapacity() != -1;
   }
 
   public static Predicate<Territory> territoryHasOwnedCarrier(final GamePlayer player) {
@@ -575,12 +575,11 @@ public final class Matches {
 
   public static Predicate<Unit> unitIsAlliedCarrier(final GamePlayer player) {
     return unit ->
-        UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1
-            && player.isAllied(unit.getOwner());
+        unit.getUnitAttachment().getCarrierCapacity() != -1 && player.isAllied(unit.getOwner());
   }
 
   public static Predicate<Unit> unitCanBeTransported() {
-    return unit -> UnitAttachment.get(unit.getType()).getTransportCost() != -1;
+    return unit -> unit.getUnitAttachment().getTransportCost() != -1;
   }
 
   public static Predicate<Unit> unitWasAmphibious() {
@@ -608,7 +607,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanTransport() {
-    return unit -> UnitAttachment.get(unit.getType()).getTransportCapacity() != -1;
+    return unit -> unit.getUnitAttachment().getTransportCapacity() != -1;
   }
 
   public static Predicate<UnitType> unitTypeCanProduceUnits() {
@@ -632,11 +631,11 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitHasMovementLimit() {
-    return obj -> UnitAttachment.get(obj.getType()).getMovementLimit() != null;
+    return obj -> obj.getUnitAttachment().getMovementLimit() != null;
   }
 
   public static Predicate<Unit> unitHasAttackingLimit() {
-    return obj -> UnitAttachment.get(obj.getType()).getAttackingLimit() != null;
+    return obj -> obj.getUnitAttachment().getAttackingLimit() != null;
   }
 
   public static Predicate<UnitType> unitTypeCanNotMoveDuringCombatMove() {
@@ -659,7 +658,7 @@ public final class Matches {
       if (!typeOfAa.test(obj)) {
         return false;
       }
-      final UnitAttachment ua = UnitAttachment.get(obj.getType());
+      final UnitAttachment ua = obj.getUnitAttachment();
       final Set<UnitType> targetsAa = ua.getTargetsAa(obj.getData().getUnitTypeList());
       for (final Unit u : targets) {
         if (targetsAa.contains(u.getType())) {
@@ -692,17 +691,17 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsAaOfTypeAa(final String typeAa) {
-    return obj -> UnitAttachment.get(obj.getType()).getTypeAa().matches(typeAa);
+    return obj -> obj.getUnitAttachment().getTypeAa().matches(typeAa);
   }
 
   public static Predicate<Unit> unitAaShotDamageableInsteadOfKillingInstantly() {
-    return obj -> UnitAttachment.get(obj.getType()).getDamageableAa();
+    return obj -> obj.getUnitAttachment().getDamageableAa();
   }
 
   private static Predicate<Unit> unitIsAaThatWillNotFireIfPresentEnemyUnits(
       final Collection<Unit> enemyUnitsPresent) {
     return obj -> {
-      final UnitAttachment ua = UnitAttachment.get(obj.getType());
+      final UnitAttachment ua = obj.getUnitAttachment();
       for (final Unit u : enemyUnitsPresent) {
         if (ua.getWillNotFireIfPresent().contains(u.getType())) {
           return true;
@@ -802,20 +801,20 @@ public final class Matches {
 
   static Predicate<Unit> unitAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
     return obj -> {
-      final UnitAttachment ua = UnitAttachment.get(obj.getType());
+      final UnitAttachment ua = obj.getUnitAttachment();
       return ua.getAttackAa(obj.getOwner()) > 0 && ua.getMaxAaAttacks() != 0;
     };
   }
 
   static Predicate<Unit> unitOffensiveAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
     return obj -> {
-      final UnitAttachment ua = UnitAttachment.get(obj.getType());
+      final UnitAttachment ua = obj.getUnitAttachment();
       return ua.getOffensiveAttackAa(obj.getOwner()) > 0 && ua.getMaxAaAttacks() != 0;
     };
   }
 
   public static Predicate<Unit> unitIsLandTransportable() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsLandTransportable();
+    return unit -> unit.getUnitAttachment().getIsLandTransportable();
   }
 
   public static Predicate<Unit> unitIsNotLandTransportable() {
@@ -851,11 +850,11 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsArtillery() {
-    return obj -> UnitAttachment.get(obj.getType()).getArtillery();
+    return obj -> obj.getUnitAttachment().getArtillery();
   }
 
   public static Predicate<Unit> unitIsArtillerySupportable() {
-    return obj -> UnitAttachment.get(obj.getType()).getArtillerySupportable();
+    return obj -> obj.getUnitAttachment().getArtillerySupportable();
   }
 
   public static Predicate<Territory> territoryIsWater() {
@@ -1148,7 +1147,7 @@ public final class Matches {
   public static Predicate<Unit> unitHasEnoughMovementForRoute(final Route route) {
     return unit -> {
       BigDecimal left = unit.getMovementLeft();
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       if (ua.getIsAir()) {
         if (TerritoryAttachment.hasAirBase(route.getStart())) {
           left = left.add(BigDecimal.ONE);
@@ -1208,7 +1207,7 @@ public final class Matches {
 
   public static Predicate<Unit> unitIsLandAndOwnedBy(final GamePlayer player) {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return !ua.getIsSea() && !ua.getIsAir() && unit.isOwnedBy(player);
     };
   }
@@ -1531,7 +1530,7 @@ public final class Matches {
       if (unitIsDisabled().test(unit) || unitIsBeingTransported().test(unit)) {
         return false;
       }
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return !ua.getRepairsUnits().isEmpty();
     };
   }
@@ -1567,7 +1566,7 @@ public final class Matches {
           return false;
         }
       }
-      final UnitAttachment ua = UnitAttachment.get(unitCanRepair.getType());
+      final UnitAttachment ua = unitCanRepair.getUnitAttachment();
       return ua.getRepairsUnits().keySet().contains(damagedUnit.getType());
     };
   }
@@ -1628,7 +1627,7 @@ public final class Matches {
 
   private static Predicate<Unit> unitCanGiveBonusMovement() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return ua != null
           && !ua.getGivesMovement().isEmpty()
           && unitIsBeingTransported().negate().test(unit);
@@ -1676,14 +1675,14 @@ public final class Matches {
 
   static Predicate<Unit> unitCreatesUnits() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return !ua.getCreatesUnitsList().isEmpty();
     };
   }
 
   static Predicate<Unit> unitCreatesResources() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return !ua.getCreatesResourcesList().isEmpty();
     };
   }
@@ -1697,7 +1696,7 @@ public final class Matches {
 
   public static Predicate<Unit> unitConsumesUnitsOnCreation() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return !ua.getConsumesUnits().isEmpty();
     };
   }
@@ -1708,7 +1707,7 @@ public final class Matches {
       if (!unitConsumesUnitsOnCreation().test(unitWhichRequiresUnits)) {
         return true;
       }
-      final UnitAttachment ua = UnitAttachment.get(unitWhichRequiresUnits.getType());
+      final UnitAttachment ua = unitWhichRequiresUnits.getUnitAttachment();
       final IntegerMap<UnitType> requiredUnitsMap = ua.getConsumesUnits();
       final Collection<UnitType> requiredUnits = requiredUnitsMap.keySet();
       boolean canBuild = true;
@@ -1739,7 +1738,7 @@ public final class Matches {
 
   public static Predicate<Unit> unitRequiresUnitsOnCreation() {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return !ua.getRequiresUnits().isEmpty();
     };
   }
@@ -1759,7 +1758,7 @@ public final class Matches {
       unitsInTerritoryAtStartOfTurn.retainAll(
           CollectionUtils.getMatches(unitsInTerritoryAtStartOfTurn, unitIsOwnedByAndNotDisabled));
       boolean canBuild = false;
-      final UnitAttachment ua = UnitAttachment.get(unitWhichRequiresUnits.getType());
+      final UnitAttachment ua = unitWhichRequiresUnits.getUnitAttachment();
       final List<String[]> unitComboPossibilities = ua.getRequiresUnits();
       for (final String[] combo : unitComboPossibilities) {
         if (combo != null) {
@@ -1788,7 +1787,7 @@ public final class Matches {
   /** Check if unit meets requiredUnitsToMove criteria and can move into territory. */
   public static Predicate<Unit> unitHasRequiredUnitsToMove(final Territory t) {
     return unit -> {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       if (ua.getRequiresUnitsToMove().isEmpty()) {
         return true;
       }
@@ -1861,7 +1860,7 @@ public final class Matches {
         // Unit isn't transported so can Invade
         return true;
       }
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return ua.canInvadeFrom(transport);
     };
   }
@@ -1972,13 +1971,13 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanReceiveAbilityWhenWith() {
-    return unit -> !UnitAttachment.get(unit.getType()).getReceivesAbilityWhenWith().isEmpty();
+    return unit -> !unit.getUnitAttachment().getReceivesAbilityWhenWith().isEmpty();
   }
 
   public static Predicate<Unit> unitCanReceiveAbilityWhenWith(
       final String filterForAbility, final String filterForUnitType) {
     return u -> {
-      for (final String receives : UnitAttachment.get(u.getType()).getReceivesAbilityWhenWith()) {
+      for (final String receives : u.getUnitAttachment().getReceivesAbilityWhenWith()) {
         final String[] s = receives.split(":", 2);
         if (s[0].equals(filterForAbility) && s[1].equals(filterForUnitType)) {
           return true;
@@ -1989,7 +1988,7 @@ public final class Matches {
   }
 
   private static Predicate<Unit> unitHasWhenCombatDamagedEffect() {
-    return u -> !UnitAttachment.get(u.getType()).getWhenCombatDamaged().isEmpty();
+    return u -> !u.getUnitAttachment().getWhenCombatDamaged().isEmpty();
   }
 
   public static Predicate<Unit> unitHasWhenCombatDamagedEffect(final String filterForEffect) {
@@ -1998,7 +1997,7 @@ public final class Matches {
             unit -> {
               final int currentDamage = unit.getHits();
               final List<UnitAttachment.WhenCombatDamaged> whenCombatDamagedList =
-                  UnitAttachment.get(unit.getType()).getWhenCombatDamaged();
+                  unit.getUnitAttachment().getWhenCombatDamaged();
               for (final UnitAttachment.WhenCombatDamaged key : whenCombatDamagedList) {
                 if (!key.getEffect().equals(filterForEffect)) {
                   continue;
@@ -2021,26 +2020,26 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitWhenHitPointsDamagedChangesInto() {
-    return u -> !UnitAttachment.get(u.getType()).getWhenHitPointsDamagedChangesInto().isEmpty();
+    return u -> !u.getUnitAttachment().getWhenHitPointsDamagedChangesInto().isEmpty();
   }
 
   public static Predicate<Unit> unitAtMaxHitPointDamageChangesInto() {
     return u -> {
-      final UnitAttachment ua = UnitAttachment.get(u.getType());
+      final UnitAttachment ua = u.getUnitAttachment();
       return ua.getWhenHitPointsDamagedChangesInto().containsKey(ua.getHitPoints());
     };
   }
 
   static Predicate<Unit> unitWhenHitPointsRepairedChangesInto() {
-    return u -> !UnitAttachment.get(u.getType()).getWhenHitPointsRepairedChangesInto().isEmpty();
+    return u -> !u.getUnitAttachment().getWhenHitPointsRepairedChangesInto().isEmpty();
   }
 
   public static Predicate<Unit> unitWhenCapturedChangesIntoDifferentUnitType() {
-    return u -> !UnitAttachment.get(u.getType()).getWhenCapturedChangesInto().isEmpty();
+    return u -> !u.getUnitAttachment().getWhenCapturedChangesInto().isEmpty();
   }
 
   public static Predicate<Unit> unitWhenCapturedSustainsDamage() {
-    return u -> UnitAttachment.get(u.getType()).getWhenCapturedSustainsDamage() > 0;
+    return u -> u.getUnitAttachment().getWhenCapturedSustainsDamage() > 0;
   }
 
   public static <T extends AbstractUserActionAttachment>
@@ -2051,7 +2050,7 @@ public final class Matches {
 
   static Predicate<Unit> unitCanOnlyPlaceInOriginalTerritories() {
     return u -> {
-      final UnitAttachment ua = UnitAttachment.get(u.getType());
+      final UnitAttachment ua = u.getUnitAttachment();
       return ua.getSpecial().contains("canOnlyPlaceInOriginalTerritories");
     };
   }
@@ -2171,24 +2170,23 @@ public final class Matches {
 
   // TODO: update scrambling to consider movement cost
   public static Predicate<Unit> unitCanScrambleOnRouteDistance(final Route route) {
-    return unit ->
-        UnitAttachment.get(unit.getType()).getMaxScrambleDistance() >= route.numberOfSteps();
+    return unit -> unit.getUnitAttachment().getMaxScrambleDistance() >= route.numberOfSteps();
   }
 
   public static Predicate<Unit> unitCanIntercept() {
-    return u -> UnitAttachment.get(u.getType()).getCanIntercept();
+    return u -> u.getUnitAttachment().getCanIntercept();
   }
 
   public static Predicate<Unit> unitRequiresAirBaseToIntercept() {
-    return u -> UnitAttachment.get(u.getType()).getRequiresAirBaseToIntercept();
+    return u -> u.getUnitAttachment().getRequiresAirBaseToIntercept();
   }
 
   static Predicate<Unit> unitCanEscort() {
-    return u -> UnitAttachment.get(u.getType()).getCanEscort();
+    return u -> u.getUnitAttachment().getCanEscort();
   }
 
   public static Predicate<Unit> unitCanAirBattle() {
-    return u -> UnitAttachment.get(u.getType()).getCanAirBattle();
+    return u -> u.getUnitAttachment().getCanAirBattle();
   }
 
   public static Predicate<Territory> territoryOwnerRelationshipTypeCanMoveIntoDuringCombatMove(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -420,14 +420,13 @@ public class MoveDelegate extends AbstractMoveDelegate {
         }
         for (final Unit bonusGiver : givesBonusUnits) {
           final int tempBonus =
-              UnitAttachment.get(bonusGiver.getType()).getGivesMovement().getInt(u.getType());
+              bonusGiver.getUnitAttachment().getGivesMovement().getInt(u.getType());
           if (tempBonus > bonusMovement) {
             bonusMovement = tempBonus;
           }
         }
         if (bonusMovement != Integer.MIN_VALUE && bonusMovement != 0) {
-          bonusMovement =
-              Math.max(bonusMovement, (UnitAttachment.get(u.getType()).getMovement(player) * -1));
+          bonusMovement = Math.max(bonusMovement, (u.getUnitAttachment().getMovement(player) * -1));
           change.add(ChangeFactory.unitPropertyChange(u, bonusMovement, Unit.BONUS_MOVEMENT));
         }
       }
@@ -532,7 +531,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final List<Unit> unitsToAdd = new ArrayList<>();
     for (final Unit unit : changesIntoUnits) {
       final Map<Integer, Tuple<Boolean, UnitType>> map =
-          UnitAttachment.get(unit.getType()).getWhenHitPointsRepairedChangesInto();
+          unit.getUnitAttachment().getWhenHitPointsRepairedChangesInto();
       if (map.containsKey(unit.getHits())) {
         final boolean translateAttributes = map.get(unit.getHits()).getFirst();
         final UnitType unitType = map.get(unit.getHits()).getSecond();
@@ -598,8 +597,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
     int largest = 0;
     for (final Unit u : repairUnitsForThisUnit) {
-      final int repair =
-          UnitAttachment.get(u.getType()).getRepairsUnits().getInt(unitToBeRepaired.getType());
+      final int repair = u.getUnitAttachment().getRepairsUnits().getInt(unitToBeRepaired.getType());
       if (largest < repair) {
         largest = repair;
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -335,7 +335,7 @@ public class MovePerformer implements Serializable {
     final Territory routeEnd = route.getEnd();
     for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitIsOwnedBy(gamePlayer))) {
       BigDecimal moved = route.getMovementCost(unit);
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       if (ua.getIsAir()) {
         if (TerritoryAttachment.hasAirBase(routeStart)
             && relationshipTracker.isAllied(routeStart.getOwner(), unit.getOwner())) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -140,7 +140,7 @@ public class RocketsFireHelper implements Serializable {
           // Not sure if that comment is still current
           for (final Unit r : rocketTargets) {
             legalTargetsForTheseRockets.addAll(
-                UnitAttachment.get(r.getType()).getBombingTargets(data.getUnitTypeList()));
+                r.getUnitAttachment().getBombingTargets(data.getUnitTypeList()));
           }
           final Collection<Unit> enemyTargets =
               CollectionUtils.getMatches(
@@ -323,7 +323,7 @@ public class RocketsFireHelper implements Serializable {
         int highestBonus = 0;
         final int diceSides = data.getDiceSides();
         for (final Unit u : rockets) {
-          final UnitAttachment ua = UnitAttachment.get(u.getType());
+          final UnitAttachment ua = u.getUnitAttachment();
           int maxDice = ua.getBombingMaxDieSides();
           final int bonus = ua.getBombingBonus();
           // both could be -1, meaning they were not set. if they were not set, then we use default
@@ -393,7 +393,7 @@ public class RocketsFireHelper implements Serializable {
         int highestBonus = 0;
         final int diceSides = data.getDiceSides();
         for (final Unit rocket : rockets) {
-          final UnitAttachment ua = UnitAttachment.get(rocket.getType());
+          final UnitAttachment ua = rocket.getUnitAttachment();
           int maxDice = ua.getBombingMaxDieSides();
           int bonus = ua.getBombingBonus();
           // both could be -1, meaning they were not set. if they were not set, then we use default

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -38,7 +38,7 @@ public class TransportTracker {
   }
 
   private static void assertTransport(final Unit u) {
-    if (UnitAttachment.get(u.getType()).getTransportCapacity() == -1) {
+    if (u.getUnitAttachment().getTransportCapacity() == -1) {
       throw new IllegalStateException("Not a transport:" + u);
     }
   }
@@ -188,7 +188,7 @@ public class TransportTracker {
 
   /** Given a unit, computes the transport capacity value available for that unit. */
   public static int getAvailableCapacity(final Unit unit) {
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    final UnitAttachment ua = unit.getUnitAttachment();
     // Check if there are transports available, also check for destroyer capacity (Tokyo Express)
     if (ua.getTransportCapacity() == -1
         || (unit.getData().getProperties().get(Constants.PACIFIC_THEATER, false)
@@ -296,7 +296,7 @@ public class TransportTracker {
     MoveValidator.carrierMustMoveWith(units, units, player)
         .forEach(
             (carrier, dependencies) -> {
-              final UnitAttachment ua = UnitAttachment.get(carrier.getType());
+              final UnitAttachment ua = carrier.getUnitAttachment();
               if (ua.getCarrierCapacity() == -1) {
                 return;
               }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -584,7 +584,7 @@ public class AirBattle extends AbstractBattle {
     for (final Unit base :
         t.getUnitCollection()
             .getMatches(Matches.unitIsAirBase().and(Matches.unitIsNotDisabled()))) {
-      final int baseMax = UnitAttachment.get(base.getType()).getMaxInterceptCount();
+      final int baseMax = base.getUnitAttachment().getMaxInterceptCount();
       if (baseMax == -1) {
         return Integer.MAX_VALUE;
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -1000,7 +1000,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> airbases = t.getUnitCollection().getMatches(Matches.unitIsAirBase());
       for (final Unit airbase : airbases) {
-        final UnitAttachment ua = UnitAttachment.get(airbase.getType());
+        final UnitAttachment ua = airbase.getUnitAttachment();
         final int currentMax = airbase.getMaxScrambleCount();
         final int allowedMax = ua.getMaxScrambleCount();
         if (currentMax != allowedMax) {
@@ -1447,7 +1447,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final String dice = " scoring " + hits + " hits.  Rolls: " + MyFormatter.asDice(rolls);
     bridge.getHistoryWriter().startEvent(title + dice, unitUnderFire);
     if (hits > 0) {
-      final UnitAttachment ua = UnitAttachment.get(unitUnderFire.getType());
+      final UnitAttachment ua = unitUnderFire.getUnitAttachment();
       final int currentHits = unitUnderFire.getHits();
       if (ua.getHitPoints() <= currentHits + hits) {
         HistoryChangeFactory.removeUnitsFromTerritory(location, List.of(unitUnderFire))
@@ -1493,7 +1493,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final int carrierCostForCurrentTerr) {
     Preconditions.checkNotNull(strandedAir);
 
-    final int maxDistance = UnitAttachment.get(strandedAir.getType()).getMaxScrambleDistance();
+    final int maxDistance = strandedAir.getUnitAttachment().getMaxScrambleDistance();
     if (maxDistance <= 0) {
       return List.of(currentTerr);
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -23,7 +23,6 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.UnitUtils;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.OriginalOwnerTracker;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -888,7 +887,7 @@ public class BattleTracker implements Serializable {
               nonCom, Matches.unitWhenCapturedChangesIntoDifferentUnitType());
       for (final Unit u : toReplace) {
         final Map<String, Tuple<String, IntegerMap<UnitType>>> map =
-            UnitAttachment.get(u.getType()).getWhenCapturedChangesInto();
+            u.getUnitAttachment().getWhenCapturedChangesInto();
         final GamePlayer currentOwner = u.getOwner();
         for (final String value : map.keySet()) {
           final String[] s = Iterables.toArray(Splitter.on(':').split(value), String.class);
@@ -939,8 +938,7 @@ public class BattleTracker implements Serializable {
       for (final Unit unit :
           CollectionUtils.getMatches(nonCom, Matches.unitWhenCapturedSustainsDamage())) {
         final int damageLimit = unit.getHowMuchMoreDamageCanThisUnitTake(territory);
-        final int sustainedDamage =
-            UnitAttachment.get(unit.getType()).getWhenCapturedSustainsDamage();
+        final int sustainedDamage = unit.getUnitAttachment().getWhenCapturedSustainsDamage();
         final int actualDamage = Math.max(0, Math.min(sustainedDamage, damageLimit));
         final int totalDamage = unit.getUnitDamage() + actualDamage;
         damageMap.put(unit, totalDamage);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
@@ -10,7 +10,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.IExecutable;
@@ -109,7 +108,8 @@ public class FireAa implements IExecutable {
       final List<Collection<Unit>> firingGroups = newFiringUnitGroups(aaTypeUnits);
       for (final Collection<Unit> firingGroup : firingGroups) {
         final Set<UnitType> validTargetTypes =
-            UnitAttachment.get(CollectionUtils.getAny(firingGroup).getType())
+            CollectionUtils.getAny(firingGroup)
+                .getUnitAttachment()
                 .getTargetsAa(bridge.getData().getUnitTypeList());
 
         final Set<UnitType> airborneTypesTargeted =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -29,7 +29,6 @@ import games.strategy.engine.history.change.units.RemoveUnitsHistoryChange;
 import games.strategy.engine.history.change.units.TransformDamagedUnitsHistoryChange;
 import games.strategy.engine.player.Player;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.IExecutable;
 import games.strategy.triplea.delegate.Matches;
@@ -1492,7 +1491,7 @@ public class MustFightBattle extends DependentBattle
         defendingAir.remove(currentUnit);
         continue;
       }
-      carrierCost += UnitAttachment.get(currentUnit.getType()).getCarrierCost();
+      carrierCost += currentUnit.getUnitAttachment().getCarrierCost();
       if (carrierCapacity >= carrierCost) {
         defendingAir.remove(currentUnit);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -455,7 +455,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         final Collection<Unit> currentPossibleAa =
             CollectionUtils.getMatches(defendingAa, Matches.unitIsAaOfTypeAa(currentTypeAa));
         final Set<UnitType> targetUnitTypesForThisTypeAa =
-            UnitAttachment.get(CollectionUtils.getAny(currentPossibleAa).getType())
+            CollectionUtils.getAny(currentPossibleAa)
+                .getUnitAttachment()
                 .getTargetsAa(gameData.getUnitTypeList());
 
         final Set<UnitType> airborneTypesTargetedToo =
@@ -733,7 +734,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
               if (rolls < 1) {
                 continue;
               }
-              final UnitAttachment ua = UnitAttachment.get(u.getType());
+              final UnitAttachment ua = u.getUnitAttachment();
               int maxDice = ua.getBombingMaxDieSides();
               final int bonus = ua.getBombingBonus();
               // both could be -1, meaning they were not set. if they were not set, then we use
@@ -770,7 +771,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             if (rolls < 1) {
               continue;
             }
-            final UnitAttachment ua = UnitAttachment.get(u.getType());
+            final UnitAttachment ua = u.getUnitAttachment();
             int maxDice = ua.getBombingMaxDieSides();
             int bonus = ua.getBombingBonus();
             // both could be -1, meaning they were not set. if they were not set, then we use
@@ -842,7 +843,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       final Map<Unit, List<Die>> targetToDiceMap = new HashMap<>();
       // limit to maxDamage
       for (final Unit attacker : attackingUnits) {
-        final UnitAttachment ua = UnitAttachment.get(attacker.getType());
+        final UnitAttachment ua = attacker.getUnitAttachment();
         final int rolls = getSbrRolls(attacker, StrategicBombingRaidBattle.this.attacker);
         int costThisUnit = 0;
         if (rolls > 1 && (lhtrBombers || ua.getChooseBestRoll())) {
@@ -1011,7 +1012,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
 
   @VisibleForTesting
   public static int getSbrRolls(final Unit unit, final GamePlayer gamePlayer) {
-    return UnitAttachment.get(unit.getType()).getAttackRolls(gamePlayer);
+    return unit.getUnitAttachment().getAttackRolls(gamePlayer);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
@@ -62,8 +62,8 @@ public class UnitBattleComparator implements Comparator<Unit> {
     }
     final boolean transporting1 = TransportTracker.isTransporting(u1);
     final boolean transporting2 = TransportTracker.isTransporting(u2);
-    final UnitAttachment ua1 = UnitAttachment.get(u1.getType());
-    final UnitAttachment ua2 = UnitAttachment.get(u2.getType());
+    final UnitAttachment ua1 = u1.getUnitAttachment();
+    final UnitAttachment ua2 = u2.getUnitAttachment();
     if (ua1.equals(ua2)
         && u1.isOwnedBy(u2.getOwner())
         && u1.getWasAmphibious() == u2.getWasAmphibious()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Die.DieType;
@@ -95,8 +94,8 @@ public class AaCasualtySelector {
     for (final Unit target : targets) {
       final int hpLeft =
           allowMultipleHitsPerUnit
-              ? (UnitAttachment.get(target.getType()).getHitPoints() - target.getHits())
-              : Math.min(1, UnitAttachment.get(target.getType()).getHitPoints() - target.getHits());
+              ? (target.getUnitAttachment().getHitPoints() - target.getHits())
+              : Math.min(1, target.getUnitAttachment().getHitPoints() - target.getHits());
       for (int hp = 0; hp < hpLeft; ++hp) {
         // if allowMultipleHitsPerUnit, then the target needs to be added for each hp
         targetsList.add(target);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -247,13 +247,13 @@ class CasualtyOrderOfLosses {
     boolean isAmphibious;
 
     static AmphibType of(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       // only track amphibious if both marine and was amphibious
       return new AmphibType(unit.getType(), ua.getIsMarine() != 0 && unit.getWasAmphibious());
     }
 
     boolean matches(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return type.equals(unit.getType())
           && (ua.getIsMarine() == 0 || isAmphibious == unit.getWasAmphibious());
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -172,7 +172,7 @@ public class CasualtySelector {
       damaged.clear();
     } else {
       for (final Unit unit : killed) {
-        final UnitAttachment ua = UnitAttachment.get(unit.getType());
+        final UnitAttachment ua = unit.getUnitAttachment();
         final int damageToUnit = Collections.frequency(damaged, unit);
         // allowed damage
         numhits += Math.max(0, Math.min(damageToUnit, (ua.getHitPoints() - (1 + unit.getHits()))));
@@ -258,7 +258,7 @@ public class CasualtySelector {
         if (numSelectedCasualties >= hits) {
           return Tuple.of(defaultCasualtySelection, sorted);
         }
-        final UnitAttachment ua = UnitAttachment.get(unit.getType());
+        final UnitAttachment ua = unit.getUnitAttachment();
         final int extraHitPoints =
             Math.min((hits - numSelectedCasualties), (ua.getHitPoints() - (1 + unit.getHits())));
         for (int i = 0; i < extraHitPoints; i++) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySortingUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySortingUtil.java
@@ -25,8 +25,8 @@ public class CasualtySortingUtil {
         return result;
       }
 
-      final UnitAttachment ua1 = UnitAttachment.get(u1.getType());
-      final UnitAttachment ua2 = UnitAttachment.get(u2.getType());
+      final UnitAttachment ua1 = u1.getUnitAttachment();
+      final UnitAttachment ua2 = u2.getUnitAttachment();
       return Integer.compare(ua1.getIsMarine(), ua2.getIsMarine());
     };
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyUtil.java
@@ -17,7 +17,7 @@ public class CasualtyUtil {
     }
     int totalHitPoints = 0;
     for (final Unit u : units) {
-      final UnitAttachment ua = UnitAttachment.get(u.getType());
+      final UnitAttachment ua = u.getUnitAttachment();
       if (!ua.getIsInfrastructure()) {
         totalHitPoints += ua.getHitPoints();
         totalHitPoints -= u.getHits();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
@@ -7,7 +7,6 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
@@ -115,7 +114,7 @@ public class SelectMainBattleCasualties
   private static int getMaxHits(final Collection<Unit> units) {
     int count = 0;
     for (final Unit unit : units) {
-      count += UnitAttachment.get(unit.getType()).getHitPoints();
+      count += unit.getUnitAttachment().getHitPoints();
       count -= unit.getHits();
     }
     return count;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
@@ -79,7 +79,8 @@ public class FiringGroupSplitterAa
 
       // grab the unit types that this typeAa can fire at
       final Set<UnitType> validTargetTypes =
-          UnitAttachment.get(CollectionUtils.getAny(firingUnits).getType())
+          CollectionUtils.getAny(firingUnits)
+              .getUnitAttachment()
               .getTargetsAa(battleState.getGameData().getUnitTypeList());
 
       final Collection<Unit> targetUnits =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/dice/RollDiceFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/dice/RollDiceFactory.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.random.IRandomStats;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Die;
 import games.strategy.triplea.delegate.dice.calculator.LowLuckDice;
@@ -36,7 +35,7 @@ public class RollDiceFactory {
       final Territory battleSite,
       final CombatValue combatValueCalculator) {
 
-    final String typeAa = UnitAttachment.get(CollectionUtils.getAny(aaUnits).getType()).getTypeAa();
+    final String typeAa = CollectionUtils.getAny(aaUnits).getUnitAttachment().getTypeAa();
     final GamePlayer player = CollectionUtils.getAny(aaUnits).getOwner();
     final String annotation =
         player.getName() + " roll " + typeAa + " dice in " + battleSite.getName();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
@@ -781,36 +781,32 @@ public final class AirMovementValidator {
    * accounts for damaged carriers with special properties and restrictions.
    */
   public static int carrierCapacity(final Unit unit, final Territory territoryUnitsAreCurrentlyIn) {
-    if (Matches.unitIsCarrier().test(unit)) {
-      // here we check to see if the unit can no longer carry units
-      if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITS_MAY_NOT_LAND_ON_CARRIER)
-          .test(unit)) {
-        // and we must check to make sure we let any allied air that are cargo stay here
-        if (Matches.unitHasWhenCombatDamagedEffect(
-                UnitAttachment.UNITS_MAY_NOT_LEAVE_ALLIED_CARRIER)
-            .test(unit)) {
-          int cargo = 0;
-          final Collection<Unit> airCargo =
-              territoryUnitsAreCurrentlyIn
-                  .getUnitCollection()
-                  .getMatches(Matches.unitIsAir().and(Matches.unitCanLandOnCarrier()));
-          for (final Unit airUnit : airCargo) {
-            if (airUnit.getTransportedBy() != null && airUnit.getTransportedBy().equals(unit)) {
-              // capacity = are cargo only
-              cargo += airUnit.getUnitAttachment().getCarrierCost();
-            }
-          }
-          return cargo;
-        }
-
-        // capacity = zero 0
-        return 0;
-      }
-
-      final UnitAttachment ua = unit.getUnitAttachment();
-      return ua.getCarrierCapacity();
+    if (!Matches.unitIsCarrier().test(unit)) {
+      return 0;
     }
-    return 0;
+    // here we check to see if the unit can no longer carry units
+    if (!Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITS_MAY_NOT_LAND_ON_CARRIER)
+        .test(unit)) {
+      return unit.getUnitAttachment().getCarrierCapacity();
+    }
+    // and we must check to make sure we let any allied air that are cargo stay here
+    if (!Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITS_MAY_NOT_LEAVE_ALLIED_CARRIER)
+        .test(unit)) {
+      // capacity = zero 0
+      return 0;
+    }
+    int cargo = 0;
+    final Collection<Unit> airCargo =
+        territoryUnitsAreCurrentlyIn
+            .getUnitCollection()
+            .getMatches(Matches.unitIsAir().and(Matches.unitCanLandOnCarrier()));
+    for (final Unit airUnit : airCargo) {
+      if (airUnit.getTransportedBy() != null && airUnit.getTransportedBy().equals(unit)) {
+        // capacity = are cargo only
+        cargo += airUnit.getUnitAttachment().getCarrierCost();
+      }
+    }
+    return cargo;
   }
 
   public static int carrierCost(final Collection<Unit> units) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
@@ -797,7 +797,7 @@ public final class AirMovementValidator {
           for (final Unit airUnit : airCargo) {
             if (airUnit.getTransportedBy() != null && airUnit.getTransportedBy().equals(unit)) {
               // capacity = are cargo only
-              cargo += UnitAttachment.get(airUnit.getType()).getCarrierCost();
+              cargo += airUnit.getUnitAttachment().getCarrierCost();
             }
           }
           return cargo;
@@ -807,7 +807,7 @@ public final class AirMovementValidator {
         return 0;
       }
 
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getCarrierCapacity();
     }
     return 0;
@@ -823,7 +823,7 @@ public final class AirMovementValidator {
 
   public static int carrierCost(final Unit unit) {
     if (Matches.unitCanLandOnCarrier().test(unit)) {
-      return UnitAttachment.get(unit.getType()).getCarrierCost();
+      return unit.getUnitAttachment().getCarrierCost();
     }
     return 0;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -743,7 +743,7 @@ public class MoveValidator {
       for (final Unit unit :
           CollectionUtils.getMatches(
               unitsWithoutDependents, Matches.unitIsOwnedBy(player).negate())) {
-        if (!(UnitAttachment.get(unit.getType()).getCarrierCost() > 0
+        if (!(unit.getUnitAttachment().getCarrierCost() > 0
             && data.getRelationshipTracker().isAllied(player, unit.getOwner()))) {
           result.addDisallowedUnit("Can only move own troops", unit);
         }
@@ -905,7 +905,7 @@ public class MoveValidator {
             unitOk = true;
           } else {
             for (final Unit transport : landTransportsWithCapacity.keySet()) {
-              final int cost = UnitAttachment.get(unit.getType()).getTransportCost();
+              final int cost = unit.getUnitAttachment().getTransportCost();
               if (cost <= landTransportsWithCapacity.getInt(transport)) {
                 landTransportsWithCapacity.add(transport, -cost);
                 unitOk = true;
@@ -939,7 +939,7 @@ public class MoveValidator {
       final Predicate<Unit> transportLand =
           Matches.unitIsLandTransportWithCapacity().and(Matches.unitIsOwnedBy(player));
       for (final Unit unit : CollectionUtils.getMatches(units, transportLand)) {
-        map.put(unit, UnitAttachment.get(unit.getType()).getTransportCapacity());
+        map.put(unit, unit.getUnitAttachment().getTransportCapacity());
       }
     }
     return map;
@@ -1087,7 +1087,7 @@ public class MoveValidator {
   private static Collection<Unit> getUnitsThatCantGoOnWater(final Collection<Unit> units) {
     final Collection<Unit> retUnits = new ArrayList<>();
     for (final Unit unit : units) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       if (!ua.getIsSea() && !ua.getIsAir() && ua.getTransportCost() == -1) {
         retUnits.add(unit);
       }
@@ -1287,7 +1287,7 @@ public class MoveValidator {
     if (route.getEnd().isWater() && route.getStart().isWater()) {
       // make sure units and transports stick together
       for (final Unit unit : units) {
-        final UnitAttachment ua = UnitAttachment.get(unit.getType());
+        final UnitAttachment ua = unit.getUnitAttachment();
         // make sure transports dont leave their units behind
         if (ua.getTransportCapacity() != -1) {
           final Collection<Unit> holding = unit.getTransporting();
@@ -1339,7 +1339,7 @@ public class MoveValidator {
             for (final Unit transportToLoad : unitsToTransports.values()) {
               if (!TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(
                   transportToLoad, route.getEnd())) {
-                final UnitAttachment ua = UnitAttachment.get(baseUnit.getType());
+                final UnitAttachment ua = baseUnit.getUnitAttachment();
                 if (TransportTracker.getAvailableCapacity(transportToLoad)
                     >= ua.getTransportCost()) {
                   alreadyUnloadedTo = null;
@@ -1364,7 +1364,7 @@ public class MoveValidator {
             if (unitsToTransports.containsKey(unit)) {
               continue;
             }
-            final UnitAttachment ua = UnitAttachment.get(unit.getType());
+            final UnitAttachment ua = unit.getUnitAttachment();
             if (ua.getTransportCost() != -1) {
               result.addDisallowedUnit("Not enough transports", unit);
             }
@@ -1373,7 +1373,7 @@ public class MoveValidator {
           // set all units as unresolved if there is at least one transport and mixed unit
           // categories
           for (final Unit unit : land) {
-            final UnitAttachment ua = UnitAttachment.get(unit.getType());
+            final UnitAttachment ua = unit.getUnitAttachment();
             if (ua.getTransportCost() != -1) {
               result.addUnresolvedUnit("Not enough transports", unit);
             }
@@ -1667,11 +1667,11 @@ public class MoveValidator {
       final Unit carrier,
       final Collection<Unit> selectFrom,
       final GamePlayer playerWhoIsDoingTheMovement) {
-    final UnitAttachment ua = UnitAttachment.get(carrier.getType());
+    final UnitAttachment ua = carrier.getUnitAttachment();
     final Collection<Unit> canCarry = new ArrayList<>();
     int available = ua.getCarrierCapacity();
     for (final Unit plane : selectFrom) {
-      final UnitAttachment planeAttachment = UnitAttachment.get(plane.getType());
+      final UnitAttachment planeAttachment = plane.getUnitAttachment();
       final int cost = planeAttachment.getCarrierCost();
       if (available >= cost) {
         // this is to test if they started in the same sea zone or not, and its not a very good way

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
@@ -4,7 +4,6 @@ import static games.strategy.triplea.image.UnitImageFactory.ImageKey;
 
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.TooltipProperties;
 import games.strategy.triplea.ui.UiContext;
@@ -93,7 +92,7 @@ public class UnitPanel extends JPanel {
       if (category.getDisabled() && Matches.unitTypeCanBeDamaged().test(category.getType())) {
         // add 1 because it is the max operational damage and we want to disable it
         final int unitDamage =
-            Math.max(0, 1 + UnitAttachment.get(category.getType()).getMaxOperationalDamage());
+            Math.max(0, 1 + category.getUnitAttachment().getMaxOperationalDamage());
         for (final Unit unit : units) {
           unit.setUnitDamage(unitDamage);
         }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -14,7 +14,6 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.TechTracker;
@@ -727,7 +726,7 @@ class EditPanel extends ActionPanel {
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();
             for (final Unit u : units) {
               currentDamageMap.put(
-                  u, Triple.of(UnitAttachment.get(u.getType()).getHitPoints() - 1, 0, u.getHits()));
+                  u, Triple.of(u.getUnitAttachment().getHitPoints() - 1, 0, u.getHits()));
             }
             final IndividualUnitPanel unitPanel =
                 new IndividualUnitPanel(
@@ -989,7 +988,7 @@ class EditPanel extends ActionPanel {
 
   private static Comparator<Unit> getRemovableUnitsOrder() {
     return (u1, u2) -> {
-      if (UnitAttachment.get(u1.getType()).getTransportCapacity() != -1) {
+      if (u1.getUnitAttachment().getTransportCapacity() != -1) {
         // Sort by decreasing transport capacity
         return Comparator.<Unit, Collection<Unit>>comparing(
                 Unit::getTransporting,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -10,7 +10,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate.MoveType;
 import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
@@ -332,7 +331,7 @@ public class MovePanel extends AbstractMovePanel {
           int minTransportCost = Integer.MAX_VALUE;
           for (final Unit unit : capableUnitsToLoad) {
             minTransportCost =
-                Math.min(minTransportCost, UnitAttachment.get(unit.getType()).getTransportCost());
+                Math.min(minTransportCost, unit.getUnitAttachment().getTransportCost());
           }
           final Collection<Unit> airTransportsToLoad = new ArrayList<>();
           for (final Unit bomber : capableTransportsToLoad) {
@@ -1126,8 +1125,7 @@ public class MovePanel extends AbstractMovePanel {
         MoveValidator.getMustMoveWith(route.getEnd(), dependentUnits, unitOwner);
     int minTransportCost = defaultMinTransportCost;
     for (final Unit unit : unitsToLoad) {
-      minTransportCost =
-          Math.min(minTransportCost, UnitAttachment.get(unit.getType()).getTransportCost());
+      minTransportCost = Math.min(minTransportCost, unit.getUnitAttachment().getTransportCost());
     }
     final Predicate<Unit> candidateTransportsMatch =
         Matches.unitIsTransport().and(Matches.alliedUnit(unitOwner));
@@ -1187,7 +1185,7 @@ public class MovePanel extends AbstractMovePanel {
         TransportUtils.mapTransportsToLoadUsingMinTransports(availableUnits, capableTransports);
     for (final Unit unit : unitsToCapableTransports.keySet()) {
       final Unit transport = unitsToCapableTransports.get(unit);
-      final int unitCost = UnitAttachment.get(unit.getType()).getTransportCost();
+      final int unitCost = unit.getUnitAttachment().getTransportCost();
       availableCapacityMap.add(transport, (-1 * unitCost));
       defaultSelections.add(transport);
     }
@@ -1198,7 +1196,7 @@ public class MovePanel extends AbstractMovePanel {
         TransportUtils.mapTransportsToLoadUsingMinTransports(availableUnits, alliedTransports);
     for (final Unit unit : unitsToAlliedTransports.keySet()) {
       final Unit transport = unitsToAlliedTransports.get(unit);
-      final int unitCost = UnitAttachment.get(unit.getType()).getTransportCost();
+      final int unitCost = unit.getUnitAttachment().getTransportCost();
       availableCapacityMap.add(transport, (-1 * unitCost));
       defaultSelections.add(transport);
       useAlliedTransports = true;
@@ -1213,7 +1211,7 @@ public class MovePanel extends AbstractMovePanel {
           TransportUtils.mapTransportsToLoadUsingMinTransports(availableUnits, incapableTransports);
       for (final Unit unit : unitsToIncapableTransports.keySet()) {
         final Unit transport = unitsToIncapableTransports.get(unit);
-        final int unitCost = UnitAttachment.get(unit.getType()).getTransportCost();
+        final int unitCost = unit.getUnitAttachment().getTransportCost();
         availableCapacityMap.add(transport, (-1 * unitCost));
         defaultSelections.add(transport);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.image.MapImage;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.image.UnitImageFactory.ImageKey;
@@ -162,12 +161,12 @@ class AvatarPanelFactory {
 
   private static Comparator<UnitCategory> unitRenderingOrder(final GamePlayer currentPlayer) {
     final Comparator<UnitCategory> isAir =
-        Comparator.comparing(unitCategory -> UnitAttachment.get(unitCategory.getType()).getIsAir());
+        Comparator.comparing(unitCategory -> unitCategory.getUnitAttachment().getIsAir());
     final Comparator<UnitCategory> isSea =
-        Comparator.comparing(unitCategory -> UnitAttachment.get(unitCategory.getType()).getIsSea());
+        Comparator.comparing(unitCategory -> unitCategory.getUnitAttachment().getIsSea());
     final Comparator<UnitCategory> unitAttackPower =
         Comparator.comparingInt(
-            unitCategory -> UnitAttachment.get(unitCategory.getType()).getAttack(currentPlayer));
+            unitCategory -> unitCategory.getUnitAttachment().getAttack(currentPlayer));
     final Comparator<UnitCategory> unitName =
         Comparator.comparing(unitCategory -> unitCategory.getType().getName());
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -187,8 +187,7 @@ public final class TransportUtils {
     for (final UnitCategory unitType : unitTypes) {
       final int transportCost = unitType.getTransportCost();
       for (final UnitCategory transportType : transportTypes) {
-        final int transportCapacity =
-            UnitAttachment.get(transportType.getType()).getTransportCapacity();
+        final int transportCapacity = transportType.getUnitAttachment().getTransportCapacity();
         if (transportCost > 0 && transportCapacity >= transportCost) {
           final int transportCount =
               CollectionUtils.countMatches(
@@ -243,7 +242,7 @@ public final class TransportUtils {
       final List<Unit> canTransport,
       final Map<Unit, Unit> mapping,
       final IntegerMap<Unit> addedLoad) {
-    final int cost = UnitAttachment.get(unit.getType()).getTransportCost();
+    final int cost = unit.getUnitAttachment().getTransportCost();
     for (final Unit transport : canTransport) {
       final int capacity =
           TransportTracker.getAvailableCapacity(transport) - addedLoad.getInt(transport);
@@ -261,7 +260,7 @@ public final class TransportUtils {
     int capacity = TransportTracker.getAvailableCapacity(transport);
     for (final Iterator<Unit> it = canBeTransported.iterator(); it.hasNext(); ) {
       final Unit unit = it.next();
-      final int cost = UnitAttachment.get(unit.getType()).getTransportCost();
+      final int cost = unit.getUnitAttachment().getTransportCost();
       if (capacity >= cost) {
         capacity -= cost;
         mapping.put(unit, transport);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import lombok.Getter;
 import org.triplea.java.collections.CollectionUtils;
 
 /**
@@ -36,7 +37,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
   // movement of the units
   private final BigDecimal movement;
   // movement of the units
-  private final int transportCost;
+  @Getter private final int transportCost;
   private final boolean canRetreat;
   private final GamePlayer owner;
   // the units in the category, may be duplicates.
@@ -172,10 +173,6 @@ public class UnitCategory implements Comparable<UnitCategory> {
 
   public BigDecimal getMovement() {
     return movement;
-  }
-
-  public int getTransportCost() {
-    return transportCost;
   }
 
   public GamePlayer getOwner() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -75,6 +75,10 @@ public class UnitCategory implements Comparable<UnitCategory> {
     createDependents(dependents);
   }
 
+  public UnitAttachment getUnitAttachment() {
+    return UnitAttachment.get(getType());
+  }
+
   public int getDamaged() {
     return damaged;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -5,7 +5,6 @@ import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.mapdata.MapData;
 import java.math.BigDecimal;
@@ -134,7 +133,6 @@ public class UnitSeparator {
   }
 
   private static boolean isAirWithHitPointsRemaining(final Unit unit) {
-    return UnitAttachment.get(unit.getType()).getIsAir()
-        && UnitAttachment.get(unit.getType()).getHitPoints() > 1;
+    return unit.getUnitAttachment().getIsAir() && unit.getUnitAttachment().getHitPoints() > 1;
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -495,9 +495,7 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    aaGunList
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(aaGunList)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
@@ -516,9 +514,7 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    aaGunList
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(aaGunList)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
@@ -538,9 +534,7 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    aaGunList
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(aaGunList)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
@@ -575,9 +569,7 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    aaGunList
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(aaGunList)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
@@ -616,9 +608,7 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    aaGunList
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(aaGunList)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -257,7 +257,7 @@ class DiceRollTest {
     final List<Unit> units = artillery.create(1, russians);
     // Set the supported unit count
     for (final Unit unit : units) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       ua.setUnitSupportCount("2");
     }
     // Now add the infantry
@@ -495,7 +495,10 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(aaGunList.iterator().next().getType())
+                    aaGunList
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
             bridge,
@@ -513,7 +516,10 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(aaGunList.iterator().next().getType())
+                    aaGunList
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
             bridge,
@@ -532,7 +538,10 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(aaGunList.iterator().next().getType())
+                    aaGunList
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
             bridge,
@@ -566,7 +575,10 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(aaGunList.iterator().next().getType())
+                    aaGunList
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
             bridge,
@@ -604,7 +616,10 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(aaGunList.iterator().next().getType())
+                    aaGunList
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
             bridge,
@@ -622,7 +637,10 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(aaGunList.iterator().next().getType())
+                    aaGunList
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
             bridge,
@@ -641,7 +659,10 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(aaGunList.iterator().next().getType())
+                    aaGunList
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
             bridge,

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -627,9 +627,7 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    aaGunList
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(aaGunList)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,
@@ -649,9 +647,7 @@ class DiceRollTest {
             CollectionUtils.getMatches(
                 fighterList,
                 Matches.unitIsOfTypes(
-                    aaGunList
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(aaGunList)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             aaGunList,

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -169,7 +169,10 @@ class WW2V3Year41Test {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             defendingAa,
             bridge,
@@ -238,7 +241,10 @@ class WW2V3Year41Test {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             defendingAa,
             bridge,
@@ -311,7 +317,10 @@ class WW2V3Year41Test {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             defendingAa,
             bridge,
@@ -1331,7 +1340,7 @@ class WW2V3Year41Test {
     final Collection<Unit> dds =
         CollectionUtils.getMatches(sz15.getUnits(), Matches.unitIsDestroyer());
     for (final Unit unit : dds) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final UnitAttachment ua = unit.getUnitAttachment();
       ua.setBombard(3);
     }
     // start the battle phase, this will ask the user to bombard

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -169,9 +169,7 @@ class WW2V3Year41Test {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             defendingAa,
@@ -241,9 +239,7 @@ class WW2V3Year41Test {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             defendingAa,
@@ -317,9 +313,7 @@ class WW2V3Year41Test {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(gameData.getUnitTypeList()))),
             defendingAa,

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
@@ -23,7 +23,6 @@ import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.BattleState;
@@ -175,7 +174,10 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
             bridge,
@@ -238,7 +240,10 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
             bridge,
@@ -302,7 +307,10 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
             bridge,
@@ -366,7 +374,10 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
             bridge,
@@ -430,7 +441,10 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
             bridge,
@@ -500,7 +514,10 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
             bridge,
@@ -565,7 +582,10 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    UnitAttachment.get(defendingAa.iterator().next().getType())
+                    defendingAa
+                        .iterator()
+                        .next()
+                        .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
             bridge,

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
@@ -174,9 +174,7 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
@@ -240,9 +238,7 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
@@ -307,9 +303,7 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
@@ -374,9 +368,7 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
@@ -441,9 +433,7 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
@@ -514,9 +504,7 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,
@@ -582,9 +570,7 @@ class CasualtySelectorTest {
             CollectionUtils.getMatches(
                 planes,
                 Matches.unitIsOfTypes(
-                    defendingAa
-                        .iterator()
-                        .next()
+                    CollectionUtils.getAny(defendingAa)
                         .getUnitAttachment()
                         .getTargetsAa(data.getUnitTypeList()))),
             defendingAa,

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/TargetGroupTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/TargetGroupTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.core.IsNot.not;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Unit;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.AbstractDelegateTestCase;
 import games.strategy.triplea.delegate.GameDataTestUtil;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -107,7 +106,7 @@ class TargetGroupTest extends AbstractDelegateTestCase {
     final List<Unit> enemyUnits = GameDataTestUtil.britishSubmarine(twwGameData).create(1, britain);
     enemyUnits.addAll(GameDataTestUtil.britishFighter(twwGameData).create(2, britain));
     final List<TargetGroup> result = TargetGroup.newTargetGroups(units, enemyUnits);
-    assertThat(UnitAttachment.get(units.get(0).getType()).getCanNotTarget(), is(not(empty())));
+    assertThat(units.get(0).getUnitAttachment().getCanNotTarget(), is(not(empty())));
     assertThat(result, hasSize(2));
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/DummyPlayerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/DummyPlayerTest.java
@@ -66,6 +66,7 @@ class DummyPlayerTest {
           when(unit.getType()).thenReturn(unitType);
           final var unitAttachment = mock(UnitAttachment.class);
           when(unitType.getAttachment(any())).thenReturn(unitAttachment);
+          when(unit.getUnitAttachment()).thenReturn(unitAttachment);
           when(unitAttachment.getIsAir()).thenReturn(!unit.equals(unitPool.get(0)));
           final var gameData = givenGameData().build();
           when(unit.getData()).thenReturn(gameData);


### PR DESCRIPTION
## Change Summary & Additional Notes
Additionally, address some codeclimate warnings and change a couple of call sites that call isTranporting() followed by getTransporting(), which do the same work and are very inefficient.


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
