### PR TITLE
Add "Land Battles May Be Ignored" property.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/Constants.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/Constants.java
@@ -181,6 +181,8 @@ public interface Constants {
   String AIR_BATTLE_ROUNDS = "Air Battle Rounds";
   String SEA_BATTLE_ROUNDS = "Sea Battle Rounds";
   String LAND_BATTLE_ROUNDS = "Land Battle Rounds";
+  String SEA_BATTLES_MAY_BE_IGNORED = "Sea Battles May Be Ignored";
+  String LAND_BATTLES_MAY_BE_IGNORED = "Land Battles May Be Ignored";
   String AIR_BATTLE_ATTACKERS_CAN_RETREAT = "Air Battle Attackers Can Retreat";
   String AIR_BATTLE_DEFENDERS_CAN_RETREAT = "Air Battle Defenders Can Retreat";
   String CAN_SCRAMBLE_INTO_AIR_BATTLES = "Can Scramble Into Air Battles";
@@ -189,7 +191,6 @@ public interface Constants {
   String CONTESTED_TERRITORIES_PRODUCE_NO_INCOME = "Contested Territories Produce No Income";
   String ALL_UNITS_CAN_ATTACK_FROM_CONTESTED_TERRITORIES =
       "All Units Can Attack From Contested Territories";
-  String SEA_BATTLES_MAY_BE_IGNORED = "Sea Battles May Be Ignored";
   String ABANDONED_TERRITORIES_MAY_BE_TAKEN_OVER_IMMEDIATELY =
       "Abandoned Territories May Be Taken Over Immediately";
   String DISABLED_PLAYERS_ASSETS_DELETED = "Disabled Players Assets Deleted";

--- a/game-app/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -561,6 +561,14 @@ public final class Properties implements Constants {
     return properties.get(LAND_BATTLE_ROUNDS, -1);
   }
 
+  public static boolean getSeaBattlesMayBeIgnored(final GameProperties properties) {
+    return properties.get(SEA_BATTLES_MAY_BE_IGNORED, false);
+  }
+
+  public static boolean getLandBattlesMayBeIgnored(final GameProperties properties) {
+    return properties.get(LAND_BATTLES_MAY_BE_IGNORED, false);
+  }
+
   public static boolean getAirBattleAttackersCanRetreat(final GameProperties properties) {
     return properties.get(AIR_BATTLE_ATTACKERS_CAN_RETREAT, false);
   }
@@ -591,10 +599,6 @@ public final class Properties implements Constants {
 
   public static boolean getAllUnitsCanAttackFromContestedTerritories(GameProperties properties) {
     return properties.get(ALL_UNITS_CAN_ATTACK_FROM_CONTESTED_TERRITORIES, false);
-  }
-
-  public static boolean getSeaBattlesMayBeIgnored(final GameProperties properties) {
-    return properties.get(SEA_BATTLES_MAY_BE_IGNORED, false);
   }
 
   public static boolean getAbandonedTerritoriesMayBeTakenOverImmediately(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -525,7 +525,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // possibility to ignore battle altogether
       if (!attackingUnits.isEmpty()) {
         final Player remotePlayer = bridge.getRemotePlayer();
-        if (territory.isWater() && Properties.getSeaBattlesMayBeIgnored(data.getProperties())) {
+        if ((territory.isWater() && Properties.getSeaBattlesMayBeIgnored(data.getProperties())) ||
+            (!territory.isWater() && Properties.getLandBattlesMayBeIgnored(data.getProperties()))) {
           if (!remotePlayer.selectAttackUnits(territory)) {
             final BattleResults results = new BattleResults(battle, WhoWon.NOT_FINISHED, data);
             battleTracker

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -525,8 +525,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // possibility to ignore battle altogether
       if (!attackingUnits.isEmpty()) {
         final Player remotePlayer = bridge.getRemotePlayer();
-        if ((territory.isWater() && Properties.getSeaBattlesMayBeIgnored(data.getProperties())) ||
-            (!territory.isWater() && Properties.getLandBattlesMayBeIgnored(data.getProperties()))) {
+        final boolean isWater = territory.isWater();
+        if ((isWater && Properties.getSeaBattlesMayBeIgnored(data.getProperties()))
+            || (!isWater && Properties.getLandBattlesMayBeIgnored(data.getProperties()))) {
           if (!remotePlayer.selectAttackUnits(territory)) {
             final BattleResults results = new BattleResults(battle, WhoWon.NOT_FINISHED, data);
             battleTracker


### PR DESCRIPTION
## Change Summary & Additional Notes
This works the same as "Sea Battles May Be Ignored", but for land battles.

This implements the rules needed by Imperialism 1974, when set.

Tested:
  - Added the property to Imperialism 1974 and observed that the user is given a prompt about whether they want to fight a given land battle. Tested playing several turns with no issues.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
