### PR TITLE
Don't spawn new process when joining host in lobby

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
@@ -4,8 +4,6 @@ package games.strategy.engine.framework;
 public class CliProperties {
   public static final String TRIPLEA_GAME = "triplea.game";
   public static final String TRIPLEA_SERVER = "triplea.server";
-  public static final String TRIPLEA_CLIENT = "triplea.client";
-  public static final String TRIPLEA_HOST = "triplea.host";
   public static final String TRIPLEA_PORT = "triplea.port";
   public static final String TRIPLEA_NAME = "triplea.name";
   public static final String SERVER_PASSWORD = "triplea.server.password";

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -1,10 +1,5 @@
 package games.strategy.engine.framework.startup.mc;
 
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_HOST;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
-
 import com.google.common.base.Preconditions;
 import games.strategy.engine.chat.ChatMessagePanel.ChatSoundProfile;
 import games.strategy.engine.chat.ChatPanel;
@@ -13,7 +8,6 @@ import games.strategy.engine.framework.ClientGame;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameObjectStreamFactory;
 import games.strategy.engine.framework.GameRunner;
-import games.strategy.engine.framework.GameState;
 import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.network.ui.ChangeGameOptionsClientAction;
@@ -51,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.swing.Action;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -166,16 +161,6 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   private static ClientProps getProps(final Component ui) {
-    if (System.getProperty(TRIPLEA_CLIENT, "false").equals("true") && GameState.notStarted()) {
-      final ClientProps props =
-          ClientProps.builder()
-              .host(System.getProperty(TRIPLEA_HOST))
-              .name(System.getProperty(TRIPLEA_NAME))
-              .port(Integer.parseInt(System.getProperty(TRIPLEA_PORT)))
-              .build();
-      GameState.setStarted();
-      return props;
-    }
     // load in the saved name!
     final String playername = ClientSetting.playerName.getValueOrThrow();
     final Interruptibles.Result<ClientProps> result =
@@ -208,12 +193,12 @@ public class ClientModel implements IMessengerErrorListener {
    * connected (user messaging will be handled by this method). Method returns true if successfully
    * connected.
    */
-  public boolean createClientMessenger(final Component ui) {
+  public boolean createClientMessenger(final Component ui, @Nullable ClientProps clientProps) {
     this.ui = JOptionPane.getFrameForComponent(ui);
     gameDataOnStartup = gameSelectorModel.getGameData();
     gameSelectorModel.setCanSelect(false);
     // load in the saved name!
-    final ClientProps props = getProps(this.ui);
+    final ClientProps props = clientProps == null ? getProps(this.ui) : clientProps;
     if (props == null) {
       return false;
     }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.auto.update;
 
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
 
@@ -28,10 +27,9 @@ public final class UpdateChecks {
   }
 
   private static boolean shouldRun() {
-    // if we are joining a game online, or hosting, or loading straight into a savegame, do not
-    // check
+    // if we are joining a game online, or hosting, or loading straight into a savegame,
+    // do not check
     return !System.getProperty(TRIPLEA_SERVER, "false").equalsIgnoreCase("true")
-        && !System.getProperty(TRIPLEA_CLIENT, "false").equalsIgnoreCase("true")
         && System.getProperty(TRIPLEA_GAME, "").isEmpty();
   }
 }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/GameProcess.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/GameProcess.java
@@ -3,9 +3,7 @@ package games.strategy.engine.framework;
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_COMMENTS;
 import static games.strategy.engine.framework.CliProperties.LOBBY_URI;
 import static games.strategy.engine.framework.CliProperties.SERVER_PASSWORD;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_HOST;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
@@ -13,9 +11,7 @@ import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import org.triplea.domain.data.UserName;
 import org.triplea.game.client.HeadedApplicationContext;
-import org.triplea.lobby.common.GameDescription;
 
 public class GameProcess {
 
@@ -44,25 +40,6 @@ public class GameProcess {
     if (fileName.length() > 0) {
       commands.add("-D" + TRIPLEA_GAME + "=" + fileName);
     }
-    commands.add(getMainClassName());
-    ProcessRunnerUtil.exec(commands);
-  }
-
-  /** Spawns a new process to join a network game. */
-  public static void joinGame(final GameDescription description, final UserName userName) {
-    final GameDescription.GameStatus status = description.getStatus();
-    if (GameDescription.GameStatus.LAUNCHING == status) {
-      return;
-    }
-
-    final List<String> commands = new ArrayList<>();
-    ProcessRunnerUtil.populateBasicJavaArgs(commands);
-    final String prefix = "-D";
-    commands.add(prefix + TRIPLEA_CLIENT + "=true");
-    commands.add(prefix + TRIPLEA_PORT + "=" + description.getHostedBy().getPort());
-    commands.add(
-        prefix + TRIPLEA_HOST + "=" + description.getHostedBy().getAddress().getHostAddress());
-    commands.add(prefix + TRIPLEA_NAME + "=" + userName.getValue());
     commands.add(getMainClassName());
     ProcessRunnerUtil.exec(commands);
   }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -74,7 +74,7 @@ public class MetaSetupPanel extends SetupPanel {
                 HtmlUtils.getHtml(
                     bundle.getText(
                         "startup.SetupPanelModel.btn.PlayOnline.ConnectToNetworkedGame.Tltp")))
-            .actionListener(() -> new Thread(model::showClient).start())
+            .actionListener(() -> new Thread(() -> model.showClient(null)).start())
             .build();
     final JButton enginePreferences =
         new JButtonBuilder(bundle.getText("startup.SetupPanelModel.btn.EnginePreferences.Lbl"))

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
@@ -27,6 +27,7 @@ import java.awt.Dimension;
 import java.net.URI;
 import java.util.Optional;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import lombok.Getter;
@@ -97,7 +98,7 @@ public class HeadedServerSetupModel {
    * A method that establishes a connection to a remote game and displays the game start screen
    * afterwards if the connection was successfully established.
    */
-  public void showClient() {
+  public void showClient(@Nullable ClientModel.ClientProps clientProps) {
     Preconditions.checkState(!SwingUtilities.isEventDispatchThread());
     final ClientModel model =
         new ClientModel(
@@ -107,7 +108,7 @@ public class HeadedServerSetupModel {
             HeadedGameRunner::showMainFrame,
             HeadedGameRunner::clientLeftGame,
             HeadedPlayerTypes.CLIENT_PLAYER);
-    if (model.createClientMessenger(ui)) {
+    if (model.createClientMessenger(ui, clientProps)) {
       SwingUtilities.invokeLater(() -> setGameTypePanel(new ClientSetupPanel(model)));
     } else {
       model.cancel();

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -21,6 +21,8 @@ import javax.swing.JTable;
 import javax.swing.JToolBar;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
+import org.triplea.game.client.HeadedGameRunner;
+import org.triplea.java.ThreadRunner;
 import org.triplea.lobby.common.GameDescription;
 import org.triplea.swing.MouseListenerBuilder;
 import org.triplea.swing.SwingAction;
@@ -190,7 +192,16 @@ class LobbyGamePanel extends JPanel {
     // we sort the table, so get the correct index
     final GameDescription description =
         gameTableModel.get(gameTable.convertRowIndexToModel(selectedIndex));
-    GameProcess.joinGame(description, lobbyClient.getUserName());
+    final GameDescription.GameStatus status = description.getStatus();
+    if (GameDescription.GameStatus.LAUNCHING == status) {
+      return;
+    }
+    ThreadRunner.runInNewThread(
+        () ->
+            HeadedGameRunner.showMainFrameClient(
+                description.getHostedBy().getAddress().getHostAddress(),
+                description.getHostedBy().getPort(),
+                lobbyClient.getUserName().getValue()));
   }
 
   private void hostGame(final URI lobbyUri) {

--- a/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -4,7 +4,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
+import static games.strategy.engine.framework.CliProperties.TRIPLEA_HOST;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_MAP_DOWNLOAD;
+import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
+import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
 
 import games.strategy.engine.ClientFileSystemHelper;
@@ -141,6 +144,14 @@ public final class HeadedGameRunner {
         });
 
     UpdateChecks.launch();
+  }
+
+  public static void showMainFrameClient(String host, int port, String name) {
+    System.setProperty(TRIPLEA_CLIENT, "true");
+    System.setProperty(TRIPLEA_HOST, host);
+    System.setProperty(TRIPLEA_PORT, String.valueOf(port));
+    System.setProperty(TRIPLEA_NAME, name);
+    showMainFrame();
   }
 
   /**

--- a/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -2,12 +2,8 @@ package org.triplea.game.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_HOST;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_MAP_DOWNLOAD;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
 
 import games.strategy.engine.ClientFileSystemHelper;
@@ -17,6 +13,7 @@ import games.strategy.engine.framework.GameShutdownRegistry;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
+import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.panels.main.HeadedServerSetupModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
@@ -147,11 +144,9 @@ public final class HeadedGameRunner {
   }
 
   public static void showMainFrameClient(String host, int port, String name) {
-    System.setProperty(TRIPLEA_CLIENT, "true");
-    System.setProperty(TRIPLEA_HOST, host);
-    System.setProperty(TRIPLEA_PORT, String.valueOf(port));
-    System.setProperty(TRIPLEA_NAME, name);
-    showMainFrame();
+    MainFrame.show();
+    headedServerSetupModel.showClient(
+        ClientModel.ClientProps.builder().host(host).name(name).port(port).build());
   }
 
   /**
@@ -167,10 +162,6 @@ public final class HeadedGameRunner {
       final ServerModel serverModel = headedServerSetupModel.showServer();
       MainFrame.addQuitAction(serverModel::cancel);
       System.clearProperty(TRIPLEA_SERVER);
-    } else if (System.getProperty(TRIPLEA_CLIENT, "false").equals("true")) {
-      MainFrame.show();
-      headedServerSetupModel.showClient();
-      System.clearProperty(TRIPLEA_CLIENT);
     } else {
       final String saveGameFileName = System.getProperty(TRIPLEA_GAME, "");
       if (!saveGameFileName.isEmpty()) {


### PR DESCRIPTION
## Change Summary & Additional Notes

@asvitkine @DanVanAtta Please have a look at this changes. I think this change might be fine 90% of the time, but for the other 10% this might introduce unexpected behaviour. I don't trust the code enough to perform the same changes for hosting games on the lobby because there's some game logic that just exists the JVM on certain conditions. I'd really like to hear your opinion on this. If you think this is a good choice or if some further refactoring is required before this can happen.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|TripleA no longer creates a new process when joining a game in the lobby<!--END_RELEASE_NOTE-->
