### PR TITLE
Fix 2.6 dice roll count from support attachments when there are casualties.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.delegate.battle.steps.fire;
 
 import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ACTIVE;
-import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
 
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate.battle.steps.fire;
 
+import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ACTIVE;
 import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
 
 import games.strategy.engine.delegate.IDelegateBridge;
@@ -27,8 +28,8 @@ public class MainDiceRoller
             step.getBattleState().getBattleSite(),
             step.getBattleState().getStatus().getRound()),
         CombatValueBuilder.mainCombatValue()
-            .enemyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()))
-            .friendlyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide()))
+            .enemyUnits(step.getBattleState().filterUnits(ACTIVE, step.getSide().getOpposite()))
+            .friendlyUnits(step.getBattleState().filterUnits(ACTIVE, step.getSide()))
             .side(step.getSide())
             .gameSequence(step.getBattleState().getGameData().getSequence())
             .supportAttachments(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
@@ -107,19 +107,7 @@ class AaDefenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return Stream.of(
-              supportFromFriends.getUnitsGivingSupport(),
-              supportFromEnemies.getUnitsGivingSupport())
-          .flatMap(map -> map.entrySet().stream())
-          .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  Map.Entry::getValue,
-                  (value1, value2) -> {
-                    final IntegerMap<Unit> merged = new IntegerMap<>(value1);
-                    merged.add(value2);
-                    return merged;
-                  }));
+      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
@@ -5,8 +5,6 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -107,7 +105,7 @@ class AaDefenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
+      return SupportCalculator.getCombinedSupportGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
@@ -5,8 +5,6 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -107,7 +105,7 @@ class AaOffenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
+      return SupportCalculator.getCombinedSupportGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
@@ -107,19 +107,7 @@ class AaOffenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return Stream.of(
-              supportFromFriends.getUnitsGivingSupport(),
-              supportFromEnemies.getUnitsGivingSupport())
-          .flatMap(map -> map.entrySet().stream())
-          .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  Map.Entry::getValue,
-                  (value1, value2) -> {
-                    final IntegerMap<Unit> merged = new IntegerMap<>(value1);
-                    merged.add(value2);
-                    return merged;
-                  }));
+      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaRoll.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaRoll.java
@@ -2,8 +2,6 @@ package games.strategy.triplea.delegate.power.calculator;
 
 import games.strategy.engine.data.Unit;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
@@ -26,6 +24,6 @@ class AaRoll implements RollCalculator {
 
   @Override
   public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-    return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
+    return SupportCalculator.getCombinedSupportGiven(supportFromFriends, supportFromEnemies);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaRoll.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaRoll.java
@@ -26,17 +26,6 @@ class AaRoll implements RollCalculator {
 
   @Override
   public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-    return Stream.of(
-            supportFromFriends.getUnitsGivingSupport(), supportFromEnemies.getUnitsGivingSupport())
-        .flatMap(map -> map.entrySet().stream())
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue,
-                (value1, value2) -> {
-                  final IntegerMap<Unit> merged = new IntegerMap<>(value1);
-                  merged.add(value2);
-                  return merged;
-                }));
+    return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
@@ -132,19 +132,7 @@ public class BombardmentCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return Stream.of(
-              supportFromFriends.getUnitsGivingSupport(),
-              supportFromEnemies.getUnitsGivingSupport())
-          .flatMap(map -> map.entrySet().stream())
-          .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  Map.Entry::getValue,
-                  (value1, value2) -> {
-                    final IntegerMap<Unit> merged = new IntegerMap<>(value1);
-                    merged.add(value2);
-                    return merged;
-                  }));
+      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
@@ -8,8 +8,6 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -132,7 +130,7 @@ public class BombardmentCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
+      return SupportCalculator.getCombinedSupportGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
@@ -129,14 +129,7 @@ class MainDefenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      Map<Unit, IntegerMap<Unit>> support = new HashMap<>();
-      for (var entry : supportFromFriends.getUnitsGivingSupport().entrySet()) {
-        support.computeIfAbsent(entry.getKey(), u -> new IntegerMap<>()).add(entry.getValue());
-      }
-      for (var entry : supportFromEnemies.getUnitsGivingSupport().entrySet()) {
-        support.computeIfAbsent(entry.getKey(), u -> new IntegerMap<>()).add(entry.getValue());
-      }
-      return support;
+      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
     }
   }
 
@@ -196,14 +189,7 @@ class MainDefenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      Map<Unit, IntegerMap<Unit>> support = new HashMap<>();
-      for (var entry : supportFromFriends.getUnitsGivingSupport().entrySet()) {
-        support.computeIfAbsent(entry.getKey(), u -> new IntegerMap<>()).add(entry.getValue());
-      }
-      for (var entry : supportFromEnemies.getUnitsGivingSupport().entrySet()) {
-        support.computeIfAbsent(entry.getKey(), u -> new IntegerMap<>()).add(entry.getValue());
-      }
-      return support;
+      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
@@ -9,7 +9,6 @@ import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -129,7 +128,7 @@ class MainDefenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
+      return SupportCalculator.getCombinedSupportGiven(supportFromFriends, supportFromEnemies);
     }
   }
 
@@ -189,7 +188,7 @@ class MainDefenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
+      return SupportCalculator.getCombinedSupportGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
@@ -12,8 +12,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -198,19 +196,14 @@ class MainDefenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return Stream.of(
-              supportFromFriends.getUnitsGivingSupport(),
-              supportFromEnemies.getUnitsGivingSupport())
-          .flatMap(map -> map.entrySet().stream())
-          .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  Map.Entry::getValue,
-                  (value1, value2) -> {
-                    final IntegerMap<Unit> merged = new IntegerMap<>(value1);
-                    merged.add(value2);
-                    return merged;
-                  }));
+      Map<Unit, IntegerMap<Unit>> support = new HashMap<>();
+      for (var entry : supportFromFriends.getUnitsGivingSupport().entrySet()) {
+        support.computeIfAbsent(entry.getKey(), u -> new IntegerMap<>()).add(entry.getValue());
+      }
+      for (var entry : supportFromEnemies.getUnitsGivingSupport().entrySet()) {
+        support.computeIfAbsent(entry.getKey(), u -> new IntegerMap<>()).add(entry.getValue());
+      }
+      return support;
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
@@ -9,8 +9,6 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -128,7 +126,7 @@ class MainOffenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
+      return SupportCalculator.getCombinedSupportGiven(supportFromFriends, supportFromEnemies);
     }
   }
 
@@ -158,7 +156,7 @@ class MainOffenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
+      return SupportCalculator.getCombinedSupportGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
@@ -128,19 +128,7 @@ class MainOffenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return Stream.of(
-              supportFromFriends.getUnitsGivingSupport(),
-              supportFromEnemies.getUnitsGivingSupport())
-          .flatMap(map -> map.entrySet().stream())
-          .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  Map.Entry::getValue,
-                  (value1, value2) -> {
-                    final IntegerMap<Unit> merged = new IntegerMap<>(value1);
-                    merged.add(value2);
-                    return merged;
-                  }));
+      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
     }
   }
 
@@ -170,19 +158,7 @@ class MainOffenseCombatValue implements CombatValue {
 
     @Override
     public Map<Unit, IntegerMap<Unit>> getSupportGiven() {
-      return Stream.of(
-              supportFromFriends.getUnitsGivingSupport(),
-              supportFromEnemies.getUnitsGivingSupport())
-          .flatMap(map -> map.entrySet().stream())
-          .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  Map.Entry::getValue,
-                  (value1, value2) -> {
-                    final IntegerMap<Unit> merged = new IntegerMap<>(value1);
-                    merged.add(value2);
-                    return merged;
-                  }));
+      return SupportCalculator.getCombinedSupportsGiven(supportFromFriends, supportFromEnemies);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
@@ -89,7 +89,7 @@ public class SupportCalculator {
     return supportRules.values();
   }
 
-  public static Map<Unit, IntegerMap<Unit>> getCombinedSupportsGiven(
+  public static Map<Unit, IntegerMap<Unit>> getCombinedSupportGiven(
       AvailableSupports supportFromFriends,
       AvailableSupports supportFromEnemies) {
     Map<Unit, IntegerMap<Unit>> support = new HashMap<>();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
@@ -82,7 +82,7 @@ public class SupportCalculator {
   }
 
   public int getSupport(final UnitSupportAttachment rule) {
-    return supportUnits.getOrDefault(rule, new IntegerMap<>()).totalValues();
+    return supportUnits.getOrDefault(rule, IntegerMap.of()).totalValues();
   }
 
   public Collection<List<UnitSupportAttachment>> getUnitSupportAttachments() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
@@ -88,4 +88,17 @@ public class SupportCalculator {
   public Collection<List<UnitSupportAttachment>> getUnitSupportAttachments() {
     return supportRules.values();
   }
+
+  public static Map<Unit, IntegerMap<Unit>> getCombinedSupportsGiven(
+      AvailableSupports supportFromFriends,
+      AvailableSupports supportFromEnemies) {
+    Map<Unit, IntegerMap<Unit>> support = new HashMap<>();
+    for (var entry : supportFromFriends.getUnitsGivingSupport().entrySet()) {
+      support.computeIfAbsent(entry.getKey(), u -> new IntegerMap<>()).add(entry.getValue());
+    }
+    for (var entry : supportFromEnemies.getUnitsGivingSupport().entrySet()) {
+      support.computeIfAbsent(entry.getKey(), u -> new IntegerMap<>()).add(entry.getValue());
+    }
+    return support;
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
@@ -90,8 +90,7 @@ public class SupportCalculator {
   }
 
   public static Map<Unit, IntegerMap<Unit>> getCombinedSupportGiven(
-      AvailableSupports supportFromFriends,
-      AvailableSupports supportFromEnemies) {
+      AvailableSupports supportFromFriends, AvailableSupports supportFromEnemies) {
     Map<Unit, IntegerMap<Unit>> support = new HashMap<>();
     for (var entry : supportFromFriends.getUnitsGivingSupport().entrySet()) {
       support.computeIfAbsent(entry.getKey(), u -> new IntegerMap<>()).add(entry.getValue());

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -239,6 +239,10 @@ public final class GameDataTestUtil {
     return unitType("britishInfantry", data);
   }
 
+  public static UnitType japaneseInfantry(final GameState data) {
+    return unitType("japaneseInfantry", data);
+  }
+
   /** Returns a bomber UnitType object for the specified GameData object. */
   public static UnitType bomber(final GameState data) {
     return unitType(Constants.UNIT_TYPE_BOMBER, data);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
@@ -17,13 +17,14 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.display.IDisplay;
 import games.strategy.engine.history.DelegateHistoryWriter;
 import games.strategy.engine.player.Player;
+import lombok.experimental.UtilityClass;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
 import org.triplea.sound.ISound;
 
+@UtilityClass
 public final class MockDelegateBridge {
-  private MockDelegateBridge() {}
 
   /**
    * Returns a new delegate bridge suitable for testing the given game data and player.
@@ -59,9 +60,17 @@ public final class MockDelegateBridge {
   public static Answer<int[]> withValues(final int... values) {
     return invocation -> {
       final int count = invocation.getArgument(1);
-      assertThat("count of requested random values does not match", values.length, is(count));
+      assertThat("count of requested random values does not match", count, is(values.length));
       return values;
     };
+  }
+
+  public static Answer<int[]> withDiceValues(final int... values) {
+    for (int i = 0; i < values.length; i++) {
+      // A die roll of N maps to a random value of N - 1.
+      values[i] -= 1;
+    }
+    return withValues(values);
   }
 
   public static void thenGetRandomShouldHaveBeenCalled(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
@@ -67,7 +67,7 @@ public final class MockDelegateBridge {
 
   public static Answer<int[]> withDiceValues(final int... values) {
     for (int i = 0; i < values.length; i++) {
-      // A die roll of N maps to a random value of N - 1.
+      // A die roll of N corresponds to a random value of N - 1.
       values[i] -= 1;
     }
     return withValues(values);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
@@ -2,29 +2,45 @@ package games.strategy.triplea.delegate.battle;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
 import static games.strategy.triplea.delegate.GameDataTestUtil.battleDelegate;
+import static games.strategy.triplea.delegate.GameDataTestUtil.britain;
+import static games.strategy.triplea.delegate.GameDataTestUtil.britishArtillery;
+import static games.strategy.triplea.delegate.GameDataTestUtil.britishInfantry;
+import static games.strategy.triplea.delegate.GameDataTestUtil.japan;
+import static games.strategy.triplea.delegate.GameDataTestUtil.japaneseInfantry;
 import static games.strategy.triplea.delegate.GameDataTestUtil.move;
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
+import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
 import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withDiceValues;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.times;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.triplea.delegate.AbstractDelegateTestCase;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.GameDataTestUtil;
 import games.strategy.triplea.xml.TestMapGameData;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
-class MustFightBattleTest extends AbstractDelegateTestCase {
+class MustFightBattleTest {
   @Test
   void testFightWithIsSuicideOnHit() {
     final GameData twwGameData = TestMapGameData.TWW.getGameData();
@@ -36,14 +52,11 @@ class MustFightBattleTest extends AbstractDelegateTestCase {
     addTo(sz33, GameDataTestUtil.americanCruiser(twwGameData).create(1, usa));
     final Territory sz40 = territory("40 Sea Zone", twwGameData);
     addTo(sz40, GameDataTestUtil.germanMine(twwGameData).create(1, germany));
-    final IDelegateBridge bridge = newDelegateBridge(usa);
-    advanceToStep(bridge, "CombatMove");
-    moveDelegate(twwGameData).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(twwGameData).start();
-    move(sz33.getUnits(), new Route(sz33, sz40));
-    moveDelegate(twwGameData).end();
+
+    final IDelegateBridge bridge = performCombatMove(usa, sz33.getUnits(), new Route(sz33, sz40));
     final IBattle battle =
         AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(sz40);
+    assertNotNull(battle);
 
     // Set first roll to hit (mine AA) and check that both units are killed
     whenGetRandom(bridge).thenAnswer(withValues(0));
@@ -68,10 +81,69 @@ class MustFightBattleTest extends AbstractDelegateTestCase {
     BattleDelegate.doInitialize(battleDelegate(twwGameData).getBattleTracker(), bridge);
     final IBattle battle =
         AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(celebes);
+    assertNotNull(battle);
 
     // Ensure battle ends, both units remain, and has 0 rolls
     battle.fight(bridge);
     assertEquals(2, celebes.getUnitCollection().size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(0));
+  }
+
+  @Test
+  void testCasualtyDefendersProvideSupport() throws Exception {
+    final GameData gameData = TestMapGameData.TWW.getGameData();
+    IEditableProperty<Boolean> lowLuck =
+        (IEditableProperty<Boolean>)
+            gameData.getProperties().getEditablePropertiesByName().get(Constants.LOW_LUCK);
+    lowLuck.setValue(false);
+
+    // Add a support rule to make british artillery provide an extra die to british infantry.
+    var supportAttachment =
+        new UnitSupportAttachment(
+                Constants.SUPPORT_ATTACHMENT_PREFIX + "Test", britishArtillery(gameData), gameData)
+            .setSide("defence")
+            .setFaction("allied")
+            .setPlayers(List.of(britain(gameData)))
+            .setUnitType(Set.of(britishInfantry(gameData)))
+            .setBonusType("bonus")
+            .setBonus(1)
+            .setDice("roll")
+            .setNumber(1);
+    britishArtillery(gameData).addAttachment(supportAttachment.getName(), supportAttachment);
+
+    // Set up an attack by 2 japanese infantry into 1 british artillery and 1 british infantry.
+    final Territory indoChina = territory("French Indochina", gameData);
+    removeFrom(indoChina, indoChina.getUnits());
+    addTo(indoChina, japaneseInfantry(gameData).create(2, japan(gameData)));
+    final Territory burma = territory("Burma", gameData);
+    removeFrom(burma, burma.getUnits());
+    addTo(burma, britishArtillery(gameData).create(1, britain(gameData)));
+    addTo(burma, britishInfantry(gameData).create(1, britain(gameData)));
+
+    final Collection<Unit> attackers = List.copyOf(indoChina.getUnits());
+    final IDelegateBridge bridge =
+        performCombatMove(japan(gameData), attackers, new Route(indoChina, burma));
+
+    final IBattle battle = AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(burma);
+    assertNotNull(battle);
+
+    // Attacking infantry roll two dice (both hit, killing the defenders).
+    // Defenders should roll 3 dice, via support attachment, even if they got killed by attackers.
+    // Note: This verifies that this exact number of dice are requested.
+    whenGetRandom(bridge).thenAnswer(withDiceValues(1, 1)).thenAnswer(withDiceValues(6, 6, 6));
+    battle.fight(bridge);
+    // Attackers killed the two defenders, while defenders failed to hit anything.
+    assertThat(burma.getUnits(), containsInAnyOrder(attackers.toArray()));
+  }
+
+  private IDelegateBridge performCombatMove(
+      GamePlayer player, Collection<Unit> units, Route route) {
+    final IDelegateBridge bridge = newDelegateBridge(player);
+    advanceToStep(bridge, "CombatMove");
+    moveDelegate(player.getData()).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(player.getData()).start();
+    move(units, route);
+    moveDelegate(player.getData()).end();
+    return bridge;
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/DefensiveGeneralTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/DefensiveGeneralTest.java
@@ -10,8 +10,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
@@ -24,8 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DefensiveGeneralTest {
 
-  @Mock ExecutionStack executionStack;
-  @Mock IDelegateBridge delegateBridge;
   @Mock BattleActions battleActions;
 
   @Nested


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix 2.6 dice roll count from support attachments when there are casualties.

This attempts to fix https://github.com/triplea-game/triplea/issues/10599, where casualties on the defensive side incorrectly stop giving support to the defensive dice roll.

Tested:
  - Open this save game: 
[2.5-correct-support-az.tsvg.zip](https://github.com/triplea-game/triplea/files/8912471/2.5-correct-support-az.tsvg.zip)
  - Perform the pending combat.

The defense side should have 6 dice rolls, regardless of the number of casualties inflicted by the attackers. The same can be confirmed with the same save game on 2.5. You can try several times if attackers end up not hitting enough times.

Adds a test to verify the behavior. Includes a some small clean ups in related code.

Concerns:
  - No unit tests are exercising this scenario. We should add some. Edit: Added.
  - It's not clear whether this has any other implications. @trevan, if you're around, could you review?

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
