### PR TITLE
Infra: install 'ACL' package first & merge apt ansible roles together

### DIFF
--- a/infrastructure/ansible/roles/system/apt_common_tools/README.md
+++ b/infrastructure/ansible/roles/system/apt_common_tools/README.md
@@ -1,2 +1,2 @@
-Install system tools that should be present on all system
+Installs system tools installed via 'apt' that should be present on all system
 

--- a/infrastructure/ansible/roles/system/apt_common_tools/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/apt_common_tools/tasks/main.yml
@@ -1,8 +1,16 @@
+- name: Update and upgrade apt packages
+  apt:
+    upgrade: yes
+    cache_valid_time: 86400 # One day, only updates if caches are older than this.
+
 - name: apt install standard utilities and packages
   apt:
     state: present
     name:
+      # acl installed to help with: "Failed to set permissions on the temporary files
+      # Ansible needs to create when becoming an unprivileged user"
+      # https://stackoverflow.com/questions/46352173/ansible-failed-to-set-permissions-on-the-temporary
+      - acl
       - htop
       - iftop
       - unzip
-

--- a/infrastructure/ansible/roles/system/apt_update/README.md
+++ b/infrastructure/ansible/roles/system/apt_update/README.md
@@ -1,1 +1,0 @@
-Installs apt mirror for faster updates and runs apt upgrade to update the systems packages.

--- a/infrastructure/ansible/roles/system/apt_update/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/apt_update/tasks/main.yml
@@ -1,5 +1,0 @@
-- name: Update and upgrade apt packages
-  apt:
-    upgrade: yes
-    cache_valid_time: 86400 # One day, only updates if caches are older than this.
-

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -1,11 +1,10 @@
 - hosts: all
   roles:
+    - system/apt_common_tools
     - system/hostname
-    - system/apt_update
     - system/firewall
     - system/security
     - system/journald
-    - system/apt_common_tools
     - system/admin_user
 
 - hosts: forums


### PR DESCRIPTION
To deploy to a 'vagrant' local virtual-machine, we need a package called 'ACL'
to avoid ownership change errors. This update adds the installation of this
and moves it to be first in the install process.

Second, we have largely similar 'apt' roles, this update merges these
two roles together.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
