### PR TITLE
Some AI optimizations around comparing units.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -16,6 +16,7 @@ import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -113,6 +114,7 @@ public final class ProSortMoveOptionsUtils {
 
     final List<Map.Entry<Unit, Set<Territory>>> list =
         new ArrayList<>(unitAttackOptions.entrySet());
+    final Map<Object, Double> attackEfficiencyCache = new HashMap<>();
     list.sort(
         (o1, o2) -> {
           final Collection<Territory> territories1 =
@@ -133,9 +135,11 @@ public final class ProSortMoveOptionsUtils {
 
           // Sort by attack efficiency
           final double attackEfficiency1 =
-              calculateAttackEfficiency(proData, player, attackMap, territories1, unit1);
+              attackEfficiencyCache.computeIfAbsent(o1, key ->
+                  calculateAttackEfficiency(proData, player, attackMap, territories1, unit1));
           final double attackEfficiency2 =
-              calculateAttackEfficiency(proData, player, attackMap, territories2, unit2);
+              attackEfficiencyCache.computeIfAbsent(o2, key ->
+                  calculateAttackEfficiency(proData, player, attackMap, territories2, unit2));
           if (attackEfficiency1 != attackEfficiency2) {
             return (attackEfficiency1 < attackEfficiency2) ? 1 : -1;
           }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -130,29 +130,29 @@ public final class ProSortMoveOptionsUtils {
             return 0;
           }
 
-          final Unit unit1 = o1.getKey();
-          final Unit unit2 = o2.getKey();
+          final Unit u1 = o1.getKey();
+          final Unit u2 = o2.getKey();
 
           // Sort by attack efficiency
           final double attackEfficiency1 =
-              attackEfficiencyCache.computeIfAbsent(o1, key ->
-                  calculateAttackEfficiency(proData, player, attackMap, territories1, unit1));
+              attackEfficiencyCache.computeIfAbsent(
+                  o1, k -> calculateAttackEfficiency(proData, player, attackMap, territories1, u1));
           final double attackEfficiency2 =
-              attackEfficiencyCache.computeIfAbsent(o2, key ->
-                  calculateAttackEfficiency(proData, player, attackMap, territories2, unit2));
+              attackEfficiencyCache.computeIfAbsent(
+                  o2, k -> calculateAttackEfficiency(proData, player, attackMap, territories2, u2));
           if (attackEfficiency1 != attackEfficiency2) {
             return (attackEfficiency1 < attackEfficiency2) ? 1 : -1;
           }
 
-          final UnitType unitType1 = unit1.getType();
-          final UnitType unitType2 = unit2.getType();
+          final UnitType unitType1 = u1.getType();
+          final UnitType unitType2 = u2.getType();
 
           // If unit types are equal and are air, then sort by average distance.
           if (unitType1.equals(unitType2) && unitType1.getUnitAttachment().getIsAir()) {
             final Predicate<Territory> predicate =
                 ProMatches.territoryCanMoveAirUnitsAndNoAa(data, player, true);
-            final Territory territory1 = unitTerritoryMap.get(unit1);
-            final Territory territory2 = unitTerritoryMap.get(unit2);
+            final Territory territory1 = unitTerritoryMap.get(u1);
+            final Territory territory2 = unitTerritoryMap.get(u2);
             int distance1 = 0;
             for (final Territory t : territories1) {
               distance1 += data.getMap().getDistanceIgnoreEndForCondition(territory1, t, predicate);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
@@ -61,9 +61,7 @@ public class UnitBattleComparator implements Comparator<Unit> {
     }
     final boolean transporting1 = u1.isTransporting();
     final boolean transporting2 = u2.isTransporting();
-    final UnitAttachment ua1 = u1.getUnitAttachment();
-    final UnitAttachment ua2 = u2.getUnitAttachment();
-    if (ua1.equals(ua2)
+    if (u1.getType().equals(u2.getType())
         && u1.isOwnedBy(u2.getOwner())
         && u1.getWasAmphibious() == u2.getWasAmphibious()) {
       if (transporting1 && !transporting2) {
@@ -173,6 +171,8 @@ public class UnitBattleComparator implements Comparator<Unit> {
     } else if (!airOrCarrierOrTransport1 && airOrCarrierOrTransport2) {
       return -1;
     }
+    final UnitAttachment ua1 = u1.getUnitAttachment();
+    final UnitAttachment ua2 = u2.getUnitAttachment();
     return ua1.getMovement(u1.getOwner()) - ua2.getMovement(u2.getOwner());
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes
Some AI optimizations around comparing units, which were showing up in performance profiles.

`sortUnitNeededOptionsThenAttack()` is made to keep a cache of attack efficiency, since this is an expensive calculation and was showing up in profiles.

`UnitBattleComparator` is changed to compare unit types instead of unit attachments, which should have the same effect but much cheaper, as comparing unit attachments is pretty expensive due to its use of toString().

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
