### PR TITLE
Fix "Duplicate key" error due to AI code.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -160,9 +160,13 @@ public class ProTerritoryManager {
       final ProTerritory patd = attackMap.get(t);
 
       // Check if I can win without amphib units
-      final List<Unit> defenders =
-          new ArrayList<>(
-              isIgnoringRelationships ? t.getUnitCollection() : patd.getMaxEnemyDefenders(player));
+      final List<Unit> defenders;
+      if (isIgnoringRelationships) {
+        defenders = new ArrayList<>(t.getUnitCollection());
+        defenders.removeAll(patd.getMaxUnits());
+      } else {
+        defenders = patd.getMaxEnemyDefenders(player);
+      }
       patd.setMaxBattleResult(
           calc.estimateAttackBattleResults(
               proData, t, patd.getMaxUnits(), defenders, new HashSet<>()));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -163,6 +163,7 @@ public class ProTerritoryManager {
       final List<Unit> defenders;
       if (isIgnoringRelationships) {
         defenders = new ArrayList<>(t.getUnitCollection());
+        // Don't include any of the attacking units as defenders.
         defenders.removeAll(patd.getMaxUnits());
       } else {
         defenders = patd.getMaxEnemyDefenders(player);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -168,8 +168,7 @@ public class ProTerritoryManager {
         defenders = patd.getMaxEnemyDefenders(player);
       }
       patd.setMaxBattleResult(
-          calc.estimateAttackBattleResults(
-              proData, t, patd.getMaxUnits(), defenders, Set.of()));
+          calc.estimateAttackBattleResults(proData, t, patd.getMaxUnits(), defenders, Set.of()));
 
       // Add in amphib units if I can't win without them
       if (patd.getMaxBattleResult().getWinPercentage() < proData.getWinPercentage()

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -169,7 +169,7 @@ public class ProTerritoryManager {
       }
       patd.setMaxBattleResult(
           calc.estimateAttackBattleResults(
-              proData, t, patd.getMaxUnits(), defenders, new HashSet<>()));
+              proData, t, patd.getMaxUnits(), defenders, Set.of()));
 
       // Add in amphib units if I can't win without them
       if (patd.getMaxBattleResult().getWinPercentage() < proData.getWinPercentage()
@@ -178,7 +178,7 @@ public class ProTerritoryManager {
         combinedUnits.addAll(patd.getMaxAmphibUnits());
         patd.setMaxBattleResult(
             calc.estimateAttackBattleResults(
-                proData, t, new ArrayList<>(combinedUnits), defenders, patd.getMaxBombardUnits()));
+                proData, t, combinedUnits, defenders, patd.getMaxBombardUnits()));
         patd.setNeedAmphibUnits(true);
       }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -144,9 +144,10 @@ class BattleCalculator implements IBattleCalculator {
   private Collection<Unit> mergeUnitCollections(Collection<Unit> c1, Collection<Unit> c2) {
     var combined = new HashSet<>(c1);
     combined.addAll(c2);
-    // Check that the two collections were distinct and didn't have duplicates. This helps catch
-    // logic errors in AI code that would otherwise be hard to debug.
-    Preconditions.checkState(combined.size() == c1.size() + c2.size());
+    Preconditions.checkState(
+        combined.size() == c1.size() + c2.size(),
+        "Attackers and defenders collections must be distinct with no duplicates. "
+            + "This helps catch logic errors in AI code that would otherwise be hard to debug.");
     return combined;
   }
 


### PR DESCRIPTION
## Change Summary & Additional Notes
Fixes https://github.com/triplea-game/triplea/issues/10653.

The cause was the AI code was passing overlapping attackers and defenders lists to the battle calculator.
Adds a precondition check to catch this type of error more explicitly in the future.
Also removes a stale comment that influences some class that doesn't exist.

Tested with an all-AI game on Global 40 house rules. 

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
