### PR TITLE
Bottom bar: show player name/icon during random start delegate.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -219,7 +219,8 @@ public class BottomBar extends JPanel {
     resourceBar.gameDataChanged(null);
   }
 
-  public void setStepInfo(int roundNumber, String stepName, @Nullable GamePlayer player, boolean isRemotePlayer) {
+  public void setStepInfo(
+      int roundNumber, String stepName, @Nullable GamePlayer player, boolean isRemotePlayer) {
     roundLabel.setText("Round:" + roundNumber + " ");
     stepLabel.setText(stepName);
     if (player != null) {
@@ -231,8 +232,7 @@ public class BottomBar extends JPanel {
     final CompletableFuture<?> future =
         CompletableFuture.supplyAsync(() -> uiContext.getFlagImageFactory().getFlag(player))
             .thenApplyAsync(ImageIcon::new)
-            .thenAccept(
-                icon -> SwingUtilities.invokeLater(() -> roundLabel.setIcon(icon)));
+            .thenAccept(icon -> SwingUtilities.invokeLater(() -> roundLabel.setIcon(icon)));
     CompletableFutureUtils.logExceptionWhenComplete(
         future, throwable -> log.error("Failed to set round icon for " + player, throwable));
     playerLabel.setText((isRemotePlayer ? "REMOTE: " : "") + player.getName());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -235,8 +235,6 @@ public class BottomBar extends JPanel {
                 icon -> SwingUtilities.invokeLater(() -> roundLabel.setIcon(icon)));
     CompletableFutureUtils.logExceptionWhenComplete(
         future, throwable -> log.error("Failed to set round icon for " + player, throwable));
-    if (player != null) {
-      playerLabel.setText((isRemotePlayer ? "REMOTE: " : "") + player.getName());
-    }
+    playerLabel.setText((isRemotePlayer ? "REMOTE: " : "") + player.getName());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -17,6 +17,7 @@ import java.awt.Image;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -26,14 +27,18 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
 import javax.swing.border.EtchedBorder;
+import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.IntegerMap;
+import org.triplea.java.concurrency.CompletableFutureUtils;
 import org.triplea.swing.SwingComponents;
 import org.triplea.swing.jpanel.GridBagConstraintsAnchor;
 import org.triplea.swing.jpanel.GridBagConstraintsBuilder;
 import org.triplea.swing.jpanel.GridBagConstraintsFill;
 
+@Slf4j
 public class BottomBar extends JPanel {
   private final UiContext uiContext;
   private final GameData data;
@@ -214,16 +219,24 @@ public class BottomBar extends JPanel {
     resourceBar.gameDataChanged(null);
   }
 
-  public void setRoundIcon(ImageIcon icon) {
-    roundLabel.setIcon(icon);
-  }
-
-  public void setStepInfo(
-      int roundNumber, String stepName, GamePlayer player, boolean isRemotePlayer) {
+  public void setStepInfo(int roundNumber, String stepName, @Nullable GamePlayer player, boolean isRemotePlayer) {
     roundLabel.setText("Round:" + roundNumber + " ");
     stepLabel.setText(stepName);
     if (player != null) {
-      this.playerLabel.setText((isRemotePlayer ? "REMOTE: " : "") + player.getName());
+      setCurrentPlayer(player, isRemotePlayer);
+    }
+  }
+
+  public void setCurrentPlayer(GamePlayer player, boolean isRemotePlayer) {
+    final CompletableFuture<?> future =
+        CompletableFuture.supplyAsync(() -> uiContext.getFlagImageFactory().getFlag(player))
+            .thenApplyAsync(ImageIcon::new)
+            .thenAccept(
+                icon -> SwingUtilities.invokeLater(() -> roundLabel.setIcon(icon)));
+    CompletableFutureUtils.logExceptionWhenComplete(
+        future, throwable -> log.error("Failed to set round icon for " + player, throwable));
+    if (player != null) {
+      playerLabel.setText((isRemotePlayer ? "REMOTE: " : "") + player.getName());
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -105,7 +105,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
         @Override
         public void mouseMoved(final @Nullable Territory territory, final MouseDetails md) {
           if (!isActive()) {
-            log.error("Should not be able to select a territory when inactive: " + territory);
+            // This could happen if the history panel is open.
             return;
           }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -108,7 +108,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -120,7 +119,6 @@ import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonModel;
-import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
@@ -148,7 +146,6 @@ import org.triplea.java.Interruptibles;
 import org.triplea.java.ThreadRunner;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
-import org.triplea.java.concurrency.CompletableFutureUtils;
 import org.triplea.sound.ClipPlayer;
 import org.triplea.sound.SoundPath;
 import org.triplea.swing.CollapsiblePanel;
@@ -1112,6 +1109,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
         () ->
             SwingAction.invokeAndWait(
                 () -> {
+                  bottomBar.setCurrentPlayer(player, false);
                   if (inGame.compareAndSet(false, true)) {
                     showGame();
                   }
@@ -1613,13 +1611,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
 
     final boolean isPlaying = localPlayers.playing(player);
     if (player != null && !player.isNull()) {
-      final CompletableFuture<?> future =
-          CompletableFuture.supplyAsync(() -> uiContext.getFlagImageFactory().getFlag(player))
-              .thenApplyAsync(ImageIcon::new)
-              .thenAccept(
-                  icon -> SwingUtilities.invokeLater(() -> this.bottomBar.setRoundIcon(icon)));
-      CompletableFutureUtils.logExceptionWhenComplete(
-          future, throwable -> log.error("Failed to set round icon for " + player, throwable));
       lastStepPlayer = currentStepPlayer;
       currentStepPlayer = player;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -746,10 +746,11 @@ public class MapData {
   }
 
   public List<Point> getTerritoryEffectPoints(final Territory territory) {
-    if (territoryEffects.get(territory.getName()) == null) {
+    List<Point> points = territoryEffects.get(territory.getName());
+    if (points == null) {
       return List.of(getCenter(territory));
     }
-    return territoryEffects.get(territory.getName());
+    return points;
   }
 
   public Optional<Image> getTerritoryEffectImage(final String effectName) {


### PR DESCRIPTION
## Change Summary & Additional Notes
Bottom bar: show player name/icon during random start delegate.

Also, remove a warning message that triggers if you view open history during random start delegate.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
