### PR TITLE
Fix PlayerChooser height with few players.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
@@ -58,10 +58,12 @@ public final class ProLogUi {
   }
 
   static void notifyAiLogMessage(final String message) {
-    if (settingsWindow == null) {
-      return;
-    }
-    SwingUtilities.invokeLater(() -> settingsWindow.addMessage(message));
+    SwingUtilities.invokeLater(
+        () -> {
+          if (settingsWindow != null) {
+            settingsWindow.addMessage(message);
+          }
+        });
   }
 
   public static void notifyStartOfRound(final int round, final String name) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -13,6 +13,7 @@ import javax.swing.DefaultListCellRenderer;
 import javax.swing.ImageIcon;
 import javax.swing.JList;
 import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 import org.triplea.swing.SwingComponents;
 
@@ -64,12 +65,13 @@ class PlayerChooser extends JOptionPane {
             }
           }
         });
-    setMessage(SwingComponents.newJScrollPane(list));
+    JScrollPane scrollPane = SwingComponents.newJScrollPane(list);
 
     final int maxSize = 700;
-    final int suggestedSize = this.players.size() * 40;
+    final int suggestedSize = list.getPreferredSize().height;
     final int actualSize = Math.min(suggestedSize, maxSize);
-    setPreferredSize(new Dimension(300, actualSize));
+    scrollPane.setPreferredSize(new Dimension(300, actualSize));
+    setMessage(scrollPane);
   }
 
   /**


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix PlayerChooser height with few players. It was not accounting for the other space needed for JOptionPane, such as the buttons.

Also fix null check in ProLogUi.java.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
