### PR TITLE
Some optimizations to speed up Hard AI code.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.ai.AiUtils;
 import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOption;
@@ -21,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -254,11 +256,12 @@ public final class ProTransportUtils {
   }
 
   private static Comparator<Unit> getDecreasingAttackComparator(final GamePlayer player) {
+    final Map<UnitType, Set<UnitSupportAttachment>> cache = new HashMap<>();
+    ;
     return (o1, o2) -> {
-
       // Very rough way to add support power
       final Set<UnitSupportAttachment> supportAttachments1 =
-          UnitSupportAttachment.get(o1.getType());
+          cache.computeIfAbsent(o1.getType(), UnitSupportAttachment::get);
       int maxSupport1 = 0;
       for (final UnitSupportAttachment usa : supportAttachments1) {
         if (usa.getAllied() && usa.getOffence() && usa.getBonus() > maxSupport1) {
@@ -267,7 +270,7 @@ public final class ProTransportUtils {
       }
       final int attack1 = o1.getUnitAttachment().getAttack(player) + maxSupport1;
       final Set<UnitSupportAttachment> supportAttachments2 =
-          UnitSupportAttachment.get(o2.getType());
+          cache.computeIfAbsent(o2.getType(), UnitSupportAttachment::get);
       int maxSupport2 = 0;
       for (final UnitSupportAttachment usa : supportAttachments2) {
         if (usa.getAllied() && usa.getOffence() && usa.getBonus() > maxSupport2) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -257,7 +257,6 @@ public final class ProTransportUtils {
 
   private static Comparator<Unit> getDecreasingAttackComparator(final GamePlayer player) {
     final Map<UnitType, Set<UnitSupportAttachment>> cache = new HashMap<>();
-    ;
     return (o1, o2) -> {
       // Very rough way to add support power
       final Set<UnitSupportAttachment> supportAttachments1 =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.MutableProperty;
-import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.gameparser.GameParseException;
@@ -34,31 +33,6 @@ public class CanalAttachment extends DefaultAttachment {
 
   public CanalAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
-  }
-
-  /**
-   * Checks if the route contains both territories to pass through the given canal. If route is null
-   * returns true.
-   */
-  public static boolean isCanalOnRoute(final String canalName, final Route route) {
-    if (route == null) {
-      return true;
-    }
-    boolean previousTerritoryHasCanal = false;
-    for (final Territory t : route) {
-      boolean currentTerritoryHasCanal = false;
-      for (final CanalAttachment canalAttachment : get(t)) {
-        if (canalAttachment.getCanalName().equals(canalName)) {
-          currentTerritoryHasCanal = true;
-          break;
-        }
-      }
-      if (previousTerritoryHasCanal && currentTerritoryHasCanal) {
-        return true;
-      }
-      previousTerritoryHasCanal = currentTerritoryHasCanal;
-    }
-    return false;
   }
 
   public static Set<CanalAttachment> get(final Territory t) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -384,20 +384,15 @@ public class MovePerformer implements Serializable {
     final boolean paratroopsLanding =
         arrived.stream().anyMatch(paratroopNAirTransports)
             && MoveValidator.allLandUnitsAreBeingParatroopered(arrived);
-    final Map<Unit, Collection<Unit>> dependentAirTransportableUnits =
-        new HashMap<>(
-            MoveValidator.getDependents(
-                CollectionUtils.getMatches(arrived, Matches.unitCanTransport())));
+    final Map<Unit, Collection<Unit>> dependentAirTransportableUnits = new HashMap<>();
+    for (final Unit unit : CollectionUtils.getMatches(arrived, Matches.unitCanTransport())) {
+      dependentAirTransportableUnits.put(unit, new ArrayList<>(unit.getTransporting()));
+    }
     // add newly created dependents
     for (final Entry<Unit, Collection<Unit>> entry : newDependents.entrySet()) {
-      Collection<Unit> dependents = dependentAirTransportableUnits.get(entry.getKey());
-      if (dependents != null) {
-        dependents = new ArrayList<>(dependents);
-        dependents.addAll(entry.getValue());
-      } else {
-        dependents = entry.getValue();
-      }
-      dependentAirTransportableUnits.put(entry.getKey(), dependents);
+      dependentAirTransportableUnits
+          .computeIfAbsent(entry.getKey(), key -> new ArrayList<>())
+          .addAll(entry.getValue());
     }
 
     // If paratroops moved normally (within their normal movement) remove their dependency to the

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -44,6 +44,15 @@ class CasualtyOrderOfLosses {
     @Nonnull Territory battlesite;
     @Nonnull IntegerMap<UnitType> costs;
     @Nonnull GameState data;
+
+    public String getCacheKey() {
+      return player.getName()
+          + "|"
+          + battlesite.getName()
+          + "|"
+          + combatValue.getBattleSide()
+          + "|";
+    }
   }
 
   /**
@@ -64,7 +73,8 @@ class CasualtyOrderOfLosses {
       targetTypes.add(AmphibType.of(u));
     }
     // Calculate hashes and cache key
-    String key = computeOolCacheKey(parameters, targetTypes);
+    final String paramsCacheKey = parameters.getCacheKey();
+    String key = computeOolCacheKey(paramsCacheKey, targetTypes);
     // Check OOL cache
     final List<AmphibType> stored = oolCache.get(key);
     if (stored != null) {
@@ -235,7 +245,7 @@ class CasualtyOrderOfLosses {
       oolCache.put(key, new ArrayList<>(unitTypes));
       final AmphibType unitTypeToRemove = it.next();
       targetTypes.remove(unitTypeToRemove);
-      key = computeOolCacheKey(parameters, targetTypes);
+      key = computeOolCacheKey(paramsCacheKey, targetTypes);
       it.remove();
     }
     return sortedWellEnoughUnitsList;
@@ -259,14 +269,7 @@ class CasualtyOrderOfLosses {
     }
   }
 
-  static String computeOolCacheKey(
-      final Parameters parameters, final List<AmphibType> targetTypes) {
-    return parameters.player.getName()
-        + "|"
-        + parameters.battlesite.getName()
-        + "|"
-        + parameters.combatValue.getBattleSide()
-        + "|"
-        + Objects.hashCode(targetTypes);
+  static String computeOolCacheKey(String paramsCacheKey, List<AmphibType> targetTypes) {
+    return paramsCacheKey + Objects.hashCode(targetTypes);
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes
Some optimizations to speed up Hard AI code.

Notes some areas for improvement during performance profiling of Hard AI code:
  - Avoid repeated CanalAttachment lookups by keeping a cache on MoveValidator and move isCanalOnRoute() to MoveValidator (only caller)
  - Use a cache for UnitSupportAttachments in getDecreasingAttackComparator()
  - Pass in the start territory to getDependents() from validateCombat() to speed it up
  - Simplify logic in markTransportsMovement()
  - Avoid repeating key prefix string appends in CasualtyOrderOfLosses 
 
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
