### PR TITLE
Turn an assert into a warning.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -36,6 +36,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.Postconditions;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.jpanel.GridBagConstraintsAnchor;
@@ -50,6 +51,7 @@ import org.triplea.swing.jpanel.GridBagConstraintsFill;
  * <p>The dialog is used by various use cases like placing units or choosing which units take hits
  * in a battle round.
  */
+@Slf4j
 public final class UnitChooser extends JPanel {
   private static final long serialVersionUID = -4667032237550267682L;
 
@@ -733,10 +735,15 @@ public final class UnitChooser extends JPanel {
 
       unitImageFactoryForDecoratedImages = unitImageFactory.withScaleFactor(scaleFactor);
 
-      Postconditions.assertState(
-          nonWithdrawableImage.getHeight()
-              == getNonWithdrawableImageHeight(
-                  unitImageFactoryForDecoratedImages.getUnitImageHeight()));
+      double expectedHeight =
+          getNonWithdrawableImageHeight(unitImageFactoryForDecoratedImages.getUnitImageHeight());
+      if (nonWithdrawableImage.getHeight() != expectedHeight) {
+        // Don't use Postconditions.assertState() as that turns a UI glitch into a game hang.
+        log.warn(
+            "Unexpected nonWithdrawableImage height {} != {}",
+            nonWithdrawableImage.getHeight(),
+            expectedHeight);
+      }
     }
 
     /**


### PR DESCRIPTION
## Change Summary & Additional Notes
As an assert, this essentially hangs the game, because the combat step can't continue.  A warning doesn't have this problem.

Repro: https://github.com/triplea-game/triplea/issues/10713

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
