### PR TITLE
Build Scripts: Remove an unnecessary validate yamls

### DIFF
--- a/.build/check-links-and-yaml-syntax/run
+++ b/.build/check-links-and-yaml-syntax/run
@@ -5,5 +5,3 @@ set -eEux
 script_dir=$(dirname "$0")
 "$script_dir/check-links"
 
-./gradlew --parallel validateYamls 
-


### PR DESCRIPTION
We already run 'validateYamls' from gradle with the 'check' command.
This validateYamls is redundant and does not cache it results.

Removing this redundancy speed up `./verify` from 90s to 60s (on my
laptop)

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
