### PR TITLE
Teach Hard AI to save up for a fleet.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
@@ -3,11 +3,13 @@ package games.strategy.engine.data.util;
 import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.Territory;
 import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import org.triplea.java.ObjectUtils;
+import org.triplea.java.collections.CollectionUtils;
 
 /**
  * Implements Breadth First Search (BFS) to traverse / find territories. Since the search criteria
@@ -41,19 +43,23 @@ public final class BreadthFirstSearch {
   }
 
   /**
-   * @param startTerritory The territory from where to start the search.
+   * @param startTerritories The territories from where to start the search.
    * @param neighborCondition Condition that neighboring territories must match to be considered
    *     neighbors.
    */
   public BreadthFirstSearch(
-      final Territory startTerritory, final Predicate<Territory> neighborCondition) {
-    this.map = startTerritory.getData().getMap();
-    this.visited = new HashSet<>(List.of(startTerritory));
-    this.territoriesToCheck = new ArrayDeque<>(List.of(startTerritory));
+      Collection<Territory> startTerritories, Predicate<Territory> neighborCondition) {
+    this.map = CollectionUtils.getAny(startTerritories).getData().getMap();
+    this.visited = new HashSet<>(startTerritories);
+    this.territoriesToCheck = new ArrayDeque<>(startTerritories);
     this.neighborCondition = neighborCondition;
   }
 
-  public BreadthFirstSearch(final Territory startTerritory) {
+  public BreadthFirstSearch(Territory startTerritory, Predicate<Territory> neighborCondition) {
+    this(List.of(startTerritory), neighborCondition);
+  }
+
+  public BreadthFirstSearch(Territory startTerritory) {
     this(startTerritory, t -> true);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -19,6 +19,7 @@ public class ProAi extends AbstractProAi {
   public void stopGame() {
     super.stopGame(); // absolutely MUST call super.stopGame() first
     concurrentCalc.cancel();
+    concurrentCalc.setGameData(null);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -608,7 +608,7 @@ class ProPurchaseAi {
         }
 
         // Find current battle result
-        final Set<Unit> enemyAttackingUnits =
+        final Collection<Unit> enemyAttackingUnits =
             new HashSet<>(enemyAttackOptions.getMax(t).getMaxUnits());
         enemyAttackingUnits.addAll(enemyAttackOptions.getMax(t).getMaxAmphibUnits());
         final ProBattleResult result =
@@ -1606,7 +1606,6 @@ class ProPurchaseAi {
                   purchaseTerritory.getTerritory(),
                   isBid);
           seaPurchaseOptionsForTerritory.addAll(purchaseOptions.getAirOptions());
-
           // Purchase enough sea defenders to hold territory
           while (true) {
             final boolean hasOnlyRetreatingSubs =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -1900,7 +1900,6 @@ class ProPurchaseAi {
       // Loop through adjacent purchase territories and purchase transport/amphib units
       final int distance =
           ProTransportUtils.findMaxMovementForTransports(purchaseOptions.getSeaTransportOptions());
-      final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(player, false);
       final Set<Territory> territoriesToCheck = new HashSet<>();
       for (final ProPurchaseTerritory purchaseTerritory : selectedPurchaseTerritories) {
         final Territory landTerritory = purchaseTerritory.getTerritory();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -1606,6 +1606,7 @@ class ProPurchaseAi {
                   purchaseTerritory.getTerritory(),
                   isBid);
           seaPurchaseOptionsForTerritory.addAll(purchaseOptions.getAirOptions());
+
           // Purchase enough sea defenders to hold territory
           while (true) {
             final boolean hasOnlyRetreatingSubs =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -2083,7 +2083,7 @@ class ProPurchaseAi {
         }
 
         // Add transport units to sea place territory and amphib units to land place territory
-        if (amphibUnitsToPlace.isEmpty() || transportUnitsToPlace.isEmpty()) {
+        if (!amphibUnitsToPlace.isEmpty() || !transportUnitsToPlace.isEmpty()) {
           for (final ProPlaceTerritory ppt : purchaseTerritory.getCanPlaceTerritories()) {
             if (landTerritory.equals(ppt.getTerritory())) {
               addUnitsToPlace(ppt, amphibUnitsToPlace);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
@@ -22,7 +22,11 @@ public class ProResourceTracker {
   }
 
   public boolean hasEnough(final ProPurchaseOption ppo) {
-    return getRemaining().greaterThanOrEqualTo(ppo.getCosts());
+    return hasEnough(ppo.getCosts());
+  }
+
+  public boolean hasEnough(final IntegerMap<Resource> amount) {
+    return getRemaining().greaterThanOrEqualTo(amount);
   }
 
   public void purchase(final ProPurchaseOption ppo) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -198,7 +198,8 @@ public final class ProMatches {
 
   public static Predicate<Territory> territoryCanMoveSeaUnitsThrough(
       final GamePlayer player, final boolean isCombatMove) {
-    return territoryCanMoveSeaUnits(player, isCombatMove).and(territoryHasOnlyIgnoredUnits(player));
+    return territoryCanMoveSeaUnits(player, isCombatMove)
+        .and(not(Matches.territoryIsBlockedSea(player)));
   }
 
   public static Predicate<Territory> territoryCanMoveSeaUnitsThroughOrClearedAndNotInList(
@@ -207,7 +208,7 @@ public final class ProMatches {
       final List<Territory> clearedTerritories,
       final List<Territory> notTerritories) {
     final Predicate<Territory> onlyIgnoredOrClearedMatch =
-        territoryHasOnlyIgnoredUnits(player).or(clearedTerritories::contains);
+        not(Matches.territoryIsBlockedSea(player)).or(clearedTerritories::contains);
     return territoryCanMoveSeaUnits(player, isCombatMove)
         .and(onlyIgnoredOrClearedMatch)
         .and(not(notTerritories::contains));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -198,8 +198,7 @@ public final class ProMatches {
 
   public static Predicate<Territory> territoryCanMoveSeaUnitsThrough(
       final GamePlayer player, final boolean isCombatMove) {
-    return territoryCanMoveSeaUnits(player, isCombatMove)
-        .and(not(Matches.territoryIsBlockedSea(player)));
+    return territoryCanMoveSeaUnits(player, isCombatMove).and(territoryHasOnlyIgnoredUnits(player));
   }
 
   public static Predicate<Territory> territoryCanMoveSeaUnitsThroughOrClearedAndNotInList(
@@ -208,7 +207,7 @@ public final class ProMatches {
       final List<Territory> clearedTerritories,
       final List<Territory> notTerritories) {
     final Predicate<Territory> onlyIgnoredOrClearedMatch =
-        not(Matches.territoryIsBlockedSea(player)).or(clearedTerritories::contains);
+        territoryHasOnlyIgnoredUnits(player).or(clearedTerritories::contains);
     return territoryCanMoveSeaUnits(player, isCombatMove)
         .and(onlyIgnoredOrClearedMatch)
         .and(not(notTerritories::contains));

--- a/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -66,6 +66,9 @@ public class AiGameTest {
       }
       log.info(i + " first round stats: " + getResourceSummary(game.getData()));
       assertThat(game.isGameOver(), is(false));
+      // Need to call stopGame() to ensure ProAI resets its static ConcurrentBattleCalculator, else
+      // the next test will use the wrong GameData for simulation.
+      game.stopGame();
     }
   }
 

--- a/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -37,11 +37,11 @@ public class AiGameTest {
     ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
     game.setStopGameOnDelegateExecutionStop(true);
     while (!game.isGameOver()) {
-      game.runNextStep();
-      if (game.getData().getSequence().getRound() > 50) {
-        log.warn("No winner after 50 rounds");
+      if (game.getData().getSequence().getRound() > 100) {
+        log.warn("No winner after 100 rounds");
         break;
       }
+      game.runNextStep();
     }
     assertThat(game.isGameOver(), is(true));
     assertThat(game.getData().getSequence().getRound(), greaterThan(2));
@@ -49,6 +49,24 @@ public class AiGameTest {
     assertThat(endDelegate.getWinners(), not(empty()));
     log.info("Game completed at round: " + game.getData().getSequence().getRound());
     log.info("Game winners: " + endDelegate.getWinners());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "map_making_tutorial,map/games/Test1.xml",
+  })
+  void testFirstRoundFiftyTimes(String mapName, String mapXmlPath) throws Exception {
+    // Run the first round of all-AI game 50 times. Ensure no errors and no winner so early.
+    for (int i = 0; i < 50; i++) {
+      GameSelectorModel gameSelector = GameTestUtils.loadGameFromURI(mapName, mapXmlPath);
+      ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
+      game.setStopGameOnDelegateExecutionStop(true);
+      while (!game.isGameOver() && game.getData().getSequence().getRound() < 2) {
+        game.runNextStep();
+      }
+      log.info(i + " first round stats: " + getResourceSummary(game.getData()));
+      assertThat(game.isGameOver(), is(false));
+    }
   }
 
   @Test
@@ -111,5 +129,13 @@ public class AiGameTest {
         GameTestUtils.loadGameFromURI(
             "imperialism_1974_board_game", "map/games/imperialism_1974_board_game.xml");
     return GameTestUtils.setUpGameWithAis(gameSelector);
+  }
+
+  private String getResourceSummary(GameData gameData) {
+    String summary = "";
+    for (GamePlayer p : gameData.getPlayerList()) {
+      summary += (summary.isEmpty() ? "" : ", ") + p.getName() + ": " + p.getResources();
+    }
+    return summary;
   }
 }

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
@@ -61,15 +61,15 @@ public class GameTestUtils {
   public static GameSelectorModel loadGameFromURI(String mapName, String mapXmlPath)
       throws Exception {
     GameSelectorModel gameSelector = new GameSelectorModel();
-    gameSelector.load(downloadMap(getMapDownloadURI(mapName)).resolve(mapXmlPath));
+    gameSelector.load(downloadMap(getMapDownloadURI(mapName), mapName).resolve(mapXmlPath));
     return gameSelector;
   }
 
-  private static Path downloadMap(URI uri) {
+  private static Path downloadMap(URI uri, String mapName) {
     return downloadedMaps.computeIfAbsent(
         uri,
         key -> {
-          Path targetTempFileToDownloadTo = FileUtils.newTempFolder().resolve("map.zip");
+          Path targetTempFileToDownloadTo = FileUtils.newTempFolder().resolve(mapName + ".zip");
           log.info("Downloading from: " + uri);
           try {
             try (ContentDownloader downloader = new ContentDownloader(uri)) {

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
@@ -37,15 +37,18 @@ import org.triplea.java.collections.CollectionUtils;
 @UtilityClass
 @Slf4j
 public class GameTestUtils {
-  private static Map<URI, Path> downloadedMaps = new HashMap<>();
+  private static Path tempHome;
+  private static final Map<URI, Path> downloadedMaps = new HashMap<>();
 
   public static void setUp() throws IOException {
     if (ProductVersionReader.getCurrentVersionOptional().isEmpty()) {
       ProductVersionReader.init();
     }
     // Use a temp dir for downloaded maps to not interfere with the real downloadedMaps folder.
-    Path tempHome = FileUtils.newTempFolder();
-    System.setProperty("user.home", tempHome.toString());
+    if (tempHome == null) {
+      tempHome = FileUtils.newTempFolder();
+      System.setProperty("user.home", tempHome.toString());
+    }
     ClientSetting.initialize();
     assertTrue(ClientFileSystemHelper.getUserMapsFolder().startsWith(tempHome.toAbsolutePath()));
     ClientSetting.aiMovePauseDuration.setValue(0);


### PR DESCRIPTION
## Change Summary & Additional Notes
With this change, Hard AI will not use its unused PUs to buy high-value non-sea units (that otherwise aren't needed) if it needs to save up for a fleet. It will do this if there are no enemy territories reachable by land from its factories and it's able to build fleets that can reach enemy land. Additionally, the logic only triggers if we tried and failed (due to not being able to defend) to place sea units and only if we're not already at the resources needed to build the max fleet we can.

This resolves a cause of the AI getting into a stalemate on the Mapmaking Tutorial map, which we use as a test for AI, see: https://github.com/triplea-game/triplea/issues/10649

Adds a test that runs 50 games for the first round only and ensures no errors and no winner on the first run (this validates that the above AI logic fix is effective in ensuring the AI doesn't leave its capital exposed). 

Tested:
  - Taking the 100-turn save game from the above issue and continuing AI turns to check that stalemate is broken: 
[autosave_round_odd.tsvg.zip](https://github.com/triplea-game/triplea/files/8915601/autosave_round_odd.tsvg.zip)
  - Truncating same save game to turn 6 (where stalemate started) and verifying it doesn't happen in the first place: 
[autosave_round_odd_t6.tsvg.zip](https://github.com/triplea-game/triplea/files/8915602/autosave_round_odd_t6.tsvg.zip)
  - Doing all-AI games on a number of maps and observing when this triggers. Observed positive improvement for AIs that exercise this (e.g. delaying the victory of the opposite AI side). Notably, this triggers for Classic 3rd ed for UK and for ANZAC on Pacific 1940. It also sometimes kicks in for Japan on Global 1940 on the first turn, when Japan would otherwise purchase 2 bombers instead of a fleet due to how it did its combat / non combat moves.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
