### PR TITLE
Infra: remove configuration to deploy to prerelease

### DIFF
--- a/infrastructure/ansible/group_vars/all.yml
+++ b/infrastructure/ansible/group_vars/all.yml
@@ -6,7 +6,6 @@ lobby_db_name: lobby_db
 lobby_db_user: lobby_user
 admin_user: "admin"
 admin_home: "/home/{{ admin_user }}"
-github_releases_url: https://github.com/triplea-game/triplea/releases/download
 ansible_python_interpreter: /usr/bin/python3
 
 # When adding a new lobby, update 'nginx' to redirect

--- a/infrastructure/ansible/roles/bot/defaults/main.yml
+++ b/infrastructure/ansible/roles/bot/defaults/main.yml
@@ -25,10 +25,6 @@ bot_numbers: ["01", "02", "03", "04" ]
 # EG: with bot_prefix = 1, and bot_number=01, the bot number in the bot name will be '101'.
 bot_prefix: ""
 
-# Download URL for grabbing bot artifacts, used only in production release builds, prerelease
-# builds use a locally built artifact.
-zip_download: "https://github.com/triplea-game/triplea/releases/download/{{ bot_version }}/triplea-game-headless-{{ bot_version }}.zip"
-
 # Name of the bot server, this will typically be overriden in inventory. The final name of the bot host is
 # concatenation of the "Bot" the "bot name", and the "bot number" with prefix.
 bot_name: "Server"

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -34,19 +34,9 @@
     - "{{ bot_install_home }}"
     - "{{ bot_maps_folder }}"
 
-- name: deploy zip file (prerelease build only)
-  tags: [prerelease]
+- name: deploy game-headless-zip file
   copy:
     src: "triplea-game-headless-{{ bot_version }}.zip"
-    dest: "{{ bot_install_home }}/triplea-game-headless-{{ bot_version }}.zip"
-    owner: "{{ bot_user }}"
-    group: "{{ bot_user }}"
-
-
-- name: download zip file (release build only)
-  tags: [release]
-  get_url:
-    url: "{{ zip_download }}"
     dest: "{{ bot_install_home }}/triplea-game-headless-{{ bot_version }}.zip"
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"

--- a/infrastructure/ansible/roles/database/flyway/defaults/main.yml
+++ b/infrastructure/ansible/roles/database/flyway/defaults/main.yml
@@ -7,9 +7,6 @@ flyway_extracted_location: "/home/flyway/flyway-{{ flyway_version }}"
 
 flyway_db_url: "jdbc:postgresql://localhost:5432/{{ lobby_db_name }}"
 
-# Location where migration .sql files can be downloaded. This is the SQL that flway will be executing
-migrations_url: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/migrations.zip"
-
 flyway_user: "{{ lobby_db_user }}"
 
 flyway_password: "{{ lobby_db_password }}"

--- a/infrastructure/ansible/roles/database/flyway/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/flyway/tasks/main.yml
@@ -22,20 +22,11 @@
     owner: flyway
     group: flyway
 
-- name: copy flyway migrations zip (prerelease build only)
-  tags: [prerelease]
+- name: copy flyway migrations zip
   copy:
     src: "migrations.zip"
     dest: "/home/flyway/migrations.zip"
     mode: "0644"
-    owner: flyway
-    group: flyway
-
-- name: download flyway migrations (release build only)
-  tags: [release]
-  get_url:
-    url: "{{ migrations_url }}"
-    dest: "/home/flyway/migrations.zip"
     owner: flyway
     group: flyway
 

--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -13,8 +13,6 @@ lobby_server_db_user: lobby_user
 github_api_token: ""
 lobby_artifact: triplea-dropwizard-server-{{ lobby_version }}.zip
 lobby_jar_file: triplea-dropwizard-server-{{ lobby_version }}.jar
-lobby_artifact_download: |
-  "{{ github_releases_url }}/{{ lobby_version }}/{{ lobby_artifact }}"
 lobby_restart_on_new_deployment: true
 
 # How often to run map indexing. We need to be able to index all maps

--- a/infrastructure/ansible/roles/lobby_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/tasks/main.yml
@@ -17,20 +17,10 @@
     owner: "{{ lobby_server_user }}"
     group: "{{ lobby_server_user }}"
 
-- name: upload zip artifact file (prerelease build)
-  tags: [prerelease, deploy]
+- name: deploy lobby_server zip artifact file
   register: deploy_artifact
   copy:
     src: "{{ lobby_artifact }}"
-    dest: "{{ lobby_server_home_folder }}/{{ lobby_artifact }}"
-    owner: "{{ lobby_server_user }}"
-    group: "{{ lobby_server_user }}"
-
-- name: download zip artifact file (release build)
-  tags: [release, deploy]
-  register: deploy_artifact
-  get_url:
-    url: "{{ lobby_artifact_download }}"
     dest: "{{ lobby_server_home_folder }}/{{ lobby_artifact }}"
     owner: "{{ lobby_server_user }}"
     group: "{{ lobby_server_user }}"

--- a/infrastructure/run_ansible
+++ b/infrastructure/run_ansible
@@ -3,7 +3,6 @@
 set -eu
 
 ENVIRONMENT_VAGRANT=vagrant
-ENVIRONMENT_PRERELEASE=prerelease
 ENVIRONMENT_PRODUCTION=production
 
 # This script orchestrates deployments via ansible. If a prerelease deployment is done then
@@ -14,10 +13,9 @@ function usage() {
   echo ""
   echo "Examples:"
   echo "$0 --environment $ENVIRONMENT_VAGRANT"
-  echo "$0 --environment $ENVIRONMENT_PRERELEASE"
   echo ""
   echo "[options]"
-  echo "  --environment [$ENVIRONMENT_VAGRANT|$ENVIRONMENT_PRERELEASE|$ENVIRONMENT_PRODUCTION]"
+  echo "  --environment [$ENVIRONMENT_VAGRANT|$ENVIRONMENT_PRODUCTION]"
   echo "      The target environment for the deployment."
   echo "         $ENVIRONMENT_VAGRANT is an environment that can be launched locally via a VM"
   echo "  --tags [ansible tags]"
@@ -40,8 +38,7 @@ while [[ $# -gt 1 ]]; do
   case $key in
     --environment)
       ENVIRONMENT="$2"
-      if [[ "$ENVIRONMENT" != "$ENVIRONMENT_PRERELEASE" \
-         && "$ENVIRONMENT" != "$ENVIRONMENT_PRODUCTION" \
+      if [[ "$ENVIRONMENT" != "$ENVIRONMENT_PRODUCTION" \
          && "$ENVIRONMENT" != "$ENVIRONMENT_VAGRANT" ]]; then
         echo "Error, invalid value for --environment:  $ENVIRONMENT"
         usage
@@ -103,24 +100,11 @@ fi
 # Parse version number from product.properties
 VERSION=$(sed 's/.*=\s*//' "$(find .. -path "*/src/main/*" -name "product.properties")")
 
-# If we are deploying to production then we will download artifacts by version number
-# Otherwise we need to build the artifacts that we will be deploying
-if [ "$ENVIRONMENT" != "$ENVIRONMENT_PRODUCTION" ]; then
-  .include/build_latest_artifacts "$VERSION"
-fi
-
-# Do not execute release tasks unless we are deploying to production.
-# For example a release task would be to download an artifact and
-# a prerelease task would be to upload an artifact
-SKIP_TAGS=release
-if [ "$ENVIRONMENT" == "$ENVIRONMENT_PRODUCTION" ]; then
-  SKIP_TAGS=prerelease
-fi
+.include/build_latest_artifacts "$VERSION"
 
 # Run deployment
 ansible-playbook \
   --extra-vars "version=$VERSION" \
-  --skip-tags $SKIP_TAGS \
    --inventory ansible/inventory/$ENVIRONMENT \
    $ANSIBLE_ARG_VAULT_PASSWORD $ANSIBLE_ARG_TAGS ansible/site.yml
 


### PR DESCRIPTION
We will either be deploying to a local 'vagrant' test environment,
or production. This update removes the 'prerelease' configuration.
Since we will also be releasing production from 'tip', we can keep
the code that builds latest artifacts and deploys those artifacts
rather than downloading artifacts from github releases. The main
advantage to this is we get better unity between test and production
deployments.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
