### PR TITLE
Cache technology bonuses to speed up engine and AI code.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
@@ -98,9 +98,9 @@ public class ChangeAttachmentChange extends Change {
           e);
     }
     if (attachment instanceof TechAttachment) {
-      ((TechAttachment) attachment).getData().getTechTracker().onTechnologyChanged();
+      ((TechAttachment) attachment).getData().getTechTracker().clearCache();
     } else if (attachment instanceof TechAbilityAttachment) {
-      ((TechAbilityAttachment) attachment).getData().getTechTracker().onTechnologyChanged();
+      ((TechAbilityAttachment) attachment).getData().getTechTracker().clearCache();
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import games.strategy.triplea.attachments.TechAbilityAttachment;
+import games.strategy.triplea.attachments.TechAttachment;
 import java.util.Optional;
 
 /** A game data change that captures a change to an attachment property value. */
@@ -94,6 +96,11 @@ public class ChangeAttachmentChange extends Change {
               "failed to set value '%s' on property '%s' for attachment '%s' associated with '%s'",
               newValue, property, attachmentName, attachedTo),
           e);
+    }
+    if (attachment instanceof TechAttachment) {
+      ((TechAttachment) attachment).getData().getTechTracker().onTechnologyChanged();
+    } else if (attachment instanceof TechAbilityAttachment) {
+      ((TechAbilityAttachment) attachment).getData().getTechTracker().onTechnologyChanged();
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
@@ -13,7 +13,6 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
   private static final long serialVersionUID = -5245743727479551766L;
 
   private final List<TechAdvance> techs = new ArrayList<>();
-  private List<TechAdvance> cachedTechs;
   private final String name;
 
   public TechnologyFrontier(final String name, final GameData data) {
@@ -31,28 +30,29 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
     final GameData gameData = getData();
     if (gameData != null) {
       techs.sort(Comparator.comparingInt(gameData.getTechnologyFrontier().getTechs()::indexOf));
-      cachedTechs = null;
     }
   }
 
   public void addAdvance(final TechAdvance t) {
-    cachedTechs = null;
     techs.add(t);
     reorderTechsToMatchGameTechsOrder();
+    getData().getTechTracker().onTechnologyChanged();
   }
 
   public void addAdvance(final List<TechAdvance> list) {
     for (final TechAdvance t : list) {
-      addAdvance(t);
+      techs.add(t);
     }
+    reorderTechsToMatchGameTechsOrder();
+    getData().getTechTracker().onTechnologyChanged();
   }
 
   public void removeAdvance(final TechAdvance t) {
     if (!techs.contains(t)) {
       throw new IllegalStateException("Advance not present:" + t);
     }
-    cachedTechs = null;
     techs.remove(t);
+    getData().getTechTracker().onTechnologyChanged();
   }
 
   public TechAdvance getAdvanceByProperty(final String property) {
@@ -64,10 +64,7 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
   }
 
   public List<TechAdvance> getTechs() {
-    if (cachedTechs == null) {
-      cachedTechs = Collections.unmodifiableList(techs);
-    }
-    return cachedTechs;
+    return Collections.unmodifiableList(techs);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
@@ -36,7 +36,7 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
   public void addAdvance(final TechAdvance t) {
     techs.add(t);
     reorderTechsToMatchGameTechsOrder();
-    getData().getTechTracker().onTechnologyChanged();
+    getData().getTechTracker().clearCache();
   }
 
   public void addAdvance(final List<TechAdvance> list) {
@@ -44,7 +44,7 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
       techs.add(t);
     }
     reorderTechsToMatchGameTechsOrder();
-    getData().getTechTracker().onTechnologyChanged();
+    getData().getTechTracker().clearCache();
   }
 
   public void removeAdvance(final TechAdvance t) {
@@ -52,7 +52,7 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
       throw new IllegalStateException("Advance not present:" + t);
     }
     techs.remove(t);
-    getData().getTechTracker().onTechnologyChanged();
+    getData().getTechTracker().clearCache();
   }
 
   public TechAdvance getAdvanceByProperty(final String property) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontierList.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontierList.java
@@ -37,7 +37,7 @@ public class TechnologyFrontierList extends GameDataComponent {
     for (final TechnologyFrontier t : technologyFrontiers) {
       techs.addAll(t.getTechs());
     }
-    return techs;
+    return Collections.unmodifiableList(techs);
   }
 
   public List<TechnologyFrontier> getFrontiers() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -309,6 +309,7 @@ public class TechAttachment extends DefaultAttachment {
 
   public void setGenericTech(final String name, final boolean value) {
     genericTech.put(name, value);
+    getData().getTechTracker().onTechnologyChanged();
   }
 
   public Map<String, Boolean> getGenericTech() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -309,7 +309,7 @@ public class TechAttachment extends DefaultAttachment {
 
   public void setGenericTech(final String name, final boolean value) {
     genericTech.put(name, value);
-    getData().getTechTracker().onTechnologyChanged();
+    getData().getTechTracker().clearCache();
   }
 
   public Map<String, Boolean> getGenericTech() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -252,7 +252,7 @@ public abstract class TechAdvance extends NamedAttachable {
 
   /**
    * Returns all tech advances that this player can possibly research. (Or if Player is null,
-   * returns all techs available in the game).
+   * returns all techs available in the game). The returned collection is immutable.
    */
   public static List<TechAdvance> getTechAdvances(
       final TechnologyFrontier technologyFrontier, final GamePlayer player) {
@@ -262,7 +262,7 @@ public abstract class TechAdvance extends NamedAttachable {
           : technologyFrontier.getTechs();
     }
     // the game has no techs, just return empty list
-    return new ArrayList<>();
+    return List.of();
   }
 
   /** Returns all possible tech categories for this player. */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -38,7 +38,7 @@ public class TechTracker {
 
   private final Map<Key, Object> cache = new ConcurrentHashMap<>();
 
-  public void onTechnologyChanged() {
+  public void clearCache() {
     cache.clear();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -27,9 +27,6 @@ import org.triplea.java.collections.IntegerMap;
 /** A collection of methods for tracking which players have which technology advances. */
 @AllArgsConstructor
 public class TechTracker {
-  // TODO: Enable caching when ready.
-  private static final boolean ENABLE_CACHING = false;
-
   private final GameData data;
 
   @Value
@@ -40,6 +37,10 @@ public class TechTracker {
   }
 
   private final Map<Key, Object> cache = new ConcurrentHashMap<>();
+
+  public void onTechnologyChanged() {
+    cache.clear();
+  }
 
   public int getAirDefenseBonus(GamePlayer player, UnitType type) {
     final Supplier<Integer> getter =
@@ -156,17 +157,11 @@ public class TechTracker {
 
   private int getCached(
       GamePlayer player, UnitType type, String property, Supplier<Integer> getter) {
-    if (!ENABLE_CACHING) {
-      return getter.get();
-    }
     return (Integer) cache.computeIfAbsent(new Key(player, type, property), key -> getter.get());
   }
 
   private boolean getCached(
       GamePlayer player, UnitType type, String property, BooleanSupplier getter) {
-    if (!ENABLE_CACHING) {
-      return getter.getAsBoolean();
-    }
     return (Boolean)
         cache.computeIfAbsent(new Key(player, type, property), key -> getter.getAsBoolean());
   }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/TechTrackerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/TechTrackerTest.java
@@ -1,7 +1,11 @@
 package games.strategy.triplea.delegate;
 
+import static games.strategy.triplea.delegate.GameDataTestUtil.americans;
+import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -9,12 +13,19 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.NamedAttachable;
+import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
+import games.strategy.triplea.attachments.TechAttachment;
+import games.strategy.triplea.xml.TestMapGameData;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -71,5 +82,51 @@ public class TechTrackerTest {
             "NamedAttachable{name=test}",
             techAdvances);
     assertThat(result, is(101));
+  }
+
+  @Test
+  void invalidateCache() {
+    // Test that updating techs updates the TechTracker's cache.
+    GameData gameData = TestMapGameData.GLOBAL1940.getGameData();
+    TechTracker techTracker = gameData.getTechTracker();
+    IDelegateBridge bridge = newDelegateBridge(americans(gameData));
+    GamePlayer player = americans(gameData);
+    TechnologyFrontier technologyFrontier = gameData.getTechnologyFrontier();
+
+    TechAdvance heavyBomber = gameData.getTechnologyFrontier().getAdvanceByName("Heavy Bomber");
+    assertThat(heavyBomber, is(notNullValue()));
+
+    // Check that modifying tech via tech tracker (via Change objects), invalidates the cache.
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(0));
+    techTracker.addAdvance(player, bridge, heavyBomber);
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(1));
+    techTracker.removeAdvance(player, bridge, heavyBomber);
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(0));
+
+    // Check that modifying the tech frontier also invalidates the cache.
+    techTracker.addAdvance(player, bridge, heavyBomber);
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(1));
+    technologyFrontier.removeAdvance(heavyBomber);
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(0));
+    technologyFrontier.addAdvance(heavyBomber);
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(1));
+    technologyFrontier.removeAdvance(heavyBomber);
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(0));
+    technologyFrontier.addAdvance(List.of(heavyBomber));
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(1));
+
+    // Check that modifying relevant attachments also invalidates the cache.
+    TechAbilityAttachment taa = TechAbilityAttachment.get(heavyBomber);
+    Change change = ChangeFactory.attachmentPropertyChange(taa, "2:bomber", "attackRollsBonus");
+    gameData.performChange(change);
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(2));
+
+    TechAttachment ta = player.getTechAttachment();
+    change = ChangeFactory.attachmentPropertyChange(ta, "false", "heavyBomber");
+    gameData.performChange(change);
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(0));
+    change = ChangeFactory.attachmentPropertyChange(ta, "true", "heavyBomber");
+    gameData.performChange(change);
+    assertThat(techTracker.getAttackRollsBonus(player, bomber(gameData)), is(2));
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/TechTrackerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/TechTrackerTest.java
@@ -85,7 +85,7 @@ public class TechTrackerTest {
   }
 
   @Test
-  void invalidateCache() {
+  void clearCache() {
     // Test that updating techs updates the TechTracker's cache.
     GameData gameData = TestMapGameData.GLOBAL1940.getGameData();
     TechTracker techTracker = gameData.getTechTracker();

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/TechTrackerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/TechTrackerTest.java
@@ -93,7 +93,7 @@ public class TechTrackerTest {
     GamePlayer player = americans(gameData);
     TechnologyFrontier technologyFrontier = gameData.getTechnologyFrontier();
 
-    TechAdvance heavyBomber = gameData.getTechnologyFrontier().getAdvanceByName("Heavy Bomber");
+    TechAdvance heavyBomber = technologyFrontier.getAdvanceByName("Heavy Bomber");
     assertThat(heavyBomber, is(notNullValue()));
 
     // Check that modifying tech via tech tracker (via Change objects), invalidates the cache.


### PR DESCRIPTION
## Change Summary & Additional Notes
On Domination 1914 No Man's land, on all Hard AI game, this speeds up the mean MustFightBattle.fight() execution time from 1.9ms to 1.4ms on my machine, a 26% speed up.

There are about 165,000 MustFightBattle.fight() calls during the first turn by Hard AI on Domination 1914.

A test is added covering the different ways in which tech can change to ensure the cache gets properly validated and the TechTracker returns the correct results.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
