### PR TITLE
Move UI code out of delegate

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
@@ -7,7 +7,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.display.IDisplay;
 import games.strategy.engine.framework.AbstractGame;
-import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.history.IDelegateHistoryWriter;
 import games.strategy.engine.message.MessengerException;
@@ -25,7 +24,7 @@ import org.triplea.sound.ISound;
 @RequiredArgsConstructor
 public class DefaultDelegateBridge implements IDelegateBridge {
   private final GameData gameData;
-  private final IGame game;
+  private final ServerGame game;
   private final IDelegateHistoryWriter historyWriter;
   private final RandomStats randomStats;
   private final DelegateExecutionManager delegateExecutionManager;
@@ -148,8 +147,8 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   }
 
   @Override
-  public void stopGameSequence() {
-    ((ServerGame) game).stopGameSequence();
+  public void stopGameSequence(String status, String title) {
+    game.stopGameSequence(status, title);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -85,7 +85,7 @@ public interface IDelegateBridge {
    * <p>This method allows the delegate to signal that the game is over, but does not force the ui
    * or the display to shutdown.
    */
-  void stopGameSequence();
+  void stopGameSequence(String status, String title);
 
   void leaveDelegateExecution();
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -1,9 +1,6 @@
 package games.strategy.engine.framework;
 
-/**
- * GameRunner - The entrance class with the main method. In this class commonly used constants are
- * getting defined and the Game is being launched
- */
+/** In this class commonly used constants are getting defined. */
 public final class GameRunner {
   public static final String TRIPLEA_HEADLESS = "triplea.headless";
   public static final String BOT_GAME_HOST_COMMENT = "automated_host";

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -685,8 +685,8 @@ public class ServerGame extends AbstractGame {
     delegateRandomSource = null;
   }
 
-  public void stopGameSequence() {
-    delegateExecutionStopped = true;
+  public void stopGameSequence(String status, String title) {
+    delegateExecutionStopped = launchAction.promptGameStop(status, title);
   }
 
   public boolean isGameSequenceRunning() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LaunchAction.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LaunchAction.java
@@ -52,4 +52,12 @@ public interface LaunchAction {
   void handleError(String error);
 
   IServerStartupRemote getStartupRemote(IServerStartupRemote.ServerModelView serverModelView);
+
+  /**
+   * Method to call if the game should try to stop the game. Implementations may choose to prompt
+   * the user with a dialog to prevent stopping the game.
+   *
+   * @return true if the game should stop execution, false otherwise.
+   */
+  boolean promptGameStop(String status, String title);
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyDelegateBridge.java
@@ -116,5 +116,5 @@ public class ProDummyDelegateBridge implements IDelegateBridge {
   }
 
   @Override
-  public void stopGameSequence() {}
+  public void stopGameSequence(String status, String title) {}
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.PlayerList;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.message.IRemote;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
@@ -17,7 +16,6 @@ import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.triplea.ui.UiContext;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,9 +26,6 @@ import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.sound.SoundPath;
-import org.triplea.swing.EventThreadJOptionPane;
-import org.triplea.swing.EventThreadJOptionPane.ConfirmDialogType;
-import org.triplea.util.LocalizeHtml;
 
 /** A delegate used to check for end of game conditions. */
 public class EndRoundDelegate extends BaseTripleADelegate {
@@ -313,34 +308,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       bridge
           .getDisplayChannelBroadcaster()
           .reportMessageToAll(("<html>" + status + "</html>"), title, true, false, true);
-      final boolean stopGame;
-      if (GameRunner.headless()) {
-        // a terrible dirty hack, but I can't think of a better way to do it right now. If we are
-        // headless, end the game.
-        stopGame = true;
-      } else {
-        // now tell the HOST, and see if they want to continue the game.
-        String displayMessage =
-            LocalizeHtml.localizeImgLinksInHtml(status, UiContext.getMapLocation());
-        if (displayMessage.endsWith("</body>")) {
-          displayMessage =
-              displayMessage.substring(0, displayMessage.length() - "</body>".length())
-                  + "</br><p>Do you want to continue?</p></body>";
-        } else {
-          displayMessage = displayMessage + "</br><p>Do you want to continue?</p>";
-        }
-        // this is currently the ONLY instance of JOptionPane that is allowed outside of the UI
-        // classes. maybe there is a better way?
-        stopGame =
-            !EventThreadJOptionPane.showConfirmDialog(
-                null,
-                "<html>" + displayMessage + "</html>",
-                "Continue Game?  (" + title + ")",
-                ConfirmDialogType.YES_NO);
-      }
-      if (stopGame) {
-        bridge.stopGameSequence();
-      }
+      bridge.stopGameSequence(status, title);
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
@@ -109,7 +109,7 @@ public class GameDelegateBridge implements IDelegateBridge {
   }
 
   @Override
-  public void stopGameSequence() {
-    bridge.stopGameSequence();
+  public void stopGameSequence(String status, String title) {
+    bridge.stopGameSequence(status, title);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
@@ -155,7 +155,7 @@ public class DummyDelegateBridge implements IDelegateBridge {
   }
 
   @Override
-  public void stopGameSequence() {}
+  public void stopGameSequence(String status, String title) {}
 
   public MustFightBattle getBattle() {
     return battle;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
@@ -127,7 +127,7 @@ public class ObjectiveDummyDelegateBridge implements IDelegateBridge {
   public void addChange(final Change change) {}
 
   @Override
-  public void stopGameSequence() {}
+  public void stopGameSequence(String status, String title) {}
 
   static class DummyGameModifiedChannel implements IGameModifiedChannel {
     @Override

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedLaunchAction.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedLaunchAction.java
@@ -20,6 +20,7 @@ import games.strategy.net.Messengers;
 import games.strategy.triplea.TripleAPlayer;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.TripleAFrame;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.display.TripleADisplay;
 import java.awt.Component;
 import java.awt.Frame;
@@ -39,8 +40,10 @@ import org.triplea.sound.ClipPlayer;
 import org.triplea.sound.DefaultSoundChannel;
 import org.triplea.sound.ISound;
 import org.triplea.sound.SoundPath;
+import org.triplea.swing.EventThreadJOptionPane;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
+import org.triplea.util.LocalizeHtml;
 
 /**
  * Headed and default implementation of {@link LaunchAction}. Ideally replaceable with any other
@@ -185,5 +188,23 @@ public class HeadedLaunchAction implements LaunchAction {
   public IServerStartupRemote getStartupRemote(
       IServerStartupRemote.ServerModelView serverModelView) {
     return new HeadedServerStartupRemote(serverModelView);
+  }
+
+  @Override
+  public boolean promptGameStop(String status, String title) {
+    // now tell the HOST, and see if they want to continue the game.
+    String displayMessage = LocalizeHtml.localizeImgLinksInHtml(status, UiContext.getMapLocation());
+    if (displayMessage.endsWith("</body>")) {
+      displayMessage =
+          displayMessage.substring(0, displayMessage.length() - "</body>".length())
+              + "</br><p>Do you want to continue?</p></body>";
+    } else {
+      displayMessage = displayMessage + "</br><p>Do you want to continue?</p>";
+    }
+    return !EventThreadJOptionPane.showConfirmDialog(
+        null,
+        "<html>" + displayMessage + "</html>",
+        "Continue Game?  (" + title + ")",
+        EventThreadJOptionPane.ConfirmDialogType.YES_NO);
   }
 }

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -149,4 +149,9 @@ public class HeadlessLaunchAction implements LaunchAction {
       IServerStartupRemote.ServerModelView serverModelView) {
     return new HeadlessServerStartupRemote(serverModelView, headlessGameServer);
   }
+
+  @Override
+  public boolean promptGameStop(String status, String title) {
+    return true;
+  }
 }


### PR DESCRIPTION
There's a single place in the delegate code where UI was directly being used. This removes this usage by moving it into another interface implementation and removing another usage of `GameRunner#headless`