### PR TITLE
Ansible config: inline 'security' role & update apt cache explicitly

### DIFF
--- a/infrastructure/ansible/roles/system/apt_common_tools/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/apt_common_tools/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Update and upgrade apt packages
   apt:
     upgrade: yes
+    update_cache: yes
     cache_valid_time: 86400 # One day, only updates if caches are older than this.
 
 - name: apt install standard utilities and packages
@@ -11,6 +12,8 @@
       # Ansible needs to create when becoming an unprivileged user"
       # https://stackoverflow.com/questions/46352173/ansible-failed-to-set-permissions-on-the-temporary
       - acl
+      - fail2ban
       - htop
       - iftop
+      - unattended-upgrades
       - unzip

--- a/infrastructure/ansible/roles/system/security/README.md
+++ b/infrastructure/ansible/roles/system/security/README.md
@@ -1,2 +1,0 @@
-Security role updates security related configurations and installs
-security related packages.

--- a/infrastructure/ansible/roles/system/security/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/security/tasks/main.yml
@@ -1,6 +1,0 @@
-- name: install security related apt packages
-  apt:
-    state: present
-    name:
-      - fail2ban
-      - unattended-upgrades

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -3,7 +3,6 @@
     - system/apt_common_tools
     - system/hostname
     - system/firewall
-    - system/security
     - system/journald
     - system/admin_user
 


### PR DESCRIPTION
1. Add an explicit update of the apt cache, we want to be sure this
is happening.
2. Simplify: Security role is just installing a couple of apt-packages, we
can avoid the additional role and just inline these few packages

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
