### PR TITLE
Rename MoveDescription fields to be clear what they're for.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -556,7 +556,7 @@ class ProNonCombatMoveAi {
       if (proTerritory.getCantMoveUnits().stream().noneMatch(Matches.unitIsOwnedBy(player))) {
         if (t.isWater()
             && proTerritory.getCantMoveUnits().stream()
-                .noneMatch(Matches.unitIsSeaTransportButNotCombatTransport())) {
+                .noneMatch(Matches.unitIsSeaTransportButNotCombatSeaTransport())) {
           unitOwnerMultiplier = 0;
         } else {
           unitOwnerMultiplier = 0.5;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -556,7 +556,7 @@ class ProNonCombatMoveAi {
       if (proTerritory.getCantMoveUnits().stream().noneMatch(Matches.unitIsOwnedBy(player))) {
         if (t.isWater()
             && proTerritory.getCantMoveUnits().stream()
-                .noneMatch(Matches.unitIsTransportButNotCombatTransport())) {
+                .noneMatch(Matches.unitIsSeaTransportButNotCombatTransport())) {
           unitOwnerMultiplier = 0;
         } else {
           unitOwnerMultiplier = 0.5;
@@ -1188,7 +1188,7 @@ class ProNonCombatMoveAi {
       t.addUnits(t.getTempUnits());
       t.putAllAmphibAttackMap(t.getTempAmphibAttackMap());
       for (final Unit u : t.getTempUnits()) {
-        if (Matches.unitIsTransport().test(u)) {
+        if (Matches.unitIsSeaTransport().test(u)) {
           transportMoveMap.remove(u);
           transportMapList.removeIf(proTransport -> proTransport.getTransport().equals(u));
         } else {
@@ -1817,7 +1817,7 @@ class ProNonCombatMoveAi {
       t.addUnits(t.getTempUnits());
       t.putAllAmphibAttackMap(t.getTempAmphibAttackMap());
       for (final Unit u : t.getTempUnits()) {
-        if (Matches.unitIsTransport().test(u)) {
+        if (Matches.unitIsSeaTransport().test(u)) {
           transportMoveMap.remove(u);
           transportMapList.removeIf(proTransport -> proTransport.getTransport().equals(u));
         } else {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -1407,8 +1407,10 @@ class ProPurchaseAi {
       final List<Unit> units = new ArrayList<>(placeTerritory.getDefendingUnits());
       units.addAll(ProPurchaseUtils.getPlaceUnits(t, purchaseTerritories));
       final List<Unit> myUnits = CollectionUtils.getMatches(units, Matches.unitIsOwnedBy(player));
-      final int numMyTransports = CollectionUtils.countMatches(myUnits, Matches.unitIsTransport());
-      final int numSeaDefenders = CollectionUtils.countMatches(units, Matches.unitIsNotTransport());
+      final int numMyTransports =
+          CollectionUtils.countMatches(myUnits, Matches.unitIsSeaTransport());
+      final int numSeaDefenders =
+          CollectionUtils.countMatches(units, Matches.unitIsNotSeaTransport());
 
       // Determine needed defense strength
       int needDefenders = 0;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -113,7 +113,7 @@ final class ProTechAi {
       final Predicate<Unit> enemyTransport =
           Matches.unitIsOwnedBy(enemyPlayer)
               .and(Matches.unitIsSea())
-              .and(Matches.unitIsTransport())
+              .and(Matches.unitIsSeaTransport())
               .and(Matches.unitCanMove());
       final Predicate<Unit> enemyShip =
           Matches.unitIsOwnedBy(enemyPlayer).and(Matches.unitIsSea()).and(Matches.unitCanMove());
@@ -123,7 +123,7 @@ final class ProTechAi {
               .and(Matches.unitIsNotAa())
               .and(Matches.unitCanMove());
       final Predicate<Unit> transport =
-          Matches.unitIsSea().and(Matches.unitIsTransport()).and(Matches.unitCanMove());
+          Matches.unitIsSea().and(Matches.unitIsSeaTransport()).and(Matches.unitCanMove());
       final List<Territory> enemyFighterTerritories = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0;
       // should change this to read production frontier and tech
@@ -270,7 +270,7 @@ final class ProTechAi {
       if (onWater) {
         final Iterator<Unit> enemyWaterUnitsIter = enemyWaterUnits.iterator();
         while (enemyWaterUnitsIter.hasNext() && !nonTransportsInAttack) {
-          if (Matches.unitIsNotTransport().test(enemyWaterUnitsIter.next())) {
+          if (Matches.unitIsNotSeaTransport().test(enemyWaterUnitsIter.next())) {
             nonTransportsInAttack = true;
           }
         }
@@ -553,7 +553,7 @@ final class ProTechAi {
       return null;
     }
     final Predicate<Unit> transport =
-        Matches.unitIsTransport().negate().and(Matches.unitIsLand().negate());
+        Matches.unitIsSeaTransport().negate().and(Matches.unitIsLand().negate());
     final Predicate<Unit> unitCond =
         PredicateBuilder.of(Matches.unitIsInfrastructure().negate())
             .and(Matches.alliedUnit(player).negate())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -361,7 +361,7 @@ public class ProTerritoryManager {
     for (final ProTerritory patd : attackOptions.getTerritoryMap().values()) {
       movedTransports.addAll(patd.getAmphibAttackMap().keySet());
       movedTransports.addAll(
-          CollectionUtils.getMatches(patd.getUnits(), Matches.unitIsTransport()));
+          CollectionUtils.getMatches(patd.getUnits(), Matches.unitIsSeaTransport()));
     }
     return movedTransports.size() >= attackOptions.getTransportList().size();
   }
@@ -804,7 +804,7 @@ public class ProTerritoryManager {
           proData.getProTerritory(moveMap, potentialTerritory).addMaxUnit(mySeaUnit);
 
           // Populate appropriate unit move options map
-          if (Matches.unitIsTransport().test(mySeaUnit)) {
+          if (Matches.unitIsSeaTransport().test(mySeaUnit)) {
             transportMoveMap
                 .computeIfAbsent(mySeaUnit, k -> new HashSet<>())
                 .add(potentialTerritory);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
@@ -104,7 +104,7 @@ public class MoveBatcher {
   }
 
   private static boolean isTransportLoad(final MoveDescription move) {
-    return !move.getUnitsToTransports().isEmpty();
+    return !move.getUnitsToSeaTransports().isEmpty();
   }
 
   // Merges the two moves. Caller must ensure canMergeMoves() is true before calling.
@@ -115,8 +115,8 @@ public class MoveBatcher {
     }
     final var units = new ArrayList<>(move1.getUnits());
     units.addAll(move2.getUnits());
-    final var unitsToTransports = new HashMap<>(move1.getUnitsToTransports());
-    unitsToTransports.putAll(move2.getUnitsToTransports());
-    return new MoveDescription(units, move1.getRoute(), unitsToTransports);
+    final var unitsToSeaTransports = new HashMap<>(move1.getUnitsToSeaTransports());
+    unitsToSeaTransports.putAll(move2.getUnitsToSeaTransports());
+    return new MoveDescription(units, move1.getRoute(), unitsToSeaTransports);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -120,7 +120,7 @@ public final class ProBattleUtils {
     if (Properties.getTransportCasualtiesRestricted(data.getProperties())) {
       unitsThatCanFight =
           CollectionUtils.getMatches(
-              unitsThatCanFight, Matches.unitIsTransportButNotCombatTransport().negate());
+              unitsThatCanFight, Matches.unitIsSeaTransportButNotCombatTransport().negate());
     }
     final int myHitPoints = CasualtyUtil.getTotalHitpointsLeft(unitsThatCanFight);
     final double myPower = estimatePower(t, myUnits, enemyUnits, attacking);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -120,7 +120,7 @@ public final class ProBattleUtils {
     if (Properties.getTransportCasualtiesRestricted(data.getProperties())) {
       unitsThatCanFight =
           CollectionUtils.getMatches(
-              unitsThatCanFight, Matches.unitIsSeaTransportButNotCombatTransport().negate());
+              unitsThatCanFight, Matches.unitIsSeaTransportButNotCombatSeaTransport().negate());
     }
     final int myHitPoints = CasualtyUtil.getTotalHitpointsLeft(unitsThatCanFight);
     final double myPower = estimatePower(t, myUnits, enemyUnits, attacking);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -458,7 +458,7 @@ public final class ProMatches {
       final GamePlayer player, final boolean isCombatMove) {
     return u ->
         (!isCombatMove || !Matches.unitCanNotMoveDuringCombatMove().test(u))
-            && unitCanBeMovedAndIsOwned(player).and(Matches.unitIsTransport()).test(u);
+            && unitCanBeMovedAndIsOwned(player).and(Matches.unitIsSeaTransport()).test(u);
   }
 
   public static Predicate<Unit> unitCanBeMovedAndIsOwnedBombard(final GamePlayer player) {
@@ -554,7 +554,7 @@ public final class ProMatches {
   }
 
   public static Predicate<Unit> unitIsOwnedTransport(final GamePlayer player) {
-    return Matches.unitIsOwnedBy(player).and(Matches.unitIsTransport());
+    return Matches.unitIsOwnedBy(player).and(Matches.unitIsSeaTransport());
   }
 
   public static Predicate<Unit> unitIsOwnedTransportableUnit(final GamePlayer player) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -420,7 +420,7 @@ public final class ProMoveUtils {
     // Group non-amphib units of the same type moving on the same route
     // TODO: #5499 Use MoveBatcher here - or ideally at the time the moves are being generated.
     final boolean noTransportLoads =
-        moves.stream().allMatch(move -> move.getUnitsToTransports().isEmpty());
+        moves.stream().allMatch(move -> move.getUnitsToSeaTransports().isEmpty());
     if (noTransportLoads) {
       for (int i = 0; i < moves.size(); i++) {
         final Route r = moves.get(i).getRoute();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -719,7 +719,7 @@ public class WeakAi extends AbstractBuiltInAi {
 
   private static int countTransports(final GameState data, final GamePlayer player) {
     final Predicate<Unit> ownedTransport =
-        Matches.unitIsTransport().and(Matches.unitIsOwnedBy(player));
+        Matches.unitIsSeaTransport().and(Matches.unitIsOwnedBy(player));
     return Streams.stream(data.getMap())
         .map(Territory::getUnitCollection)
         .mapToInt(c -> c.countMatches(ownedTransport))

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -171,7 +171,7 @@ public class WeakAi extends AbstractBuiltInAi {
         continue;
       }
       final List<Unit> units = new ArrayList<>();
-      final Map<Unit, Unit> transportMap = new HashMap<>();
+      final Map<Unit, Unit> unitsToSeaTransports = new HashMap<>();
       for (final Unit transport :
           neighbor.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player))) {
         int free = TransportTracker.getAvailableCapacity(transport);
@@ -189,13 +189,13 @@ public class WeakAi extends AbstractBuiltInAi {
             iter.remove();
             free -= ua.getTransportCost();
             units.add(current);
-            transportMap.put(current, transport);
+            unitsToSeaTransports.put(current, transport);
           }
         }
       }
       if (!units.isEmpty()) {
         final Route route = new Route(capitol, neighbor);
-        moves.add(new MoveDescription(units, route, transportMap, Map.of()));
+        moves.add(new MoveDescription(units, route, unitsToSeaTransports, Map.of()));
       }
     }
     return moves;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -903,7 +903,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     return Matches.enemyUnitOfAnyOfThesePlayers(players)
         .and(Matches.unitIsSea())
         .and(Matches.unitCanEvade().negate())
-        .and(Matches.unitIsNotTransportButCouldBeCombatTransport());
+        .and(Matches.unitIsNotSeaTransportButCouldBeCombatSeaTransport());
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -86,7 +86,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
         return "Can't add mixed nationality units to water";
       }
       final Predicate<Unit> friendlySeaTransports =
-          Matches.unitIsTransport().and(Matches.unitIsSea()).and(Matches.alliedUnit(player));
+          Matches.unitIsSeaTransport().and(Matches.unitIsSea()).and(Matches.alliedUnit(player));
       final Collection<Unit> seaTransports =
           CollectionUtils.getMatches(units, friendlySeaTransports);
       final Collection<Unit> landUnitsToAdd =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -60,7 +60,7 @@ final class EditValidator {
             return "Can't add mixed nationality units to water";
           }
           final Predicate<Unit> friendlySeaTransports =
-              Matches.unitIsTransport().and(Matches.unitIsSea()).and(Matches.alliedUnit(player));
+              Matches.unitIsSeaTransport().and(Matches.unitIsSea()).and(Matches.alliedUnit(player));
           final Collection<Unit> seaTransports =
               CollectionUtils.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -112,7 +112,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
       }
       // map transports, try to fill
       final Collection<Unit> transports =
-          CollectionUtils.getMatches(units, Matches.unitIsTransport());
+          CollectionUtils.getMatches(units, Matches.unitIsSeaTransport());
       final Collection<Unit> land = CollectionUtils.getMatches(units, Matches.unitIsLand());
       for (final Unit toLoad : land) {
         final UnitAttachment ua = toLoad.getUnitAttachment();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -147,7 +147,7 @@ public final class Matches {
     return unitIsCombatSeaTransport().negate();
   }
 
-  public static Predicate<Unit> unitIsSeaTransportButNotCombatTransport() {
+  public static Predicate<Unit> unitIsSeaTransportButNotCombatSeaTransport() {
     return unit -> {
       final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport();
@@ -1512,7 +1512,7 @@ public final class Matches {
 
   public static Predicate<Territory> territoryIsBlockedSea(final GamePlayer player) {
     final Predicate<Unit> transport =
-        unitIsSeaTransportButNotCombatTransport().negate().and(unitIsLand().negate());
+        unitIsSeaTransportButNotCombatSeaTransport().negate().and(unitIsLand().negate());
     final Predicate<Unit> unitCond =
         PredicateBuilder.of(unitIsInfrastructure().negate())
             .and(alliedUnit(player).negate())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -136,25 +136,25 @@ public final class Matches {
     return unit -> !unit.getUnitAttachment().getCanNotBeTargetedBy().isEmpty();
   }
 
-  private static Predicate<Unit> unitIsCombatTransport() {
+  private static Predicate<Unit> unitIsCombatSeaTransport() {
     return unit -> {
       final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getIsCombatTransport() && ua.getIsSea();
     };
   }
 
-  public static Predicate<Unit> unitIsNotCombatTransport() {
-    return unitIsCombatTransport().negate();
+  public static Predicate<Unit> unitIsNotCombatSeaTransport() {
+    return unitIsCombatSeaTransport().negate();
   }
 
-  public static Predicate<Unit> unitIsTransportButNotCombatTransport() {
+  public static Predicate<Unit> unitIsSeaTransportButNotCombatTransport() {
     return unit -> {
       final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport();
     };
   }
 
-  public static Predicate<Unit> unitIsNotTransportButCouldBeCombatTransport() {
+  public static Predicate<Unit> unitIsNotSeaTransportButCouldBeCombatSeaTransport() {
     return unit -> {
       final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getTransportCapacity() == -1 || (ua.getIsCombatTransport() && ua.getIsSea());
@@ -169,18 +169,18 @@ public final class Matches {
     return type -> type.getUnitAttachment().getIsDestroyer();
   }
 
-  public static Predicate<Unit> unitIsTransport() {
+  public static Predicate<Unit> unitIsSeaTransport() {
     return unit -> {
       final UnitAttachment ua = unit.getUnitAttachment();
       return ua.getTransportCapacity() != -1 && ua.getIsSea();
     };
   }
 
-  public static Predicate<Unit> unitIsNotTransport() {
-    return unitIsTransport().negate();
+  public static Predicate<Unit> unitIsNotSeaTransport() {
+    return unitIsSeaTransport().negate();
   }
 
-  public static Predicate<Unit> unitIsTransportAndNotDestroyer() {
+  public static Predicate<Unit> unitIsSeaTransportAndNotDestroyer() {
     return unit -> {
       final UnitAttachment ua = unit.getUnitAttachment();
       return !unitIsDestroyer().test(unit) && ua.getTransportCapacity() != -1 && ua.getIsSea();
@@ -1512,7 +1512,7 @@ public final class Matches {
 
   public static Predicate<Territory> territoryIsBlockedSea(final GamePlayer player) {
     final Predicate<Unit> transport =
-        unitIsTransportButNotCombatTransport().negate().and(unitIsLand().negate());
+        unitIsSeaTransportButNotCombatTransport().negate().and(unitIsLand().negate());
     final Predicate<Unit> unitCond =
         PredicateBuilder.of(unitIsInfrastructure().negate())
             .and(alliedUnit(player).negate())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -46,7 +46,7 @@ public class MovePerformer implements Serializable {
   private AaInMoveUtil aaInMoveUtil;
   private final ExecutionStack executionStack = new ExecutionStack();
   private UndoableMove currentMove;
-  private Map<Unit, Collection<Unit>> newDependents;
+  private Map<Unit, Collection<Unit>> airTransportDependents;
   private Collection<Unit> arrivingUnits;
 
   MovePerformer() {}
@@ -75,8 +75,8 @@ public class MovePerformer implements Serializable {
   void moveUnits(
       final MoveDescription move, final GamePlayer gamePlayer, final UndoableMove currentMove) {
     this.currentMove = currentMove;
-    this.newDependents = move.getDependentUnits();
-    populateStack(move.getUnits(), move.getRoute(), gamePlayer, move.getUnitsToTransports());
+    this.airTransportDependents = move.getAirTransportsDependents();
+    populateStack(move.getUnits(), move.getRoute(), gamePlayer, move.getUnitsToSeaTransports());
     executionStack.execute(bridge);
   }
 
@@ -129,7 +129,8 @@ public class MovePerformer implements Serializable {
                   aaCasualtiesWithDependents.addAll(dependents);
                 }
                 // we might have new dependents too (ie: paratroopers)
-                final Collection<Unit> newDependents = MovePerformer.this.newDependents.get(u);
+                final Collection<Unit> newDependents =
+                    MovePerformer.this.airTransportDependents.get(u);
                 if (newDependents != null) {
                   aaCasualtiesWithDependents.addAll(newDependents);
                 }
@@ -389,7 +390,7 @@ public class MovePerformer implements Serializable {
             MoveValidator.getDependents(
                 CollectionUtils.getMatches(arrived, Matches.unitCanTransport())));
     // add newly created dependents
-    for (final Entry<Unit, Collection<Unit>> entry : newDependents.entrySet()) {
+    for (final Entry<Unit, Collection<Unit>> entry : airTransportDependents.entrySet()) {
       Collection<Unit> dependents = dependentAirTransportableUnits.get(entry.getKey());
       if (dependents != null) {
         dependents = new ArrayList<>(dependents);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -248,11 +248,11 @@ public class MovePerformer implements Serializable {
               // Ignore Trn on Trn forces.
               if (Properties.getIgnoreTransportInMovement(bridge.getData().getProperties())) {
                 final boolean allOwnedTransports =
-                    arrived.stream().allMatch(Matches.unitIsSeaTransportButNotCombatTransport());
+                    arrived.stream().allMatch(Matches.unitIsSeaTransportButNotCombatSeaTransport());
                 final boolean allEnemyTransports =
                     !enemyUnits.isEmpty()
                         && enemyUnits.stream()
-                            .allMatch(Matches.unitIsSeaTransportButNotCombatTransport());
+                            .allMatch(Matches.unitIsSeaTransportButNotCombatSeaTransport());
                 // If everybody is a transport, don't create a battle
                 if (allOwnedTransports && allEnemyTransports) {
                   ignoreBattle = true;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -129,10 +129,10 @@ public class MovePerformer implements Serializable {
                   aaCasualtiesWithDependents.addAll(dependents);
                 }
                 // we might have new dependents too (ie: paratroopers)
-                final Collection<Unit> newDependents =
+                final Collection<Unit> airTransportDependents =
                     MovePerformer.this.airTransportDependents.get(u);
-                if (newDependents != null) {
-                  aaCasualtiesWithDependents.addAll(newDependents);
+                if (airTransportDependents != null) {
+                  aaCasualtiesWithDependents.addAll(airTransportDependents);
                 }
               }
             }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -248,11 +248,11 @@ public class MovePerformer implements Serializable {
               // Ignore Trn on Trn forces.
               if (Properties.getIgnoreTransportInMovement(bridge.getData().getProperties())) {
                 final boolean allOwnedTransports =
-                    arrived.stream().allMatch(Matches.unitIsTransportButNotCombatTransport());
+                    arrived.stream().allMatch(Matches.unitIsSeaTransportButNotCombatTransport());
                 final boolean allEnemyTransports =
                     !enemyUnits.isEmpty()
                         && enemyUnits.stream()
-                            .allMatch(Matches.unitIsTransportButNotCombatTransport());
+                            .allMatch(Matches.unitIsSeaTransportButNotCombatTransport());
                 // If everybody is a transport, don't create a battle
                 if (allOwnedTransports && allEnemyTransports) {
                   ignoreBattle = true;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -101,7 +101,7 @@ abstract class AbstractBattle implements IBattle {
   void clearTransportedBy(final IDelegateBridge bridge) {
     // Clear the transported_by for successfully off loaded units
     final Collection<Unit> transports =
-        CollectionUtils.getMatches(attackingUnits, Matches.unitIsTransport());
+        CollectionUtils.getMatches(attackingUnits, Matches.unitIsSeaTransport());
     if (!transports.isEmpty()) {
       final CompositeChange change = new CompositeChange();
       final Collection<Unit> dependents = getTransportDependents(transports);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -415,7 +415,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final GameData data = bridge.getData();
     final boolean ignoreTransports = Properties.getIgnoreTransportInMovement(data.getProperties());
     final Predicate<Unit> seaTransports =
-        Matches.unitIsTransportButNotCombatTransport().and(Matches.unitIsSea());
+        Matches.unitIsSeaTransportButNotCombatTransport().and(Matches.unitIsSea());
     final Predicate<Unit> seaTranportsOrSubs = seaTransports.or(Matches.unitCanEvade());
     // we want to match all sea zones with our units and enemy units
     final Predicate<Territory> anyTerritoryWithOwnAndEnemy =
@@ -876,7 +876,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         battle = battleTracker.getPendingBattle(to, BattleType.NORMAL);
         if (battle instanceof MustFightBattle) {
           final MustFightBattle mfb = (MustFightBattle) battle;
-          if (attackingUnits.stream().anyMatch(Matches.unitIsTransport())) {
+          if (attackingUnits.stream().anyMatch(Matches.unitIsSeaTransport())) {
             // need to reload the transports since unload only happens after amphibious sea battles
             // are finished
             final CompositeChange reloadTransportChange = new CompositeChange();
@@ -1229,7 +1229,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final Predicate<Unit> canBeAttackedDefault =
         Matches.unitIsOwnedBy(player)
             .and(Matches.unitIsSea())
-            .and(Matches.unitIsNotTransportButCouldBeCombatTransport())
+            .and(Matches.unitIsNotSeaTransportButCouldBeCombatSeaTransport())
             .and(Matches.unitCanEvade().negate());
     final boolean onlyWhereThereAreBattlesOrAmphibious =
         Properties.getKamikazeSuicideAttacksOnlyWhereBattlesAre(data.getProperties());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -415,7 +415,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final GameData data = bridge.getData();
     final boolean ignoreTransports = Properties.getIgnoreTransportInMovement(data.getProperties());
     final Predicate<Unit> seaTransports =
-        Matches.unitIsSeaTransportButNotCombatTransport().and(Matches.unitIsSea());
+        Matches.unitIsSeaTransportButNotCombatSeaTransport().and(Matches.unitIsSea());
     final Predicate<Unit> seaTranportsOrSubs = seaTransports.or(Matches.unitCanEvade());
     // we want to match all sea zones with our units and enemy units
     final Predicate<Territory> anyTerritoryWithOwnAndEnemy =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -548,8 +548,8 @@ public class BattleTracker implements Serializable {
               - CollectionUtils.countMatches(arrivedUnits, Matches.unitIsSubmerged());
       // If transports are restricted from controlling sea zones, subtract them
       final Predicate<Unit> transportsCanNotControl =
-          Matches.unitIsTransportAndNotDestroyer()
-              .and(Matches.unitIsTransportButNotCombatTransport());
+          Matches.unitIsSeaTransportAndNotDestroyer()
+              .and(Matches.unitIsSeaTransportButNotCombatTransport());
       if (!Properties.getTransportControlSeaZone(data.getProperties())) {
         totalMatches -= CollectionUtils.countMatches(arrivedUnits, transportsCanNotControl);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -549,7 +549,7 @@ public class BattleTracker implements Serializable {
       // If transports are restricted from controlling sea zones, subtract them
       final Predicate<Unit> transportsCanNotControl =
           Matches.unitIsSeaTransportAndNotDestroyer()
-              .and(Matches.unitIsSeaTransportButNotCombatTransport());
+              .and(Matches.unitIsSeaTransportButNotCombatSeaTransport());
       if (!Properties.getTransportControlSeaZone(data.getProperties())) {
         totalMatches -= CollectionUtils.countMatches(arrivedUnits, transportsCanNotControl);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -832,7 +832,7 @@ public class MustFightBattle extends DependentBattle
             .and(Matches.unitCanBeMovedThroughByEnemies().negate())
             .andIf(
                 Properties.getIgnoreTransportInMovement(gameData.getProperties()),
-                Matches.unitIsNotTransportButCouldBeCombatTransport())
+                Matches.unitIsNotSeaTransportButCouldBeCombatSeaTransport())
             .build();
     Collection<Territory> possible =
         CollectionUtils.getMatches(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
@@ -77,11 +77,11 @@ public class UnitBattleComparator implements Comparator<Unit> {
     final boolean airOrCarrierOrTransport1 =
         Matches.unitIsAir().test(u1)
             || Matches.unitIsCarrier().test(u1)
-            || (!transporting1 && Matches.unitIsTransport().test(u1));
+            || (!transporting1 && Matches.unitIsSeaTransport().test(u1));
     final boolean airOrCarrierOrTransport2 =
         Matches.unitIsAir().test(u2)
             || Matches.unitIsCarrier().test(u2)
-            || (!transporting2 && Matches.unitIsTransport().test(u2));
+            || (!transporting2 && Matches.unitIsSeaTransport().test(u2));
     final boolean subDestroyer1 =
         Matches.unitHasSubBattleAbilities().test(u1) || Matches.unitIsDestroyer().test(u1);
     final boolean subDestroyer2 =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
@@ -31,6 +31,6 @@ public class RetreatChecks {
       final @Nonnull Collection<Unit> units, final @Nonnull GameState gameData) {
     return Properties.getTransportCasualtiesRestricted(gameData.getProperties())
         && !units.isEmpty()
-        && units.stream().allMatch(Matches.unitIsSeaTransportButNotCombatTransport());
+        && units.stream().allMatch(Matches.unitIsSeaTransportButNotCombatSeaTransport());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
@@ -31,6 +31,6 @@ public class RetreatChecks {
       final @Nonnull Collection<Unit> units, final @Nonnull GameState gameData) {
     return Properties.getTransportCasualtiesRestricted(gameData.getProperties())
         && !units.isEmpty()
-        && units.stream().allMatch(Matches.unitIsTransportButNotCombatTransport());
+        && units.stream().allMatch(Matches.unitIsSeaTransportButNotCombatTransport());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnits.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnits.java
@@ -36,9 +36,9 @@ public class RemoveUnprotectedUnits implements BattleStep {
   public List<String> getNames() {
     if (battleState.getBattleSite().isWater()
         && Properties.getTransportCasualtiesRestricted(battleState.getGameData().getProperties())
-        && (battleState.filterUnits(ALIVE, OFFENSE).stream().anyMatch(Matches.unitIsTransport())
+        && (battleState.filterUnits(ALIVE, OFFENSE).stream().anyMatch(Matches.unitIsSeaTransport())
             || battleState.filterUnits(ALIVE, DEFENSE).stream()
-                .anyMatch(Matches.unitIsTransport()))) {
+                .anyMatch(Matches.unitIsSeaTransport()))) {
       return List.of(REMOVE_UNESCORTED_TRANSPORTS);
     }
     return List.of();
@@ -103,8 +103,8 @@ public class RemoveUnprotectedUnits implements BattleStep {
 
   private List<Unit> getAlliedTransports(final GamePlayer player) {
     final Predicate<Unit> matchAllied =
-        Matches.unitIsTransport()
-            .and(Matches.unitIsNotCombatTransport())
+        Matches.unitIsSeaTransport()
+            .and(Matches.unitIsNotCombatSeaTransport())
             .and(Matches.isUnitAllied(player))
             .and(Matches.unitIsSea());
     return CollectionUtils.getMatches(battleState.getBattleSite().getUnits(), matchAllied);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
@@ -100,7 +100,7 @@ public class SelectMainBattleCasualties
                       .or(Matches.unitIsNotSea())),
               CollectionUtils.getMatches(
                   step.getFiringGroup().getTargetUnits(),
-                  Matches.unitIsSeaTransportButNotCombatTransport().and(Matches.unitIsSea())));
+                  Matches.unitIsSeaTransportButNotCombatSeaTransport().and(Matches.unitIsSea())));
     } else {
       targetUnits =
           TargetUnits.of(new ArrayList<>(step.getFiringGroup().getTargetUnits()), List.of());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
@@ -96,10 +96,11 @@ public class SelectMainBattleCasualties
           TargetUnits.of(
               CollectionUtils.getMatches(
                   step.getFiringGroup().getTargetUnits(),
-                  Matches.unitIsNotTransportButCouldBeCombatTransport().or(Matches.unitIsNotSea())),
+                  Matches.unitIsNotSeaTransportButCouldBeCombatSeaTransport()
+                      .or(Matches.unitIsNotSea())),
               CollectionUtils.getMatches(
                   step.getFiringGroup().getTargetUnits(),
-                  Matches.unitIsTransportButNotCombatTransport().and(Matches.unitIsSea())));
+                  Matches.unitIsSeaTransportButNotCombatTransport().and(Matches.unitIsSea())));
     } else {
       targetUnits =
           TargetUnits.of(new ArrayList<>(step.getFiringGroup().getTargetUnits()), List.of());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/RetreaterGeneral.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/RetreaterGeneral.java
@@ -109,7 +109,7 @@ class RetreaterGeneral implements Retreater {
       final Collection<Unit> units, final Territory retreatTo) {
     final CompositeChange change = new CompositeChange();
     final Collection<Unit> transports =
-        CollectionUtils.getMatches(units, Matches.unitIsTransport());
+        CollectionUtils.getMatches(units, Matches.unitIsSeaTransport());
     for (final Unit transport : transports) {
       final Collection<Unit> retreated = battleState.getTransportDependents(List.of(transport));
       if (!retreated.isEmpty()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -972,7 +972,7 @@ public class MoveValidator {
       final Route route, final GamePlayer player, final boolean ignoreRouteEnd) {
     final Predicate<Unit> transportOnly =
         Matches.unitIsInfrastructure()
-            .or(Matches.unitIsTransportButNotCombatTransport())
+            .or(Matches.unitIsSeaTransportButNotCombatTransport())
             .or(Matches.unitIsLand())
             .or(Matches.enemyUnit(player).negate());
     final Predicate<Unit> subOnly =
@@ -1052,7 +1052,7 @@ public class MoveValidator {
       // etc...)
       final List<Unit> transports =
           CollectionUtils.getMatches(
-              units, Matches.unitIsTransport().or(Matches.unitIsAirTransport()));
+              units, Matches.unitIsSeaTransport().or(Matches.unitIsAirTransport()));
       final List<Unit> transportable =
           CollectionUtils.getMatches(
               units, Matches.unitCanBeTransported().or(Matches.unitIsAirTransportable()));
@@ -1189,7 +1189,7 @@ public class MoveValidator {
       final Predicate<Unit> ownedSeaNonTransportMatch =
           Matches.unitIsOwnedBy(player)
               .and(Matches.unitIsSea())
-              .and(Matches.unitIsNotTransportButCouldBeCombatTransport());
+              .and(Matches.unitIsNotSeaTransportButCouldBeCombatSeaTransport());
       for (final Unit transport : transports) {
         if (!isNonCombat) {
           if (Matches.territoryHasEnemyUnits(player).test(routeEnd)
@@ -1578,7 +1578,7 @@ public class MoveValidator {
       final Territory start, final Collection<Unit> units) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
     final Collection<Unit> transports =
-        CollectionUtils.getMatches(units, Matches.unitIsTransport());
+        CollectionUtils.getMatches(units, Matches.unitIsSeaTransport());
     for (final Unit transport : transports) {
       final Collection<Unit> transporting = transport.getTransporting(start);
       mustMoveWith.put(transport, new ArrayList<>(transporting));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -95,8 +95,8 @@ public class MoveValidator {
       final MoveDescription move, final GamePlayer player, final List<UndoableMove> undoableMoves) {
     final Collection<Unit> units = move.getUnits();
     final Route route = move.getRoute();
-    final Map<Unit, Unit> unitsToTransports = move.getUnitsToTransports();
-    final Map<Unit, Collection<Unit>> newDependents = move.getDependentUnits();
+    final Map<Unit, Unit> unitsToSeaTransports = move.getUnitsToSeaTransports();
+    final Map<Unit, Collection<Unit>> airTransportDependents = move.getAirTransportsDependents();
     final MoveValidationResult result = new MoveValidationResult();
     if (route.hasNoSteps()) {
       return result;
@@ -116,21 +116,22 @@ public class MoveValidator {
     if (validateNonEnemyUnitsOnPath(units, route, player, result).hasError()) {
       return result;
     }
-    if (validateBasic(units, route, player, unitsToTransports, newDependents, result).hasError()) {
+    if (validateBasic(units, route, player, unitsToSeaTransports, airTransportDependents, result)
+        .hasError()) {
       return result;
     }
     if (AirMovementValidator.validateAirCanLand(units, route, player, result).hasError()) {
       return result;
     }
     if (validateTransport(
-            isNonCombat, undoableMoves, units, route, player, unitsToTransports, result)
+            isNonCombat, undoableMoves, units, route, player, unitsToSeaTransports, result)
         .hasError()) {
       return result;
     }
     if (validateParatroops(isNonCombat, units, route, player, result).hasError()) {
       return result;
     }
-    if (validateCanal(units, route, player, newDependents, result).hasError()) {
+    if (validateCanal(units, route, player, airTransportDependents, result).hasError()) {
       return result;
     }
     if (validateFuel(units, route, player, result).hasError()) {
@@ -267,13 +268,13 @@ public class MoveValidator {
       final Collection<Unit> units,
       final Route route,
       final GamePlayer player,
-      final Map<Unit, Collection<Unit>> newDependents,
+      final Map<Unit, Collection<Unit>> airTransportDependents,
       final MoveValidationResult result) {
     if (getEditMode(data.getProperties())) {
       return result;
     }
     // TODO: merge validateCanal here and provide granular unit warnings
-    return result.setErrorReturnResult(validateCanal(route, units, newDependents, player));
+    return result.setErrorReturnResult(validateCanal(route, units, airTransportDependents, player));
   }
 
   /**
@@ -290,7 +291,7 @@ public class MoveValidator {
   String validateCanal(
       final Route route,
       @Nullable final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> newDependents,
+      final Map<Unit, Collection<Unit>> airTransportDependents,
       final GamePlayer player) {
     // Check each unit 1 by 1 to see if they can move through necessary canals on route
     String result = null;
@@ -298,7 +299,7 @@ public class MoveValidator {
     final Set<Unit> setWithNull = new HashSet<>();
     setWithNull.add(null);
     final Collection<Unit> unitsWithoutDependents =
-        (units == null) ? setWithNull : findNonDependentUnits(units, route, newDependents);
+        (units == null) ? setWithNull : findNonDependentUnits(units, route, airTransportDependents);
     for (final Unit unit : unitsWithoutDependents) {
       for (final Territory t : route.getAllTerritories()) {
         Optional<String> failureMessage = Optional.empty();
@@ -694,13 +695,13 @@ public class MoveValidator {
       final Collection<Unit> units,
       final Route route,
       final GamePlayer player,
-      final Map<Unit, Unit> unitToTransport,
-      final Map<Unit, Collection<Unit>> newDependents,
+      final Map<Unit, Unit> unitsToSeaTransports,
+      final Map<Unit, Collection<Unit>> airTransportDependents,
       final MoveValidationResult result) {
     final boolean isEditMode = getEditMode(data.getProperties());
     // make sure transports in the destination
-    if (!route.getEnd().getUnitCollection().containsAll(unitToTransport.values())
-        && !units.containsAll(unitToTransport.values())) {
+    if (!route.getEnd().getUnitCollection().containsAll(unitsToSeaTransports.values())
+        && !units.containsAll(unitsToSeaTransports.values())) {
       return result.setErrorReturnResult("Transports not found in route end");
     }
     if (!isEditMode) {
@@ -711,9 +712,9 @@ public class MoveValidator {
       }
 
       // Ensure all air transports are included
-      for (final Unit airTransport : newDependents.keySet()) {
+      for (final Unit airTransport : airTransportDependents.keySet()) {
         if (!units.contains(airTransport)) {
-          for (final Unit unit : newDependents.get(airTransport)) {
+          for (final Unit unit : airTransportDependents.get(airTransport)) {
             if (units.contains(unit)) {
               result.addDisallowedUnit("Not all units have enough movement", unit);
             }
@@ -723,7 +724,7 @@ public class MoveValidator {
 
       // Check that units have enough movement considering land transports
       final Collection<Unit> unitsWithoutDependents =
-          findNonDependentUnits(units, route, newDependents);
+          findNonDependentUnits(units, route, airTransportDependents);
       final Set<Unit> unitsWithEnoughMovement =
           unitsWithoutDependents.stream()
               .filter(unit -> Matches.unitHasEnoughMovementForRoute(route).test(unit))
@@ -861,13 +862,15 @@ public class MoveValidator {
   private static Collection<Unit> findNonDependentUnits(
       final Collection<Unit> units,
       final Route route,
-      final Map<Unit, Collection<Unit>> newDependents) {
+      final Map<Unit, Collection<Unit>> airTransportDependents) {
     final Map<Unit, Collection<Unit>> dependentsMap =
         getDependents(CollectionUtils.getMatches(units, Matches.unitCanTransport()));
     final Set<Unit> dependents =
         dependentsMap.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
     dependents.addAll(
-        newDependents.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()));
+        airTransportDependents.values().stream()
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet()));
     final Collection<Unit> unitsWithoutDependents = new ArrayList<>();
     unitsWithoutDependents.addAll(route.getStart().isWater() ? getNonLand(units) : units);
     unitsWithoutDependents.removeAll(dependents);
@@ -1034,11 +1037,11 @@ public class MoveValidator {
   // TODO KEV revise these to include paratroop load/unload
   public static boolean isLoad(
       final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> newDependents,
+      final Map<Unit, Collection<Unit>> airTransportDependents,
       final Route route,
       final GamePlayer player) {
     final Map<Unit, Collection<Unit>> alreadyLoaded =
-        mustMoveWith(route.getStart(), units, newDependents, player);
+        mustMoveWith(route.getStart(), units, airTransportDependents, player);
     if (route.hasNoSteps() && alreadyLoaded.isEmpty()) {
       return false;
     }
@@ -1150,15 +1153,15 @@ public class MoveValidator {
       final Collection<Unit> units,
       final Route route,
       final GamePlayer player,
-      final Map<Unit, Unit> unitsToTransports,
+      final Map<Unit, Unit> unitsToSeaTransports,
       final MoveValidationResult result) {
     if (!route.hasWater() || units.stream().allMatch(Matches.unitIsAir())) {
       return result;
     }
     // If there are non-sea transports return
     final boolean loadingNonSeaTransportsOnly =
-        !unitsToTransports.isEmpty()
-            && unitsToTransports.values().stream()
+        !unitsToSeaTransports.isEmpty()
+            && unitsToSeaTransports.values().stream()
                 .noneMatch(Matches.unitIsSea().and(Matches.unitCanTransport()));
     if (loadingNonSeaTransportsOnly) {
       return result;
@@ -1315,7 +1318,7 @@ public class MoveValidator {
           if (baseUnit.hasMoved()) {
             result.addDisallowedUnit("Units cannot move before loading onto transports", baseUnit);
           }
-          final Unit transport = unitsToTransports.get(baseUnit);
+          final Unit transport = unitsToSeaTransports.get(baseUnit);
           if (transport == null) {
             continue;
           }
@@ -1328,7 +1331,7 @@ public class MoveValidator {
               transport, route.getEnd())) {
             Territory alreadyUnloadedTo =
                 getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
-            for (final Unit transportToLoad : unitsToTransports.values()) {
+            for (final Unit transportToLoad : unitsToSeaTransports.values()) {
               if (!TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(
                   transportToLoad, route.getEnd())) {
                 final UnitAttachment ua = baseUnit.getUnitAttachment();
@@ -1346,14 +1349,14 @@ public class MoveValidator {
           }
         }
       }
-      if (!unitsToTransports.keySet().containsAll(land)) {
+      if (!unitsToSeaTransports.keySet().containsAll(land)) {
         // some units didn't get mapped to a transport
         final Collection<UnitCategory> unitsToLoadCategories = UnitSeparator.categorize(land);
-        if (unitsToTransports.isEmpty() || unitsToLoadCategories.size() == 1) {
+        if (unitsToSeaTransports.isEmpty() || unitsToLoadCategories.size() == 1) {
           // set all unmapped units as disallowed if there are no transports or only one unit
           // category
           for (final Unit unit : land) {
-            if (unitsToTransports.containsKey(unit)) {
+            if (unitsToSeaTransports.containsKey(unit)) {
               continue;
             }
             final UnitAttachment ua = unit.getUnitAttachment();
@@ -1544,22 +1547,23 @@ public class MoveValidator {
 
   public static MustMoveWithDetails getMustMoveWith(
       final Territory start,
-      final Map<Unit, Collection<Unit>> newDependents,
+      final Map<Unit, Collection<Unit>> airTransportDependents,
       final GamePlayer player) {
-    return new MustMoveWithDetails(mustMoveWith(start, start.getUnits(), newDependents, player));
+    return new MustMoveWithDetails(
+        mustMoveWith(start, start.getUnits(), airTransportDependents, player));
   }
 
   private static Map<Unit, Collection<Unit>> mustMoveWith(
       final Territory start,
       final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> newDependents,
+      final Map<Unit, Collection<Unit>> airTransportDependents,
       final GamePlayer player) {
     final List<Unit> sortedUnits = new ArrayList<>(units);
     sortedUnits.sort(UnitComparator.getHighestToLowestMovementComparator());
     final Map<Unit, Collection<Unit>> mapping = transportsMustMoveWith(start, sortedUnits);
     // Check if there are combined transports (carriers that are transports) and load them.
     addToMapping(mapping, carrierMustMoveWith(sortedUnits, start, player));
-    addToMapping(mapping, airTransportsMustMoveWith(start, sortedUnits, newDependents));
+    addToMapping(mapping, airTransportsMustMoveWith(start, sortedUnits, airTransportDependents));
     return mapping;
   }
 
@@ -1585,7 +1589,7 @@ public class MoveValidator {
   private static Map<Unit, Collection<Unit>> airTransportsMustMoveWith(
       final Territory start,
       final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> newDependents) {
+      final Map<Unit, Collection<Unit>> airTransportDependents) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
     final Collection<Unit> airTransports =
         CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
@@ -1593,8 +1597,8 @@ public class MoveValidator {
     for (final Unit airTransport : airTransports) {
       if (!mustMoveWith.containsKey(airTransport)) {
         Collection<Unit> transporting = airTransport.getTransporting(start);
-        if (transporting.isEmpty() && !newDependents.isEmpty()) {
-          transporting = newDependents.get(airTransport);
+        if (transporting.isEmpty() && !airTransportDependents.isEmpty()) {
+          transporting = airTransportDependents.get(airTransport);
         }
         mustMoveWith.put(airTransport, transporting);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -972,7 +972,7 @@ public class MoveValidator {
       final Route route, final GamePlayer player, final boolean ignoreRouteEnd) {
     final Predicate<Unit> transportOnly =
         Matches.unitIsInfrastructure()
-            .or(Matches.unitIsSeaTransportButNotCombatTransport())
+            .or(Matches.unitIsSeaTransportButNotCombatSeaTransport())
             .or(Matches.unitIsLand())
             .or(Matches.enemyUnit(player).negate());
     final Predicate<Unit> subOnly =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovableUnitsFilter.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovableUnitsFilter.java
@@ -186,7 +186,7 @@ final class MovableUnitsFilter {
     // TODO kev check for already loaded airTransports
     if (MoveValidator.isLoad(units, airTransportDependents, route, player)) {
       final UnitCollection unitsAtEnd = route.getEnd().getUnitCollection();
-      return unitsAtEnd.getMatches(Matches.unitIsTransport().and(Matches.alliedUnit(player)));
+      return unitsAtEnd.getMatches(Matches.unitIsSeaTransport().and(Matches.alliedUnit(player)));
     }
     return List.of();
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -498,7 +498,7 @@ public class MovePanel extends AbstractMovePanel {
           Collection<Unit> transports = null;
           final var units = new ArrayList<>(unitsThatCanMoveOnRoute);
           if (route.isLoad() && units.stream().anyMatch(Matches.unitIsLand())) {
-            transports = getTransportsToLoad(route, units);
+            transports = getSeaTransportsToLoad(route, units);
             if (transports.isEmpty()) {
               cancelMove();
               return;
@@ -782,7 +782,7 @@ public class MovePanel extends AbstractMovePanel {
     final Predicate<Collection<Unit>> transportsToUnloadMatch =
         units -> {
           final List<Unit> sortedTransports =
-              CollectionUtils.getMatches(units, Matches.unitIsTransport());
+              CollectionUtils.getMatches(units, Matches.unitIsSeaTransport());
           final Collection<Unit> availableUnits = new ArrayList<>(unitsToUnload);
 
           // track the changing capacities of the transports as we assign units
@@ -853,7 +853,7 @@ public class MovePanel extends AbstractMovePanel {
       return List.of();
     }
     final Collection<Unit> chosenTransports =
-        CollectionUtils.getMatches(chooser.getSelected(), Matches.unitIsTransport());
+        CollectionUtils.getMatches(chooser.getSelected(), Matches.unitIsSeaTransport());
     return chooseUnitsToUnload(route, unitsToUnload, candidateUnits, chosenTransports);
   }
 
@@ -1105,7 +1105,7 @@ public class MovePanel extends AbstractMovePanel {
    * Allow the user to select what transports to load. If an empty collection is returned, the move
    * should be canceled.
    */
-  private Collection<Unit> getTransportsToLoad(
+  private Collection<Unit> getSeaTransportsToLoad(
       final Route route, final Collection<Unit> unitsToLoad) {
     if (!route.isLoad()) {
       return List.of();
@@ -1121,7 +1121,7 @@ public class MovePanel extends AbstractMovePanel {
       minTransportCost = Math.min(minTransportCost, unit.getUnitAttachment().getTransportCost());
     }
     final Predicate<Unit> candidateTransportsMatch =
-        Matches.unitIsTransport().and(Matches.alliedUnit(unitOwner));
+        Matches.unitIsSeaTransport().and(Matches.alliedUnit(unitOwner));
     final List<Unit> candidateTransports =
         CollectionUtils.getMatches(route.getEnd().getUnits(), candidateTransportsMatch);
 
@@ -1243,7 +1243,7 @@ public class MovePanel extends AbstractMovePanel {
     final Predicate<Collection<Unit>> transportsToLoadMatch =
         units -> {
           final Collection<Unit> transports =
-              CollectionUtils.getMatches(units, Matches.unitIsTransport());
+              CollectionUtils.getMatches(units, Matches.unitIsSeaTransport());
           // prevent too many transports from being selected
           return (transports.size() <= Math.min(unitsToLoad.size(), candidateTransports.size()));
         };
@@ -1312,7 +1312,7 @@ public class MovePanel extends AbstractMovePanel {
     if (mustQueryUser) {
       final List<Unit> defaultSelections = new ArrayList<>(units.size());
       if (route.isLoad()) {
-        final Collection<Unit> transportsToLoad = getTransportsToLoad(route, units);
+        final Collection<Unit> transportsToLoad = getSeaTransportsToLoad(route, units);
         defaultSelections.addAll(
             TransportUtils.mapTransports(route, units, transportsToLoad).keySet());
       } else {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -91,7 +91,7 @@ public class UnitSeparator {
     for (final Unit current : units) {
       BigDecimal unitMovement = new BigDecimal(-1);
       if (separatorCategories.movement
-          || (separatorCategories.transportMovement && Matches.unitIsTransport().test(current))
+          || (separatorCategories.transportMovement && Matches.unitIsSeaTransport().test(current))
           || (separatorCategories.movementForAirUnitsOnly
               && isAirWithHitPointsRemaining(current))) {
         unitMovement = current.getMovementLeft();

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -300,7 +300,7 @@ class RevisedTest {
     final Territory sz2 = territory("2 Sea Zone", gameData);
     final Collection<Unit> units =
         uk.getUnitCollection().getMatches(Matches.unitIsOwnedBy(americans));
-    final List<Unit> transports = sz2.getUnitCollection().getMatches(Matches.unitIsTransport());
+    final List<Unit> transports = sz2.getUnitCollection().getMatches(Matches.unitIsSeaTransport());
     final Map<Unit, Unit> unitsToTransports =
         TransportUtils.mapTransports(new Route(uk, sz2), units, transports);
     final String error =
@@ -408,7 +408,7 @@ class RevisedTest {
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
     final Route sz14To13 = new Route(sz14, sz13);
-    final List<Unit> transports = sz14.getUnitCollection().getMatches(Matches.unitIsTransport());
+    final List<Unit> transports = sz14.getUnitCollection().getMatches(Matches.unitIsSeaTransport());
     assertEquals(1, transports.size());
     move(transports, sz14To13);
   }
@@ -429,7 +429,7 @@ class RevisedTest {
     final List<Unit> infantry =
         eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
+    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsSeaTransport()).get(0);
     final String error =
         moveDelegate.performMove(
             new MoveDescription(
@@ -464,7 +464,7 @@ class RevisedTest {
     final List<Unit> infantry =
         eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
+    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsSeaTransport()).get(0);
     // load the transport
     String error =
         moveDelegate.performMove(
@@ -510,7 +510,7 @@ class RevisedTest {
     final List<Unit> infantry =
         eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
+    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsSeaTransport()).get(0);
     // load the transports
     // in two moves
     String error =
@@ -556,7 +556,7 @@ class RevisedTest {
             .getUnitCollection()
             .getMatches(Matches.unitIsOfType(infantryType).and(Matches.unitIsOwnedBy(japanese)));
     assertEquals(1, infantry.size());
-    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
+    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsSeaTransport()).get(0);
     String error =
         moveDelegate.performMove(
             new MoveDescription(infantry, eeToSz5, Map.of(infantry.get(0), transport)));
@@ -584,7 +584,7 @@ class RevisedTest {
     final List<Unit> infantry =
         eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
+    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsSeaTransport()).get(0);
     String error =
         moveDelegate.performMove(
             new MoveDescription(
@@ -635,7 +635,7 @@ class RevisedTest {
     final List<Unit> infantry =
         eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
+    final Unit transport = sz5.getUnitCollection().getMatches(Matches.unitIsSeaTransport()).get(0);
     String error =
         moveDelegate.performMove(
             new MoveDescription(
@@ -1507,7 +1507,7 @@ class RevisedTest {
         new Route(germany, sz5));
     // attack sz 6
     move(
-        sz5.getUnitCollection().getMatches(Matches.unitCanBlitz().or(Matches.unitIsTransport())),
+        sz5.getUnitCollection().getMatches(Matches.unitCanBlitz().or(Matches.unitIsSeaTransport())),
         new Route(sz5, sz6));
     // unload transports, 1 each to a different country
     // this move is illegal now
@@ -1564,7 +1564,7 @@ class RevisedTest {
 
   @Test
   void testTransportIsTransport() {
-    assertTrue(Matches.unitIsTransport().test(transport(gameData).create(british(gameData))));
-    assertFalse(Matches.unitIsTransport().test(infantry(gameData).create(british(gameData))));
+    assertTrue(Matches.unitIsSeaTransport().test(transport(gameData).create(british(gameData))));
+    assertFalse(Matches.unitIsSeaTransport().test(infantry(gameData).create(british(gameData))));
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -462,7 +462,7 @@ class WW2V3Year41Test {
     final Territory sz13 = territory("13 Sea Zone", gameData);
     final Route sz9ToSz13 = new Route(sz9, territory("12 Sea Zone", gameData), sz13);
     // move the transport to attack, this is suicide but valid
-    move(sz9.getUnitCollection().getMatches(Matches.unitIsTransport()), sz9ToSz13);
+    move(sz9.getUnitCollection().getMatches(Matches.unitIsSeaTransport()), sz9ToSz13);
     // load the transport
     load(gibraltar.getUnits(), new Route(gibraltar, sz13));
     moveDelegate.end();
@@ -487,7 +487,7 @@ class WW2V3Year41Test {
     final Territory uk = territory("United Kingdom", gameData);
     final Route sz9ToSz7 = new Route(sz9, territory("8 Sea Zone", gameData), sz7);
     // move the transport to attack, this is suicide but valid
-    final List<Unit> transports = sz9.getUnitCollection().getMatches(Matches.unitIsTransport());
+    final List<Unit> transports = sz9.getUnitCollection().getMatches(Matches.unitIsSeaTransport());
     move(transports, sz9ToSz7);
     // load the transport
     load(uk.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(uk, sz7));
@@ -1013,11 +1013,11 @@ class WW2V3Year41Test {
     // move the battleship
     move(sz14.getUnitCollection().getMatches(Matches.unitHasMoreThanOneHitPointTotal()), r);
     // move everything
-    move(sz14.getUnitCollection().getMatches(Matches.unitIsNotTransport()), r);
+    move(sz14.getUnitCollection().getMatches(Matches.unitIsNotSeaTransport()), r);
     // undo it
     move.undoMove(1);
     // move again
-    move(sz14.getUnitCollection().getMatches(Matches.unitIsNotTransport()), r);
+    move(sz14.getUnitCollection().getMatches(Matches.unitIsNotSeaTransport()), r);
     final MustFightBattle mfb =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz12);
     // only 3 attacking units

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -45,7 +45,7 @@ class WW2V3Year42Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     final Route sz13To12 = new Route(sz13, sz12);
-    final List<Unit> transports = sz13.getUnitCollection().getMatches(Matches.unitIsTransport());
+    final List<Unit> transports = sz13.getUnitCollection().getMatches(Matches.unitIsSeaTransport());
     assertEquals(1, transports.size());
     move(transports, sz13To12);
   }
@@ -143,7 +143,7 @@ class WW2V3Year42Test {
     // attack with a german sub
     move(sz7.getUnits(), new Route(sz7, sz6, sz5));
     // move the transport away
-    move(sz5.getUnitCollection().getMatches(Matches.unitIsTransport()), new Route(sz5, sz6));
+    move(sz5.getUnitCollection().getMatches(Matches.unitIsSeaTransport()), new Route(sz5, sz6));
     moveDelegate(gameData).end();
     // adding of lingering units was moved from end of combat-move phase, to start of battle phase
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/MoveValidatorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/MoveValidatorTest.java
@@ -213,7 +213,7 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     final Route r = new Route(northernGermany, sz27);
     northernGermany.getUnitCollection().clear();
     addTo(northernGermany, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
-    final List<Unit> transport = sz27.getUnitCollection().getMatches(Matches.unitIsTransport());
+    final List<Unit> transport = sz27.getUnitCollection().getMatches(Matches.unitIsSeaTransport());
     Map<Unit, Unit> unitsToTransports =
         TransportUtils.mapTransports(r, northernGermany.getUnitCollection(), transport);
 


### PR DESCRIPTION
## Change Summary & Additional Notes
Rename MoveDescription fields to be clear what they're for.

Also update variables and function names in related code to be explicit as well (e.g. being clear about matchers that check for sea transports and not any other kind).

Note: I don't believe anything changing here is part of the serialized game state. For example, UndoableMove doesn't use MoveDescription.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
