### PR TITLE
Refactor TuvUtils to allow caching to speed up AIs & battle calculator.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -3,13 +3,16 @@ package games.strategy.engine.delegate;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.display.IDisplay;
 import games.strategy.engine.history.IDelegateHistoryWriter;
 import games.strategy.engine.player.Player;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.ResourceLoader;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import java.util.Properties;
 import org.triplea.http.client.web.socket.messages.WebSocketMessage;
+import org.triplea.java.collections.IntegerMap;
 import org.triplea.sound.ISound;
 
 /**
@@ -97,4 +100,8 @@ public interface IDelegateBridge {
   void sendMessage(WebSocketMessage webSocketMessage);
 
   ResourceLoader getResourceLoader();
+
+  default IntegerMap<UnitType> getCostsForTuv(final GamePlayer player) {
+    return new TuvCostsCalculator().getCostsForTuv(player);
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/stats/TuvStat.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/stats/TuvStat.java
@@ -7,7 +7,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.mapdata.MapData;
-import games.strategy.triplea.util.TuvUtils;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import java.util.Collection;
 import java.util.function.Predicate;
 import org.triplea.java.collections.IntegerMap;
@@ -20,7 +20,7 @@ public class TuvStat implements IStat {
 
   @Override
   public double getValue(final GamePlayer player, final GameData data, final MapData mapData) {
-    final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(player, data);
+    final IntegerMap<UnitType> costs = new TuvCostsCalculator().getCostsForTuv(player);
     final Predicate<Unit> unitIsOwnedBy = Matches.unitIsOwnedBy(player);
     return data.getMap().getTerritories().stream()
         .map(Territory::getUnitCollection)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/fast/AggregateEstimate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/fast/AggregateEstimate.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.odds.calculator.AggregateResults;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.Collection;
 import org.triplea.java.collections.IntegerMap;
@@ -54,8 +55,9 @@ class AggregateEstimate extends AggregateResults {
       final GamePlayer defender,
       final Collection<Unit> defenders,
       final GameData data) {
-    final IntegerMap<UnitType> attackerCostsForTuv = TuvUtils.getCostsForTuv(attacker, data);
-    final IntegerMap<UnitType> defenderCostsForTuv = TuvUtils.getCostsForTuv(defender, data);
+    final TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
+    final IntegerMap<UnitType> attackerCostsForTuv = tuvCalculator.getCostsForTuv(attacker);
+    final IntegerMap<UnitType> defenderCostsForTuv = tuvCalculator.getCostsForTuv(defender);
     final int attackerTotalTuv = TuvUtils.getTuv(attackers, attackerCostsForTuv);
     final int defenderTotalTuv = TuvUtils.getTuv(defenders, defenderCostsForTuv);
     final Tuple<Double, Double> average =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -12,7 +12,7 @@ import games.strategy.triplea.ai.pro.data.ProPurchaseOptionMap;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.util.TuvUtils;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,7 +83,7 @@ public final class ProData {
         CollectionUtils.getMatches(
             data.getMap().getTerritories(), Matches.territoryHasUnitsOwnedBy(player));
     unitTerritoryMap = newUnitTerritoryMap(data);
-    unitValueMap = TuvUtils.getCostsForTuv(player, data);
+    unitValueMap = new TuvCostsCalculator().getCostsForTuv(player);
     purchaseOptions = new ProPurchaseOptionMap(player, data);
     minCostPerHitPoint = getMinCostPerHitPoint(purchaseOptions.getLandOptions());
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -103,7 +103,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
       if (randomTerritories) {
         pos += hitRandom[i];
         i++;
-        final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(currentPickingPlayer, data);
+        final IntegerMap<UnitType> costs = bridge.getCostsForTuv(currentPickingPlayer);
         final List<Unit> units = new ArrayList<>(currentPickingPlayer.getUnits());
 
         units.sort(Comparator.comparingInt(unit -> costs.getInt(unit.getType())));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -11,7 +11,6 @@ import games.strategy.engine.message.IRemote;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.triplea.util.TuvUtils;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -180,9 +180,9 @@ public class AirBattle extends AbstractBattle {
                 return;
               }
               final IntegerMap<UnitType> defenderCosts =
-                  TuvUtils.getCostsForTuv(defender, gameData);
+                  bridge.getCostsForTuv(defender);
               final IntegerMap<UnitType> attackerCosts =
-                  TuvUtils.getCostsForTuv(attacker, gameData);
+                  bridge.getCostsForTuv(attacker);
               attackingUnits.removeAll(attackingWaitingToDie);
               remove(attackingWaitingToDie, bridge, battleSite);
               defendingUnits.removeAll(defendingWaitingToDie);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -179,10 +179,8 @@ public class AirBattle extends AbstractBattle {
               if (!intercept) {
                 return;
               }
-              final IntegerMap<UnitType> defenderCosts =
-                  bridge.getCostsForTuv(defender);
-              final IntegerMap<UnitType> attackerCosts =
-                  bridge.getCostsForTuv(attacker);
+              final IntegerMap<UnitType> defenderCosts = bridge.getCostsForTuv(defender);
+              final IntegerMap<UnitType> attackerCosts = bridge.getCostsForTuv(attacker);
               attackingUnits.removeAll(attackingWaitingToDie);
               remove(attackingWaitingToDie, bridge, battleSite);
               defendingUnits.removeAll(defendingWaitingToDie);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/FinishedBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/FinishedBattle.java
@@ -123,7 +123,7 @@ public class FinishedBattle extends AbstractBattle {
     if (!lost.isEmpty()) {
       attackingUnits.removeAll(lost);
       if (attackingUnits.isEmpty()) {
-        final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(attacker, gameData);
+        final IntegerMap<UnitType> costs = bridge.getCostsForTuv(attacker);
         final int tuvLostAttacker =
             (withdrawn ? 0 : TuvUtils.getTuv(lost, attacker, costs, gameData));
         attackerLostTuv += tuvLostAttacker;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -441,7 +441,7 @@ public class MustFightBattle extends DependentBattle
       removeUnits(lost, bridge, battleSite, OFFENSE);
     }
     if (attackingUnits.isEmpty()) {
-      final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(attacker, gameData);
+      final IntegerMap<UnitType> costs = bridge.getCostsForTuv(attacker);
       final int tuvLostAttacker =
           (withdrawn ? 0 : TuvUtils.getTuv(lost, attacker, costs, gameData));
       attackerLostTuv += tuvLostAttacker;
@@ -1505,9 +1505,9 @@ public class MustFightBattle extends DependentBattle
       return;
     }
     // a handy summary of all the units killed
-    IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(attacker, gameData);
+    IntegerMap<UnitType> costs = bridge.getCostsForTuv(attacker);
     final int tuvLostAttacker = TuvUtils.getTuv(killed, attacker, costs, gameData);
-    costs = TuvUtils.getCostsForTuv(defender, gameData);
+    costs = bridge.getCostsForTuv(defender);
     final int tuvLostDefender = TuvUtils.getTuv(killed, defender, costs, gameData);
     final int tuvChange = tuvLostDefender - tuvLostAttacker;
     bridge

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -305,7 +305,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
               HistoryChangeFactory.removeUnitsFromTerritory(battleSite, suicideUnits)
                   .perform(bridge);
 
-              final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(attacker, gameData);
+              final IntegerMap<UnitType> costs = bridge.getCostsForTuv(attacker);
               final int tuvLostAttacker = TuvUtils.getTuv(suicideUnits, attacker, costs, gameData);
               attackerLostTuv += tuvLostAttacker;
             }
@@ -321,7 +321,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
                 // targets.removeAll(unitsCanDie);
                 HistoryChangeFactory.removeUnitsFromTerritory(battleSite, unitsCanDie)
                     .perform(bridge);
-                final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(defender, gameData);
+                final IntegerMap<UnitType> costs = bridge.getCostsForTuv(defender);
                 final int tuvLostDefender = TuvUtils.getTuv(unitsCanDie, defender, costs, gameData);
                 defenderLostTuv += tuvLostDefender;
               }
@@ -652,7 +652,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       final IDelegateBridge bridge, final CasualtyDetails casualties, final String currentTypeAa) {
     final List<Unit> killed = casualties.getKilled();
     if (!killed.isEmpty()) {
-      final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(attacker, gameData);
+      final IntegerMap<UnitType> costs = bridge.getCostsForTuv(attacker);
       final int tuvLostAttacker = TuvUtils.getTuv(killed, attacker, costs, gameData);
       attackerLostTuv += tuvLostAttacker;
       // attackingUnits.removeAll(casualties);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -55,7 +55,7 @@ public class CasualtySelector {
       final GamePlayer player,
       final Collection<Unit> targetsToPickFrom,
       final CombatValue combatValue,
-      final Territory battlesite,
+      final Territory battleSite,
       final IDelegateBridge bridge,
       final String text,
       final DiceRoll dice,
@@ -92,7 +92,7 @@ public class CasualtySelector {
           List.of(),
           new CasualtyDetails(),
           battleId,
-          battlesite,
+          battleSite,
           allowMultipleHitsPerUnit);
     }
 
@@ -109,7 +109,7 @@ public class CasualtySelector {
             hitsRemaining,
             player,
             combatValue,
-            battlesite,
+            battleSite,
             costs,
             data,
             allowMultipleHitsPerUnit);
@@ -144,7 +144,7 @@ public class CasualtySelector {
                 List.of(),
                 defaultCasualties,
                 battleId,
-                battlesite,
+                battleSite,
                 allowMultipleHitsPerUnit);
 
     if (!Properties.getPartialAmphibiousRetreat(data.getProperties())) {
@@ -197,7 +197,7 @@ public class CasualtySelector {
           player,
           sortedTargetsToPickFrom,
           combatValue,
-          battlesite,
+          battleSite,
           bridge,
           text,
           dice,
@@ -221,7 +221,7 @@ public class CasualtySelector {
           player,
           sortedTargetsToPickFrom,
           combatValue,
-          battlesite,
+          battleSite,
           bridge,
           text,
           dice,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -17,7 +17,6 @@ import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.triplea.util.TuvUtils;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeparator;
 import java.util.Collection;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -102,7 +102,7 @@ public class CasualtySelector {
 
     // Create production cost map, Maybe should do this elsewhere, but in case prices change, we do
     // it here.
-    final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(player, data);
+    final IntegerMap<UnitType> costs = bridge.getCostsForTuv(player);
     final Tuple<CasualtyList, List<Unit>> defaultCasualtiesAndSortedTargets =
         getDefaultCasualties(
             targetsToPickFrom,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.battle.BattleResults;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -165,8 +166,9 @@ public class AggregateResults {
     //
     // Because mean(x_i+c) = mean(x_i)+c for a constant c - the startingTuv in this case - we save
     // some computations and add the startingTuv after we have calculated the mean.
-    final IntegerMap<UnitType> attackerCostsForTuv = TuvUtils.getCostsForTuv(attacker, data);
-    final IntegerMap<UnitType> defenderCostsForTuv = TuvUtils.getCostsForTuv(defender, data);
+    final TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
+    final IntegerMap<UnitType> attackerCostsForTuv = tuvCalculator.getCostsForTuv(attacker);
+    final IntegerMap<UnitType> defenderCostsForTuv = tuvCalculator.getCostsForTuv(defender);
     final int attackerStartingTuv = TuvUtils.getTuv(attackers, attackerCostsForTuv);
     final int defenderStartingTuv = TuvUtils.getTuv(defenders, defenderCostsForTuv);
     final Mean mean = new Mean();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -14,6 +14,7 @@ import games.strategy.engine.framework.GameDataUtils;
 import games.strategy.triplea.delegate.battle.BattleResults;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -92,6 +93,8 @@ class BattleCalculator implements IBattleCalculator {
       final List<Unit> defenderOrderOfLosses =
           OrderOfLossesInputPanel.getUnitListByOrderOfLoss(
               this.defenderOrderOfLosses, defendingUnits, gameData);
+      // Use a single TuvCostsCalculator so its computations are cached.
+      final TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
       for (int i = 0; i < runCount && !cancelled; i++) {
         final CompositeChange allChanges = new CompositeChange();
         final DummyDelegateBridge bridge =
@@ -104,7 +107,8 @@ class BattleCalculator implements IBattleCalculator {
                 keepOneAttackingLandUnit,
                 retreatAfterRound,
                 retreatAfterXUnitsLeft,
-                retreatWhenOnlyAirLeft);
+                retreatWhenOnlyAirLeft,
+                tuvCalculator);
         final MustFightBattle battle =
             new MustFightBattle(location2, attacker2, gameData, battleTracker);
         battle.setHeadless(true);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -26,6 +26,8 @@ import org.triplea.util.Version;
 
 class BattleCalculator implements IBattleCalculator {
   @Nonnull private final GameData gameData;
+  // Use a single TuvCostsCalculator so its computations are cached.
+  private final TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
   @Setter private boolean keepOneAttackingLandUnit = false;
   @Setter private boolean amphibious = false;
   @Setter private int retreatAfterRound = -1;
@@ -93,8 +95,6 @@ class BattleCalculator implements IBattleCalculator {
       final List<Unit> defenderOrderOfLosses =
           OrderOfLossesInputPanel.getUnitListByOrderOfLoss(
               this.defenderOrderOfLosses, defendingUnits, gameData);
-      // Use a single TuvCostsCalculator so its computations are cached.
-      final TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
       for (int i = 0; i < runCount && !cancelled; i++) {
         final CompositeChange allChanges = new CompositeChange();
         final DummyDelegateBridge bridge =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -18,6 +18,7 @@ import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.UiContext;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.ui.Util;
 import java.awt.BorderLayout;
@@ -103,6 +104,7 @@ class BattleCalculatorPanel extends JPanel {
   private String defenderOrderOfLosses = null;
   private final Territory location;
   private final JList<String> territoryEffectsJList;
+  private TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
 
   BattleCalculatorPanel(final GameData data, final UiContext uiContext, final Territory location) {
     this.data = data;
@@ -1337,11 +1339,11 @@ class BattleCalculatorPanel extends JPanel {
       attackerUnitsTotalTuv.setText(
           "TUV: "
               + TuvUtils.getTuv(
-                  attackers, getAttacker(), TuvUtils.getCostsForTuv(getAttacker(), data), data));
+                  attackers, getAttacker(), tuvCalculator.getCostsForTuv(getAttacker()), data));
       defenderUnitsTotalTuv.setText(
           "TUV: "
               + TuvUtils.getTuv(
-                  defenders, getDefender(), TuvUtils.getCostsForTuv(getDefender(), data), data));
+                  defenders, getDefender(), tuvCalculator.getCostsForTuv(getDefender()), data));
       final int attackHitPoints = CasualtyUtil.getTotalHitpointsLeft(attackers);
       final int defenseHitPoints = CasualtyUtil.getTotalHitpointsLeft(defenders);
       attackerUnitsTotalHitpoints.setText("HP: " + attackHitPoints);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.units.UnitDamageReceivedChange;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.display.IDisplay;
@@ -16,9 +17,11 @@ import games.strategy.engine.random.PlainRandomSource;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import java.util.List;
 import java.util.Properties;
 import org.triplea.http.client.web.socket.messages.WebSocketMessage;
+import org.triplea.java.collections.IntegerMap;
 import org.triplea.sound.HeadlessSoundChannel;
 import org.triplea.sound.ISound;
 
@@ -34,6 +37,7 @@ public class DummyDelegateBridge implements IDelegateBridge {
   private final CompositeChange allChanges;
   private final GameData gameData;
   private MustFightBattle battle = null;
+  private TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
 
   public DummyDelegateBridge(
       final GamePlayer attacker,
@@ -169,5 +173,10 @@ public class DummyDelegateBridge implements IDelegateBridge {
 
   public void setBattle(final MustFightBattle battle) {
     this.battle = battle;
+  }
+
+  @Override
+  public IntegerMap<UnitType> getCostsForTuv(final GamePlayer player) {
+    return tuvCalculator.getCostsForTuv(player);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
@@ -37,7 +37,7 @@ public class DummyDelegateBridge implements IDelegateBridge {
   private final CompositeChange allChanges;
   private final GameData gameData;
   private MustFightBattle battle = null;
-  private TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
+  private final TuvCostsCalculator tuvCalculator;
 
   public DummyDelegateBridge(
       final GamePlayer attacker,
@@ -48,7 +48,8 @@ public class DummyDelegateBridge implements IDelegateBridge {
       final boolean attackerKeepOneLandUnit,
       final int retreatAfterRound,
       final int retreatAfterXUnitsLeft,
-      final boolean retreatWhenOnlyAirLeft) {
+      final boolean retreatWhenOnlyAirLeft,
+      final TuvCostsCalculator tuvCalculator) {
     attackingPlayer =
         new DummyPlayer(
             this,
@@ -72,6 +73,7 @@ public class DummyDelegateBridge implements IDelegateBridge {
     gameData = data;
     this.attacker = attacker;
     this.allChanges = allChanges;
+    this.tuvCalculator = tuvCalculator;
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -11,7 +11,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.UiContext;
-import games.strategy.triplea.util.TuvUtils;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeparator;
 import java.util.ArrayList;
@@ -120,7 +120,7 @@ public class PlayerUnitsPanel extends JPanel {
     }
     final IntegerMap<UnitType> costs;
     try (GameData.Unlocker ignored = data.acquireReadLock()) {
-      costs = TuvUtils.getCostsForTuv(gamePlayer, data);
+      costs = new TuvCostsCalculator().getCostsForTuv(gamePlayer);
     }
 
     GamePlayer previousPlayer = null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
@@ -9,7 +9,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.util.TuvUtils;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -23,6 +23,8 @@ import org.triplea.java.collections.CollectionUtils;
 
 @Slf4j
 class UnitInformation {
+  final TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
+
   void saveToFile(
       final PrintGenerationData printData, final Map<UnitType, UnitAttachment> unitInfoMap) {
     final Path outFile = printData.getOutDir().resolve("General Information.csv");
@@ -110,7 +112,7 @@ class UnitInformation {
     }
   }
 
-  private static int getCostInformation(final UnitType type, final GameData data) {
+  private int getCostInformation(final UnitType type, final GameData data) {
     final ProductionFrontier production =
         data.getProductionFrontierList().getProductionFrontier("production");
     if (production != null) {
@@ -122,7 +124,7 @@ class UnitInformation {
       }
     } else {
       final GamePlayer player = CollectionUtils.getAny(data.getPlayerList().getPlayers());
-      final int cost = TuvUtils.getCostsForTuv(player, data).getInt(type);
+      final int cost = tuvCalculator.getCostsForTuv(player).getInt(type);
       if (cost > 0) {
         return cost;
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -29,7 +29,7 @@ import games.strategy.triplea.ui.panels.map.MapPanel;
 import games.strategy.triplea.ui.panels.map.MapSelectionListener;
 import games.strategy.triplea.ui.panels.map.UnitSelectionListener;
 import games.strategy.triplea.util.TransportUtils;
-import games.strategy.triplea.util.TuvUtils;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import games.strategy.triplea.util.UnitSeparator;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -706,7 +706,7 @@ class EditPanel extends ActionPanel {
             sortUnitsToRemove(units);
             units.sort(
                 new UnitBattleComparator(
-                        TuvUtils.getCostsForTuv(player, getData()),
+                        new TuvCostsCalculator().getCostsForTuv(player),
                         getData(),
                         CombatValueBuilder.mainCombatValue()
                             .enemyUnits(List.of())
@@ -794,7 +794,7 @@ class EditPanel extends ActionPanel {
             sortUnitsToRemove(units);
             units.sort(
                 new UnitBattleComparator(
-                        TuvUtils.getCostsForTuv(player, getData()),
+                        new TuvCostsCalculator().getCostsForTuv(player),
                         getData(),
                         CombatValueBuilder.mainCombatValue()
                             .enemyUnits(List.of())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -703,25 +703,7 @@ class EditPanel extends ActionPanel {
               cancelEditAction.actionPerformed(null);
               return;
             }
-            sortUnitsToRemove(units);
-            units.sort(
-                new UnitBattleComparator(
-                        new TuvCostsCalculator().getCostsForTuv(player),
-                        getData(),
-                        CombatValueBuilder.mainCombatValue()
-                            .enemyUnits(List.of())
-                            .friendlyUnits(List.of())
-                            .side(BattleState.Side.OFFENSE)
-                            .gameSequence(getData().getSequence())
-                            .supportAttachments(getData().getUnitTypeList().getSupportRules())
-                            .lhtrHeavyBombers(
-                                Properties.getLhtrHeavyBombers(getData().getProperties()))
-                            .gameDiceSides(getData().getDiceSides())
-                            .territoryEffects(List.of())
-                            .build(),
-                        true,
-                        false)
-                    .reversed());
+            sortUnits(player, units);
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();
             for (final Unit u : units) {
@@ -791,25 +773,7 @@ class EditPanel extends ActionPanel {
               cancelEditAction.actionPerformed(null);
               return;
             }
-            sortUnitsToRemove(units);
-            units.sort(
-                new UnitBattleComparator(
-                        new TuvCostsCalculator().getCostsForTuv(player),
-                        getData(),
-                        CombatValueBuilder.mainCombatValue()
-                            .enemyUnits(List.of())
-                            .friendlyUnits(List.of())
-                            .side(BattleState.Side.OFFENSE)
-                            .gameSequence(getData().getSequence())
-                            .supportAttachments(getData().getUnitTypeList().getSupportRules())
-                            .lhtrHeavyBombers(
-                                Properties.getLhtrHeavyBombers(getData().getProperties()))
-                            .gameDiceSides(getData().getDiceSides())
-                            .territoryEffects(List.of())
-                            .build(),
-                        true,
-                        false)
-                    .reversed());
+            sortUnits(player, units);
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();
             for (final Unit u : units) {
@@ -968,6 +932,26 @@ class EditPanel extends ActionPanel {
     add(new JButton(changePoliticalRelationships));
     add(Box.createVerticalStrut(15));
     setWidgetActivation();
+  }
+
+  private void sortUnits(GamePlayer player, List<Unit> units) {
+    units.sort(
+        new UnitBattleComparator(
+                new TuvCostsCalculator().getCostsForTuv(player),
+                getData(),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(List.of())
+                    .friendlyUnits(List.of())
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(getData().getSequence())
+                    .supportAttachments(getData().getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(getData().getProperties()))
+                    .gameDiceSides(getData().getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                true,
+                false)
+            .reversed());
   }
 
   @SuppressWarnings("PMD.UnusedFormalParameter")

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -71,7 +71,7 @@ import games.strategy.triplea.ui.history.HistoryPanel;
 import games.strategy.triplea.ui.menubar.TripleAMenuBar;
 import games.strategy.triplea.ui.panel.move.MovePanel;
 import games.strategy.triplea.ui.panels.map.MapPanel;
-import games.strategy.triplea.util.TuvUtils;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import games.strategy.ui.ImageScrollModel;
 import games.strategy.ui.ImageScrollerSmallView;
 import games.strategy.ui.Util;
@@ -1161,6 +1161,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     SwingUtilities.invokeLater(
         () -> {
           final Map<String, Collection<Unit>> possibleUnitsToAttackStringForm = new HashMap<>();
+          final TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
           for (final Map.Entry<Territory, Collection<Unit>> entry :
               possibleUnitsToAttack.entrySet()) {
             final List<Unit> units = new ArrayList<>(entry.getValue());
@@ -1179,7 +1180,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                         .territoryEffects(TerritoryEffectHelper.getEffects(entry.getKey()))
                         .build(),
                     entry.getKey(),
-                    TuvUtils.getCostsForTuv(units.get(0).getOwner(), data),
+                    tuvCalculator.getCostsForTuv(units.get(0).getOwner()),
                     data);
             // OOL is ordered with the first unit the owner would want to remove but in a kamikaze
             // the player who picks is the attacker, so flip the order

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvCostsCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvCostsCalculator.java
@@ -1,0 +1,161 @@
+package games.strategy.triplea.util;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.NamedAttachable;
+import games.strategy.engine.data.ProductionFrontier;
+import games.strategy.engine.data.ProductionRule;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.attachments.UnitAttachment;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.triplea.java.collections.IntegerMap;
+
+public class TuvCostsCalculator {
+  @Nullable private IntegerMap<UnitType> costsAll;
+  private Map<GamePlayer, IntegerMap<UnitType>> costsPerPlayer = new HashMap<>();
+
+  /**
+   * Return map where keys are unit types and values are PU costs of that unit type, based on a
+   * player. Any production rule that produces multiple units (like artillery in NWO, costs 7 but
+   * makes 2 artillery, meaning effective price is 3.5 each) will have their costs rounded up on a
+   * per unit basis (so NWO artillery will become 4). Therefore, this map should NOT be used for
+   * Purchasing information!
+   *
+   * @param player The player to get costs schedule for
+   * @return a map of unit types to PU cost
+   */
+  public IntegerMap<UnitType> getCostsForTuv(final GamePlayer player) {
+    return costsPerPlayer.computeIfAbsent(player, p -> computeCostsForTuv(p));
+  }
+
+  public IntegerMap<UnitType> computeCostsForTuv(final GamePlayer player) {
+    final IntegerMap<UnitType> costs = computeBaseCostsForPlayer(player);
+    // since our production frontier may not cover all the units we control, and not the enemy
+    // units, we will add any unit types not in our list, based on the list for everyone
+    if (costsAll == null) {
+      costsAll = getCostsForTuvForAllPlayersMergedAndAveraged(player.getData());
+    }
+    for (final UnitType ut : costsAll.keySet()) {
+      if (!costs.keySet().contains(ut)) {
+        costs.put(ut, costsAll.getInt(ut));
+      }
+    }
+
+    // Override with XML TUV or consumesUnit sum
+    final IntegerMap<UnitType> result = new IntegerMap<>(costs);
+    for (final UnitType unitType : costs.keySet()) {
+      result.put(unitType, getTotalTuv(unitType, costs, new HashSet<>()));
+    }
+
+    return result;
+  }
+
+  private IntegerMap<UnitType> computeBaseCostsForPlayer(GamePlayer player) {
+    final Resource pus;
+    try (GameData.Unlocker ignored = player.getData().acquireReadLock()) {
+      pus = player.getData().getResourceList().getResource(Constants.PUS);
+    }
+
+    final IntegerMap<UnitType> costs = new IntegerMap<>();
+    final ProductionFrontier frontier = player.getProductionFrontier();
+    if (frontier != null) {
+      for (final ProductionRule rule : frontier.getRules()) {
+        final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
+        if (!(resourceOrUnit instanceof UnitType)) {
+          continue;
+        }
+        final UnitType type = (UnitType) resourceOrUnit;
+        final int costPerGroup = rule.getCosts().getInt(pus);
+        final int numberProduced = rule.getResults().getInt(type);
+        // we average the cost for a single unit, rounding up
+        final int roundedCostPerSingle =
+            (int) Math.ceil((double) costPerGroup / (double) numberProduced);
+        costs.put(type, roundedCostPerSingle);
+      }
+    }
+    return costs;
+  }
+
+  /**
+   * Return a map where key are unit types and values are the AVERAGED for all RULES (not for all
+   * players). Any production rule that produces multiple units (like artillery in NWO, costs 7 but
+   * makes 2 artillery, meaning effective price is 3.5 each) will have their costs rounded up on a
+   * per unit basis. Therefore, this map should NOT be used for Purchasing information!
+   */
+  private static IntegerMap<UnitType> getCostsForTuvForAllPlayersMergedAndAveraged(
+      final GameData data) {
+    final Resource pus;
+    try (GameData.Unlocker ignored = data.acquireReadLock()) {
+      pus = data.getResourceList().getResource(Constants.PUS);
+    }
+    final IntegerMap<UnitType> costs = new IntegerMap<>();
+    final Map<UnitType, List<Integer>> differentCosts = new HashMap<>();
+    for (final ProductionRule rule : data.getProductionRuleList().getProductionRules()) {
+      // only works for the first result, so we are assuming each purchase frontier only gives one
+      // type of unit
+      final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
+      if (!(resourceOrUnit instanceof UnitType)) {
+        continue;
+      }
+      final UnitType ut = (UnitType) resourceOrUnit;
+      final int numberProduced = rule.getResults().getInt(ut);
+      final int costPerGroup = rule.getCosts().getInt(pus);
+      // we round up the cost
+      final int roundedCostPerSingle =
+          (int) Math.ceil((double) costPerGroup / (double) numberProduced);
+      if (differentCosts.containsKey(ut)) {
+        differentCosts.get(ut).add(roundedCostPerSingle);
+      } else {
+        final List<Integer> listTemp = new ArrayList<>();
+        listTemp.add(roundedCostPerSingle);
+        differentCosts.put(ut, listTemp);
+      }
+    }
+    for (final UnitType ut : differentCosts.keySet()) {
+      int totalCosts = 0;
+      final List<Integer> costsForType = differentCosts.get(ut);
+      for (final int cost : costsForType) {
+        totalCosts += cost;
+      }
+      final int averagedCost =
+          (int) Math.round(((double) totalCosts / (double) costsForType.size()));
+      costs.put(ut, averagedCost);
+    }
+
+    // Add any units that have XML TUV even if they aren't purchasable
+    for (final UnitType unitType : data.getUnitTypeList()) {
+      final UnitAttachment ua = unitType.getUnitAttachment();
+      if (ua.getTuv() > 0) {
+        costs.put(unitType, ua.getTuv());
+      }
+    }
+
+    return costs;
+  }
+
+  private static int getTotalTuv(
+      final UnitType unitType, final IntegerMap<UnitType> costs, final Set<UnitType> alreadyAdded) {
+    final UnitAttachment ua = unitType.getUnitAttachment();
+    if (ua.getTuv() > 0) {
+      return ua.getTuv();
+    }
+    int tuv = costs.getInt(unitType);
+    if (ua.getConsumesUnits().isEmpty() || alreadyAdded.contains(unitType)) {
+      return tuv;
+    }
+    alreadyAdded.add(unitType);
+    for (final UnitType ut : ua.getConsumesUnits().keySet()) {
+      tuv += ua.getConsumesUnits().getInt(ut) * getTotalTuv(ut, costs, alreadyAdded);
+    }
+    alreadyAdded.remove(unitType);
+    return tuv;
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -30,21 +30,6 @@ import org.triplea.java.collections.IntegerMap;
 @UtilityClass
 public class TuvUtils {
   /**
-   * Return map where keys are unit types and values are PU costs of that unit type, based on a
-   * player. Any production rule that produces multiple units (like artillery in NWO, costs 7 but
-   * makes 2 artillery, meaning effective price is 3.5 each) will have their costs rounded up on a
-   * per unit basis (so NWO artillery will become 4). Therefore, this map should NOT be used for
-   * Purchasing information!
-   *
-   * @param player The player to get costs schedule for
-   * @param data The game data.
-   * @return a map of unit types to PU cost
-   */
-  public static IntegerMap<UnitType> getCostsForTuv(final GamePlayer player, final GameData data) {
-    return new TuvCostsCalculator().getCostsForTuv(player);
-  }
-
-  /**
    * Return map where keys are unit types and values are resource costs of that unit type, based on
    * a player. Any production rule that produces multiple units (like artillery in NWO, costs 7 but
    * makes 2 artillery, meaning effective price is 3.5 each) will have their costs rounded up on a

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -11,7 +11,6 @@ import games.strategy.engine.data.ResourceCollection;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,120 +41,7 @@ public class TuvUtils {
    * @return a map of unit types to PU cost
    */
   public static IntegerMap<UnitType> getCostsForTuv(final GamePlayer player, final GameData data) {
-    final Resource pus;
-    try (GameData.Unlocker ignored = data.acquireReadLock()) {
-      pus = data.getResourceList().getResource(Constants.PUS);
-    }
-
-    final IntegerMap<UnitType> costs = new IntegerMap<>();
-    final ProductionFrontier frontier = player.getProductionFrontier();
-    if (frontier != null) {
-      for (final ProductionRule rule : frontier.getRules()) {
-        final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
-        if (!(resourceOrUnit instanceof UnitType)) {
-          continue;
-        }
-        final UnitType type = (UnitType) resourceOrUnit;
-        final int costPerGroup = rule.getCosts().getInt(pus);
-        final int numberProduced = rule.getResults().getInt(type);
-        // we average the cost for a single unit, rounding up
-        final int roundedCostPerSingle =
-            (int) Math.ceil((double) costPerGroup / (double) numberProduced);
-        costs.put(type, roundedCostPerSingle);
-      }
-    }
-    // since our production frontier may not cover all the units we control, and not the enemy
-    // units,
-    // we will add any unit types not in our list, based on the list for everyone
-    final IntegerMap<UnitType> costsAll = getCostsForTuvForAllPlayersMergedAndAveraged(data);
-    for (final UnitType ut : costsAll.keySet()) {
-      if (!costs.keySet().contains(ut)) {
-        costs.put(ut, costsAll.getInt(ut));
-      }
-    }
-
-    // Override with XML TUV or consumesUnit sum
-    final IntegerMap<UnitType> result = new IntegerMap<>(costs);
-    for (final UnitType unitType : costs.keySet()) {
-      result.put(unitType, getTotalTuv(unitType, costs, new HashSet<>()));
-    }
-
-    return result;
-  }
-
-  /**
-   * Return a map where key are unit types and values are the AVERAGED for all RULES (not for all
-   * players). Any production rule that produces multiple units (like artillery in NWO, costs 7 but
-   * makes 2 artillery, meaning effective price is 3.5 each) will have their costs rounded up on a
-   * per unit basis. Therefore, this map should NOT be used for Purchasing information!
-   */
-  private static IntegerMap<UnitType> getCostsForTuvForAllPlayersMergedAndAveraged(
-      final GameData data) {
-    final Resource pus;
-    try (GameData.Unlocker ignored = data.acquireReadLock()) {
-      pus = data.getResourceList().getResource(Constants.PUS);
-    }
-    final IntegerMap<UnitType> costs = new IntegerMap<>();
-    final Map<UnitType, List<Integer>> differentCosts = new HashMap<>();
-    for (final ProductionRule rule : data.getProductionRuleList().getProductionRules()) {
-      // only works for the first result, so we are assuming each purchase frontier only gives one
-      // type of unit
-      final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
-      if (!(resourceOrUnit instanceof UnitType)) {
-        continue;
-      }
-      final UnitType ut = (UnitType) resourceOrUnit;
-      final int numberProduced = rule.getResults().getInt(ut);
-      final int costPerGroup = rule.getCosts().getInt(pus);
-      // we round up the cost
-      final int roundedCostPerSingle =
-          (int) Math.ceil((double) costPerGroup / (double) numberProduced);
-      if (differentCosts.containsKey(ut)) {
-        differentCosts.get(ut).add(roundedCostPerSingle);
-      } else {
-        final List<Integer> listTemp = new ArrayList<>();
-        listTemp.add(roundedCostPerSingle);
-        differentCosts.put(ut, listTemp);
-      }
-    }
-    for (final UnitType ut : differentCosts.keySet()) {
-      int totalCosts = 0;
-      final List<Integer> costsForType = differentCosts.get(ut);
-      for (final int cost : costsForType) {
-        totalCosts += cost;
-      }
-      final int averagedCost =
-          (int) Math.round(((double) totalCosts / (double) costsForType.size()));
-      costs.put(ut, averagedCost);
-    }
-
-    // Add any units that have XML TUV even if they aren't purchasable
-    for (final UnitType unitType : data.getUnitTypeList()) {
-      final UnitAttachment ua = unitType.getUnitAttachment();
-      if (ua.getTuv() > 0) {
-        costs.put(unitType, ua.getTuv());
-      }
-    }
-
-    return costs;
-  }
-
-  private static int getTotalTuv(
-      final UnitType unitType, final IntegerMap<UnitType> costs, final Set<UnitType> alreadyAdded) {
-    final UnitAttachment ua = unitType.getUnitAttachment();
-    if (ua.getTuv() > 0) {
-      return ua.getTuv();
-    }
-    int tuv = costs.getInt(unitType);
-    if (ua.getConsumesUnits().isEmpty() || alreadyAdded.contains(unitType)) {
-      return tuv;
-    }
-    alreadyAdded.add(unitType);
-    for (final UnitType ut : ua.getConsumesUnits().keySet()) {
-      tuv += ua.getConsumesUnits().getInt(ut) * getTotalTuv(ut, costs, alreadyAdded);
-    }
-    alreadyAdded.remove(unitType);
-    return tuv;
+    return new TuvCostsCalculator().getCostsForTuv(player);
   }
 
   /**

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
@@ -50,6 +50,7 @@ public final class MockDelegateBridge {
     when(delegateBridge.getRemotePlayer()).thenReturn(remotePlayer);
     when(delegateBridge.getRemotePlayer(any())).thenReturn(remotePlayer);
     when(delegateBridge.getSoundChannelBroadcaster()).thenReturn(mock(ISound.class));
+    when(delegateBridge.getCostsForTuv(any())).thenCallRealMethod();
     return delegateBridge;
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/AggregateResultsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/AggregateResultsTest.java
@@ -9,7 +9,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.triplea.util.TuvUtils;
+import games.strategy.triplea.util.TuvCostsCalculator;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -28,8 +28,9 @@ public class AggregateResultsTest {
     final List<Unit> attackingUnits = infantry(gameData).create(100, attacker);
     final GamePlayer defender = germans(gameData);
     final List<Unit> defendingUnits = infantry(gameData).create(100, defender);
-    final IntegerMap<UnitType> attackerCostsForTuv = TuvUtils.getCostsForTuv(attacker, gameData);
-    final IntegerMap<UnitType> defenderCostsForTuv = TuvUtils.getCostsForTuv(defender, gameData);
+    final TuvCostsCalculator tuvCalculator = new TuvCostsCalculator();
+    final IntegerMap<UnitType> attackerCostsForTuv = tuvCalculator.getCostsForTuv(attacker);
+    final IntegerMap<UnitType> defenderCostsForTuv = tuvCalculator.getCostsForTuv(defender);
 
     final Tuple<Double, Double> t =
         results.getAverageTuvOfUnitsLeftOver(attackerCostsForTuv, defenderCostsForTuv);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/util/TuvCostsCalculatorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/util/TuvCostsCalculatorTest.java
@@ -10,34 +10,35 @@ import games.strategy.triplea.xml.TestMapGameData;
 import org.junit.jupiter.api.Test;
 import org.triplea.java.collections.IntegerMap;
 
-class TuvUtilsTest {
+class TuvCostsCalculatorTest {
   private GameData gameData = TestMapGameData.TWW.getGameData();
+  private TuvCostsCalculator calculator = new TuvCostsCalculator();
 
   @Test
   void testCostsForTuv() {
     final GamePlayer germans = GameDataTestUtil.germany(gameData);
-    final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(germans, gameData);
+    final IntegerMap<UnitType> result = calculator.getCostsForTuv(germans);
     assertEquals(3, result.getInt(GameDataTestUtil.germanInfantry(gameData)));
   }
 
   @Test
   void testCostsForTuvWithConsumesUnit() {
     final GamePlayer germans = GameDataTestUtil.germany(gameData);
-    final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(germans, gameData);
+    final IntegerMap<UnitType> result = calculator.getCostsForTuv(germans);
     assertEquals(11, result.getInt(GameDataTestUtil.germanFactory(gameData)));
   }
 
   @Test
   void testCostsForTuvWithConsumesUnitChain() {
     final GamePlayer germans = GameDataTestUtil.germany(gameData);
-    final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(germans, gameData);
+    final IntegerMap<UnitType> result = calculator.getCostsForTuv(germans);
     assertEquals(12, result.getInt(GameDataTestUtil.germanFortification(gameData)));
   }
 
   @Test
   void testCostsForTuvWithXmlPropertySet() {
     final GamePlayer germans = GameDataTestUtil.germany(gameData);
-    final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(germans, gameData);
+    final IntegerMap<UnitType> result = calculator.getCostsForTuv(germans);
     assertEquals(25, result.getInt(GameDataTestUtil.germanBattleship(gameData)));
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes
Refactor TuvUtils to allow caching. New TuvCostsCalculator class is introduced, that keeps around intermediate calculations allowing repeated calls to re-use them. Refactors call sites to call the new class, although the BattleCalculator call site is the one that benefits the most from this, by re-using the same object for all battle simulations (which is heavily used by AI).

This should be especially impactful for maps with lots of units, for example "another world". I tested a round 7 game on "another world" with all Hard AI players and the mean runtime of MustFightBattle.fight() went from 3.0ms to 2.3ms, a 23% speedup (which was called around ~185,000 times during the course of AI simulations). 

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
