### PR TITLE
Fix locking when cloning data.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -275,10 +275,7 @@ public abstract class AbstractProAi extends AbstractAi {
   private GameData copyData(GameData data) {
     Version engineVersion = ProductVersionReader.getCurrentVersion();
     GameDataManager.Options options = GameDataManager.Options.builder().withDelegates(true).build();
-    GameData dataCopy;
-    try (GameData.Unlocker ignored = data.acquireWriteLock()) {
-      dataCopy = GameDataUtils.cloneGameData(data, options, engineVersion).orElse(null);
-    }
+    GameData dataCopy = GameDataUtils.cloneGameData(data, options, engineVersion).orElse(null);
     Optional.ofNullable(dataCopy).ifPresent(this::prepareData);
     return dataCopy;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -162,14 +162,14 @@ final class ExportMenu extends JMenu {
     if (chooser.showSaveDialog(frame) != JOptionPane.OK_OPTION) {
       return;
     }
+    final var cloneOptions = GameDataManager.Options.builder().withHistory(true).build();
+    final GameData clone = GameDataUtils.cloneGameData(gameData, cloneOptions).orElse(null);
+    if (clone == null) {
+      return;
+    }
     try (PrintWriter writer =
             new PrintWriter(chooser.getSelectedFile(), StandardCharsets.UTF_8.toString());
         GameData.Unlocker ignored = gameData.acquireReadLock()) {
-      final var cloneOptions = GameDataManager.Options.builder().withHistory(true).build();
-      final GameData clone = GameDataUtils.cloneGameData(gameData, cloneOptions).orElse(null);
-      if (clone == null) {
-        return;
-      }
       writer.append(defaultFileName).println(',');
       writer.append("TripleA Engine Version: ,");
       writer.append(ProductVersionReader.getCurrentVersion().toString()).println(',');
@@ -388,13 +388,11 @@ final class ExportMenu extends JMenu {
   private void exportSetupCharts() {
     final JFrame frame = new JFrame("Export Setup Charts");
     frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    final GameData clonedGameData;
-    try (GameData.Unlocker ignored = gameData.acquireReadLock()) {
-      final var cloneOptions = GameDataManager.Options.builder().withHistory(true).build();
-      clonedGameData = GameDataUtils.cloneGameData(gameData, cloneOptions).orElse(null);
-      if (clonedGameData == null) {
-        return;
-      }
+    final var cloneOptions = GameDataManager.Options.builder().withHistory(true).build();
+    final GameData clonedGameData =
+        GameDataUtils.cloneGameData(gameData, cloneOptions).orElse(null);
+    if (clonedGameData == null) {
+      return;
     }
     final JComponent newContentPane = new SetupFrame(clonedGameData);
     // content panes must be opaque


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix locking when cloning data.

Since cloneGameData() internally acquires a lock, the callers don't need to hold one. This fixes an issue where the caller might hold a read lock when calling into clone, which requires a write lock, causing a self-deadlock.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
