### PR TITLE
Fix logic error in getFullyResearchedPlayerTechCategories().

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -237,7 +237,7 @@ public class TechTracker {
     final Collection<TechnologyFrontier> technologyFrontiers = new ArrayList<>();
     final TechAttachment attachment = gamePlayer.getTechAttachment();
     for (final TechnologyFrontier tf : TechAdvance.getPlayerTechCategories(gamePlayer)) {
-      if (tf.getTechs().stream().anyMatch(t -> !t.hasTech(attachment))) {
+      if (tf.getTechs().stream().allMatch(t -> t.hasTech(attachment))) {
         technologyFrontiers.add(tf);
       }
     }


### PR DESCRIPTION
## Change Summary & Additional Notes
Also add a test.

Fixes the "cannot roll for technologies" part of https://github.com/triplea-game/triplea/issues/10684.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
