### PR TITLE
Simplify servers.yml pending different version handling

### DIFF
--- a/servers.yml
+++ b/servers.yml
@@ -1,19 +1,9 @@
 latest: 2.5.22294
 servers:
-  - version: "2.6.0"
-    lobby_uri: https://prerelease.triplea-game.org
-    message: |
-      Welcome to the TripleA PRE-RELEASE lobby!
   - version: "2.0.20057"
     lobby_uri: https://prod2-lobby.triplea-game.org
     message: |
       Welcome to the TripleA lobby!
       Please no politics, stay respectful, be welcoming, have fun.
-  - version: "2.0.19800"
-    inactive: true
-  - version: "2.0.0"
-    lobby_uri: https://prerelease.triplea-game.org
-    message: |
-      Welcome to the TripleA PRE-RELEASE lobby!
   - version: "0.0"
     inactive: true


### PR DESCRIPTION
Servers.yml will eventually no longer be used in favor of the server handling
correct version routing. Further, we are likely to have one server moving
forward that will enforce its own 'min-version'.

This update simplifies the 'servers.yml' file. Eventually we could delete it,
though the path to the file is hardcoded in 2.5 and previous game-clients

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
