### PR TITLE
Fix ProMatches logic around passable sea territories.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -207,8 +207,8 @@ public final class ProMatches {
       final List<Territory> clearedTerritories,
       final List<Territory> notTerritories) {
     final Predicate<Territory> onlyIgnoredOrClearedMatch =
-        Matches.territoryIsBlockedSea(player).or(clearedTerritories::contains);
-    return territoryCanMoveSeaUnitsThrough(player, isCombatMove)
+        not(Matches.territoryIsBlockedSea(player)).or(clearedTerritories::contains);
+    return territoryCanMoveSeaUnits(player, isCombatMove)
         .and(onlyIgnoredOrClearedMatch)
         .and(not(notTerritories::contains));
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -197,7 +197,8 @@ public final class ProMatches {
 
   public static Predicate<Territory> territoryCanMoveSeaUnitsThrough(
       final GamePlayer player, final boolean isCombatMove) {
-    return territoryCanMoveSeaUnits(player, isCombatMove).and(territoryHasOnlyIgnoredUnits(player));
+    return territoryCanMoveSeaUnits(player, isCombatMove)
+        .and(not(Matches.territoryIsBlockedSea(player)));
   }
 
   public static Predicate<Territory> territoryCanMoveSeaUnitsThroughOrClearedAndNotInList(
@@ -206,21 +207,10 @@ public final class ProMatches {
       final List<Territory> clearedTerritories,
       final List<Territory> notTerritories) {
     final Predicate<Territory> onlyIgnoredOrClearedMatch =
-        territoryHasOnlyIgnoredUnits(player).or(clearedTerritories::contains);
-    return territoryCanMoveSeaUnits(player, isCombatMove)
+        Matches.territoryIsBlockedSea(player).or(clearedTerritories::contains);
+    return territoryCanMoveSeaUnitsThrough(player, isCombatMove)
         .and(onlyIgnoredOrClearedMatch)
         .and(not(notTerritories::contains));
-  }
-
-  private static Predicate<Territory> territoryHasOnlyIgnoredUnits(final GamePlayer player) {
-    return t -> {
-      final Predicate<Unit> subOnly =
-          Matches.unitIsInfrastructure()
-              .or(Matches.unitCanBeMovedThroughByEnemies())
-              .or(Matches.enemyUnit(player).negate());
-      return t.getUnitCollection().allMatch(subOnly)
-          || Matches.territoryHasNoEnemyUnits(player).test(t);
-    };
   }
 
   public static Predicate<Territory> territoryHasEnemyUnitsOrCantBeHeld(


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix ProMatches logic around passable sea territories to account for transports that don't block movement.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
