### PR TITLE
Remove TransportTracker.isTransporting().

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -23,7 +23,6 @@ import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.ai.pro.util.ProUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.battle.AirBattle;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import java.util.ArrayList;
@@ -1509,9 +1508,7 @@ public class ProCombatMoveAi {
         for (final Territory t : transportAttackOptions.get(transport)) {
           final ProTerritory patd = attackMap.get(t);
           final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player);
-          if (!patd.isCurrentlyWins()
-              && !transport.isTransporting()
-              && !defendingUnits.isEmpty()) {
+          if (!patd.isCurrentlyWins() && !transport.isTransporting() && !defendingUnits.isEmpty()) {
             if (patd.getBattleResult() == null) {
               patd.estimateBattleResult(calc, player);
             }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -1510,7 +1510,7 @@ public class ProCombatMoveAi {
           final ProTerritory patd = attackMap.get(t);
           final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player);
           if (!patd.isCurrentlyWins()
-              && !TransportTracker.isTransporting(transport)
+              && !transport.isTransporting()
               && !defendingUnits.isEmpty()) {
             if (patd.getBattleResult() == null) {
               patd.estimateBattleResult(calc, player);
@@ -1673,7 +1673,7 @@ public class ProCombatMoveAi {
         if (bombardMap.get(u).contains(patd.getTerritory())
             && !patd.getTransportTerritoryMap().isEmpty()
             && hasDefenders
-            && !TransportTracker.isTransporting(u)) {
+            && !u.isTransporting()) {
           canBombardTerritories.add(patd.getTerritory());
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -882,7 +882,7 @@ class ProNonCombatMoveAi {
         for (final Unit transport : transportDefendOptions.keySet()) {
           // Find current naval defense that needs transport if it isn't transporting units
           for (final Territory t : transportDefendOptions.get(transport)) {
-            if (!TransportTracker.isTransporting(transport)) {
+            if (!transport.isTransporting()) {
               final ProTerritory proTerritory = moveMap.get(t);
               proTerritory.setBattleResultIfNull(
                   () ->
@@ -1403,7 +1403,7 @@ class ProNonCombatMoveAi {
         final Unit transport = it.next();
         final Territory currentTerritory = unitTerritoryMap.get(transport);
         final int moves = transport.getMovementLeft().intValue();
-        if (TransportTracker.isTransporting(transport) || moves <= 0) {
+        if (transport.isTransporting() || moves <= 0) {
           continue;
         }
         final List<ProTerritory> priorizitedLoadTerritories = new ArrayList<>();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -34,7 +34,6 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.data.MoveValidationResult;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -9,7 +9,6 @@ import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.ai.pro.util.ProMatches;
 import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.TransportTracker;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -269,7 +269,7 @@ public class ProTerritory {
 
   public void putAmphibAttackMap(final Unit transport, final List<Unit> amphibUnits) {
     this.amphibAttackMap.put(transport, amphibUnits);
-    this.isTransportingMap.put(transport, TransportTracker.isTransporting(transport));
+    this.isTransportingMap.put(transport, transport.isTransporting());
   }
 
   public void setCanAttack(final boolean canAttack) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -186,7 +186,7 @@ public final class ProMoveUtils {
         final var loadedUnits = new ArrayList<Unit>();
         final var remainingUnitsToLoad = new ArrayList<Unit>();
 
-        if (TransportTracker.isTransporting(transport)) {
+        if (transport.isTransporting()) {
           loadedUnits.addAll(amphibAttackMap.get(transport));
         } else {
           remainingUnitsToLoad.addAll(amphibAttackMap.get(transport));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import java.util.ArrayList;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -60,7 +60,7 @@ public final class ProTransportUtils {
       final Map<Unit, Set<Territory>> unitMoveMap,
       final double value) {
     final List<Unit> unitsToIgnoreOrHaveBetterLandMove = new ArrayList<>(unitsToIgnore);
-    if (!TransportTracker.isTransporting(transport)) {
+    if (!transport.isTransporting()) {
       // Get all units that can be transported
       Predicate<Unit> canBeLoaded =
           ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, transport, true);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -17,7 +17,6 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.move.validation.AirMovementValidator;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1428,7 +1428,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> transportIsNotTransporting() {
-    return transport -> !TransportTracker.isTransporting(transport);
+    return transport -> !transport.isTransporting();
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
-import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
@@ -280,8 +279,7 @@ public class TransportTracker {
   }
 
   public static AlliedAirTransportChange markTransportedByForAlliedAirOnCarrier(
-      final Collection<Unit> units,
-      final GamePlayer player) {
+      final Collection<Unit> units, final GamePlayer player) {
     final CompositeChange change = new CompositeChange();
     final Collection<Unit> alliedAir = new ArrayList<>();
     MoveValidator.carrierMustMoveWith(units, units, player)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -24,19 +24,15 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.Value;
+import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.CollectionUtils;
 
 /**
  * Tracks which transports are carrying which units. Also tracks the capacity that has been
  * unloaded. To reset the unloaded call clearUnloadedCapacity().
  */
+@UtilityClass
 public class TransportTracker {
-  private TransportTracker() {}
-
-  private static int getCost(final Collection<Unit> units) {
-    return TransportUtils.getTransportCost(units);
-  }
-
   private static void assertTransport(final Unit u) {
     if (u.getUnitAttachment().getTransportCapacity() == -1) {
       throw new IllegalStateException("Not a transport:" + u);
@@ -85,10 +81,6 @@ public class TransportTracker {
   public static Map<Unit, Collection<Unit>> transportingInTerritory(
       final Collection<Unit> units, final Territory territory) {
     return transporting(units, transport -> transport.getTransporting(territory));
-  }
-
-  public static boolean isTransporting(final Unit transport) {
-    return !transport.getTransporting().isEmpty();
   }
 
   public static Collection<Unit> transportingAndUnloaded(final Unit transport) {
@@ -197,8 +189,8 @@ public class TransportTracker {
       return 0;
     }
     final int capacity = ua.getTransportCapacity();
-    final int used = getCost(unit.getTransporting());
-    final int unloaded = getCost(unit.getUnloaded());
+    final int used = TransportUtils.getTransportCost(unit.getTransporting());
+    final int unloaded = TransportUtils.getTransportCost(unit.getUnloaded());
     return capacity - used - unloaded;
   }
 
@@ -289,7 +281,6 @@ public class TransportTracker {
 
   public static AlliedAirTransportChange markTransportedByForAlliedAirOnCarrier(
       final Collection<Unit> units,
-      final RelationshipTracker relationshipTracker,
       final GamePlayer player) {
     final CompositeChange change = new CompositeChange();
     final Collection<Unit> alliedAir = new ArrayList<>();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -230,7 +230,7 @@ public class MustFightBattle extends DependentBattle
       // and remove them from the attacking units
       final TransportTracker.AlliedAirTransportChange alliedAirTransportChange =
           TransportTracker.markTransportedByForAlliedAirOnCarrier(
-              units, gameData.getRelationshipTracker(), attacker);
+              units, attacker);
       change.add(alliedAirTransportChange.getChange());
       this.attackingUnits.removeAll(alliedAirTransportChange.getAlliedAir());
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -229,8 +229,7 @@ public class MustFightBattle extends DependentBattle
       // allied air can not participate in the battle so set transportedBy on each allied air unit
       // and remove them from the attacking units
       final TransportTracker.AlliedAirTransportChange alliedAirTransportChange =
-          TransportTracker.markTransportedByForAlliedAirOnCarrier(
-              units, attacker);
+          TransportTracker.markTransportedByForAlliedAirOnCarrier(units, attacker);
       change.add(alliedAirTransportChange.getChange());
       this.attackingUnits.removeAll(alliedAirTransportChange.getAlliedAir());
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import java.util.Collection;
 import java.util.Comparator;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
@@ -60,8 +60,8 @@ public class UnitBattleComparator implements Comparator<Unit> {
     if (u1.equals(u2)) {
       return 0;
     }
-    final boolean transporting1 = TransportTracker.isTransporting(u1);
-    final boolean transporting2 = TransportTracker.isTransporting(u2);
+    final boolean transporting1 = u1.isTransporting();
+    final boolean transporting2 = u2.isTransporting();
     final UnitAttachment ua1 = u1.getUnitAttachment();
     final UnitAttachment ua2 = u2.getUnitAttachment();
     if (ua1.equals(ua2)

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/TransportTrackerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/TransportTrackerTest.java
@@ -25,11 +25,11 @@ class TransportTrackerTest {
   @Test
   void testIsTransporting() {
     addTo(sz18, List.of(transport));
-    assertThat(TransportTracker.isTransporting(transport), is(false));
+    assertThat(transport.isTransporting(), is(false));
 
     addTo(sz18, List.of(tank));
     final Change change = TransportTracker.loadTransportChange(transport, tank);
     gameData.performChange(change);
-    assertThat(TransportTracker.isTransporting(transport), is(true));
+    assertThat(transport.isTransporting(), is(true));
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes
Remove TransportTracker.isTransporting().

It's a duplicate of u.isTransporting(), so this PR migrates the callers. The latter is marked deprecated for performance reasons, but the former ran the same code and so it didn't make sense for one to be deprecated but not the other.

Long term, it still makes sense to reduce usage of this, but that's not in scope for this PR.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
