### PR TITLE
Code-Climate Config: exclude markdown (md) files

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -40,3 +40,4 @@ exclude_patterns:
   - "gradlew"
   - ".github/ISSUE_TEMPLATES/*"
   - "**/*Test.java"
+  - "*.md"


### PR DESCRIPTION
It does not make a lot of sense to do markdown format linting, so it is
being turned off. We routinely ignore the called out warnings and they
are largely not important. The MD syntax enforces a consistent enough style,
beyond this deviations in consistency of MD files is largely inconsequential.
So, this is just not an important thing for us to be linting on right now.
Perhaps in the future an auto-formatter could do all the formatting for us.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
