### PR TITLE
Fixing Global 40 House Rules 2.72 Update

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -2037,7 +2037,7 @@
 - mapName: Global 40 House Rules
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/global_40_house_rules/archive/master.zip
-  version: 15
+  version: 16
   img: https://raw.githubusercontent.com/triplea-maps/global_40_house_rules/master/preview.png
   description:
     <br>
@@ -2679,11 +2679,3 @@
   img: https://raw.githubusercontent.com/triplea-maps/Belgium/master/preview.png
   description: |
    <br>Conflict on a map of Belgium
-- mapName: Global 40 House Rules
-  mapCategory: EXPERIMENTAL
-  url: https://github.com/triplea-maps/global_40_house_rules/archive/master.zip
-  version: 16
-  img: https://raw.githubusercontent.com/triplea-maps/global_40_house_rules/master/preview.png
-  description:
-    <br>
-    <br>Global 40 House Rules. Adds House Rules using Technologies and Map Options. Also adds Canada that was created by simon 33.<br>


### PR DESCRIPTION
Hopefully lol
Fixes Issue #10729

Edit
Is there a way to change the default so it doesn't automatically update without a PR ? I keep forgetting and hit enter without switching it. Seems the default should be the PR one
## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
