### PR TITLE
Infra: run certbot 'certonly' to avoid updating nginx configuration

### DIFF
--- a/infrastructure/ansible/roles/certbot/tasks/main.yml
+++ b/infrastructure/ansible/roles/certbot/tasks/main.yml
@@ -10,17 +10,12 @@
       - certbot
       - python3-certbot-nginx
 
-- name: look for certbot generated key file
-  stat:
-    path: /etc/letsencrypt/live/{{ inventory_hostname }}/cert.pem
-  register: has_certbot_pem
-
-- name: run certbot
+- name: run certbot to get certs
   command: |
-     certbot --nginx -n \
+     certbot certonly \
+         --nginx -n \
          -m tripleabuilderbot@gmail.com \
          -d {{ inventory_hostname }} \
          --agree-tos \
          --rsa-key-size 4096
-  when: has_certbot_pem.stat.exists == false
-
+  creates: /etc/letsencrypt/live/{{ inventory_hostname }}/cert.pem

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -30,11 +30,6 @@
   tags: lobby
   roles:
     - certbot
-    # Re-run nginx role to fix configuration and do final restart.
-    # Modifications to /etc/nginx/sites-enabled/default triggers a NGINX restart.
-    # Certbot role adds a new line to /etc/nginx/sites-enabled/default
-    # every time it runs and makes changes.
-    - nginx
 
 - hosts: botHosts
   tags: [bot, bots]


### PR DESCRIPTION
Certbot adds a new line to nginx config after it runs, even if no
other changes are made. This causes some trouble in automatically
restarting nginx. We hack around this by running a nginx role
after the certbot role to restore the configuration file.

If we did not do this confguration restore, then the next lobby
deployment would cause a change in configuration (removing the new
blank new line) which then woudl trigger a needless nginx
restart.

There is a flag on certbot to only get a new certificate, which
is useful for us here so we don't have to do special work restore
the nginx configuration.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
