### PR TITLE
Cap testAiGame() to 100 rounds.

### DIFF
--- a/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -36,7 +36,13 @@ public class AiGameTest {
     GameSelectorModel gameSelector = GameTestUtils.loadGameFromURI(mapName, mapXmlPath);
     ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
     game.setStopGameOnDelegateExecutionStop(true);
-    game.startGame();
+    while (!game.isGameOver()) {
+      game.runNextStep();
+      if (game.getData().getSequence().getRound() > 100) {
+        log.warn("No winner after 100 rounds");
+        break;
+      }
+    }
     assertThat(game.isGameOver(), is(true));
     assertThat(game.getData().getSequence().getRound(), greaterThan(2));
     EndRoundDelegate endDelegate = (EndRoundDelegate) game.getData().getDelegate("endRound");


### PR DESCRIPTION
## Change Summary & Additional Notes
Cap testAiGame() to 100 rounds.

I've not seen it locally, but I've seen a few cases on the CI bots that this test doesn't complete and runs for many minutes. 
Instead of letting it run indefinitely, don't run it for more than 100 rounds. If the game isn't over by then, the test will fail.

Ideally, we should figure out why this happens some times and fix the relevant code, but for now limit the impact by having the test fail when this happens.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
