### PR TITLE
Remove impossible to hit code.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -496,18 +496,14 @@ public class MovePanel extends AbstractMovePanel {
           }
           setSelectedEndpointTerritory(territory);
           Collection<Unit> transports = null;
-          final Predicate<Unit> paratroopNBombers =
-              Matches.unitIsAirTransport().and(Matches.unitIsAirTransportable());
           final var units = new ArrayList<>(unitsThatCanMoveOnRoute);
-          final boolean paratroopsLanding = units.stream().anyMatch(paratroopNBombers);
           if (route.isLoad() && units.stream().anyMatch(Matches.unitIsLand())) {
             transports = getTransportsToLoad(route, units);
             if (transports.isEmpty()) {
               cancelMove();
               return;
             }
-          } else if ((route.isUnload() && units.stream().anyMatch(Matches.unitIsLand()))
-              || paratroopsLanding) {
+          } else if (route.isUnload() && units.stream().anyMatch(Matches.unitIsLand())) {
             units.clear();
             // Have user select which transports and land units to unload
             units.addAll(
@@ -519,9 +515,6 @@ public class MovePanel extends AbstractMovePanel {
             if (units.isEmpty()) {
               cancelMove();
               return;
-            }
-            if (paratroopsLanding) {
-              transports = units;
             }
             selectedUnits.clear();
             selectedUnits.addAll(units);


### PR DESCRIPTION
## Change Summary & Additional Notes
Remove impossible to hit code.

This matcher requires a unit to be both an air transport and air transportable, which is impossible:
```
          final Predicate<Unit> paratroopNBombers =
              Matches.unitIsAirTransport().and(Matches.unitIsAirTransportable());
```
So this was always false:
```
final boolean paratroopsLanding = units.stream().anyMatch(paratroopNBombers);
```

To prove that a unit can't be both an air transport and air transportable, we can look at `UnitAttachment.validate()`.

First, an air unit can't be air transportable per lines 2606 and 2615 in UnitAttachment.java.
Second, an air transport can't be a land unit or sea unit (and thus must be an air unit), per lines 2632 and 2636 and lines 2619 and 2628 in UnitAttachment.java. 

So `Matches.unitIsAirTransport().and(Matches.unitIsAirTransportable())` can't match any units and this is just dead code.


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
