### PR TITLE
Fix error when bringing up battle calc in history.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -365,10 +365,7 @@ public class GameData implements Serializable, GameState {
     gameHistory
         .getHistoryWriter()
         .startNextStep(
-            step.getName(),
-            step.getDelegateName(),
-            step.getPlayerId(),
-            step.getDisplayName());
+            step.getName(), step.getDelegateName(), step.getPlayerId(), step.getDisplayName());
     forceInSwingEventThread = oldForceInSwingEventThread;
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -364,7 +364,7 @@ public class GameData implements Serializable, GameState {
         .getHistoryWriter()
         .startNextStep(
             step.getName(),
-            step.getDelegate().getName(),
+            step.getDelegateName(),
             step.getPlayerId(),
             step.getDisplayName());
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -360,6 +360,8 @@ public class GameData implements Serializable, GameState {
     gameHistory = new History(this);
     GameStep step = getSequence().getStep();
     // Put the history in a round and step, so that child nodes can be added without errors.
+    final boolean oldForceInSwingEventThread = forceInSwingEventThread;
+    forceInSwingEventThread = false;
     gameHistory
         .getHistoryWriter()
         .startNextStep(
@@ -367,6 +369,7 @@ public class GameData implements Serializable, GameState {
             step.getDelegateName(),
             step.getPlayerId(),
             step.getDisplayName());
+    forceInSwingEventThread = oldForceInSwingEventThread;
   }
 
   /** Not to be called by mere mortals. */

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -118,7 +118,8 @@ public class GameStep extends GameDataComponent {
 
   public String getDisplayName() {
     if (displayName == null) {
-      return getDelegate().getDisplayName();
+      IDelegate delegate = getDelegate();
+      return delegate != null ? delegate.getDisplayName() : delegateName;
     }
     return displayName;
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import javax.annotation.Nullable;
+import lombok.Getter;
 
 /**
  * A single step in a game.
@@ -18,7 +19,7 @@ public class GameStep extends GameDataComponent {
   @Nullable private final String name;
   @Nullable private final String displayName;
   @Nullable private final GamePlayer player;
-  private final String delegateName;
+  @Getter private final String delegateName;
   private int runCount = 0;
   private int maxRunCount = -1;
   private final Properties properties;


### PR DESCRIPTION
## Change Summary & Additional Notes
Bringing up the battle calc in history mode caused errors due to delegates being not present on the GameData (thus causing errors accessing step properties) and due to HistoryWriter assertions.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
