### PR TITLE
Clean up and optimize transport validation code.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -1,7 +1,5 @@
 package games.strategy.triplea.delegate.move.validation;
 
-import static java.util.function.Predicate.not;
-
 import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -1596,7 +1594,8 @@ public class MoveValidator {
 
   private static Map<Unit, Collection<Unit>> airTransportsMustMoveWith(
       final Territory start,
-      final Collection<Unit> units, final Map<Unit, Collection<Unit>> newDependents) {
+      final Collection<Unit> units,
+      final Map<Unit, Collection<Unit>> newDependents) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
     final Collection<Unit> airTransports =
         CollectionUtils.getMatches(units, Matches.unitIsAirTransport());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.delegate.move.validation;
 
+import static java.util.function.Predicate.not;
+
 import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -1566,42 +1568,34 @@ public class MoveValidator {
       final GamePlayer player) {
     final List<Unit> sortedUnits = new ArrayList<>(units);
     sortedUnits.sort(UnitComparator.getHighestToLowestMovementComparator());
-    final Map<Unit, Collection<Unit>> mapping = new HashMap<>(transportsMustMoveWith(sortedUnits));
+    final Map<Unit, Collection<Unit>> mapping = transportsMustMoveWith(start, sortedUnits);
     // Check if there are combined transports (carriers that are transports) and load them.
     addToMapping(mapping, carrierMustMoveWith(sortedUnits, start, player));
-    addToMapping(mapping, airTransportsMustMoveWith(sortedUnits, newDependents));
+    addToMapping(mapping, airTransportsMustMoveWith(start, sortedUnits, newDependents));
     return mapping;
   }
 
   private static void addToMapping(
       final Map<Unit, Collection<Unit>> mapping, final Map<Unit, Collection<Unit>> newMapping) {
-    if (mapping.isEmpty()) {
-      mapping.putAll(newMapping);
-      return;
-    }
-    for (final Unit key : newMapping.keySet()) {
-      if (mapping.containsKey(key)) {
-        final Collection<Unit> heldUnits = new ArrayList<>(mapping.get(key));
-        heldUnits.addAll(newMapping.get(key));
-        mapping.put(key, heldUnits);
-      } else {
-        mapping.put(key, newMapping.get(key));
-      }
+    for (final Map.Entry<Unit, Collection<Unit>> entry : newMapping.entrySet()) {
+      mapping.computeIfAbsent(entry.getKey(), key -> new ArrayList<>()).addAll(entry.getValue());
     }
   }
 
-  private static Map<Unit, Collection<Unit>> transportsMustMoveWith(final Collection<Unit> units) {
+  private static Map<Unit, Collection<Unit>> transportsMustMoveWith(
+      final Territory start, final Collection<Unit> units) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
     final Collection<Unit> transports =
         CollectionUtils.getMatches(units, Matches.unitIsTransport());
     for (final Unit transport : transports) {
-      final Collection<Unit> transporting = transport.getTransporting();
-      mustMoveWith.put(transport, transporting);
+      final Collection<Unit> transporting = transport.getTransporting(start);
+      mustMoveWith.put(transport, new ArrayList<>(transporting));
     }
     return mustMoveWith;
   }
 
   private static Map<Unit, Collection<Unit>> airTransportsMustMoveWith(
+      final Territory start,
       final Collection<Unit> units, final Map<Unit, Collection<Unit>> newDependents) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
     final Collection<Unit> airTransports =
@@ -1609,7 +1603,7 @@ public class MoveValidator {
     // Then check those that have already had their transportedBy set
     for (final Unit airTransport : airTransports) {
       if (!mustMoveWith.containsKey(airTransport)) {
-        Collection<Unit> transporting = airTransport.getTransporting();
+        Collection<Unit> transporting = airTransport.getTransporting(start);
         if (transporting.isEmpty() && !newDependents.isEmpty()) {
           transporting = newDependents.get(airTransport);
         }


### PR DESCRIPTION
## Change Summary & Additional Notes
Clean up and optimize transport validation code.

No functional changes.

 - Passes in start territory when getting transported units, so the whole map doesn't need to be checked.
 - Changes some logic around constructing mutable collections in transportsMustMoveWith() computation to streamline the code.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
