### PR TITLE
Select correct attacker in history battle calc.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -174,8 +174,7 @@ public class History extends DefaultTreeModel {
    */
   public @Nullable GamePlayer getCurrentPlayer() {
     GamePlayer player = null;
-    final Enumeration<?> enumeration =
-        ((DefaultMutableTreeNode) getRoot()).preorderEnumeration();
+    final Enumeration<?> enumeration = ((DefaultMutableTreeNode) getRoot()).preorderEnumeration();
     while (enumeration.hasMoreElements()) {
       final HistoryNode node = (HistoryNode) enumeration.nextElement();
       if (node instanceof Step) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.triplea.ui.history.HistoryPanel;
 import games.strategy.ui.Util;
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 
@@ -164,6 +166,27 @@ public class History extends DefaultTreeModel {
         removeNodeFromParent(node);
       }
     }
+  }
+
+  /**
+   * Returns the current player, accounting for the fact that we may be looking at a previous node
+   * in history, unlike data.getSequence().getStep().getPlayerId().
+   */
+  public @Nullable GamePlayer getCurrentPlayer() {
+    GamePlayer player = null;
+    final Enumeration<?> enumeration =
+        ((DefaultMutableTreeNode) getRoot()).preorderEnumeration();
+    while (enumeration.hasMoreElements()) {
+      final HistoryNode node = (HistoryNode) enumeration.nextElement();
+      if (node instanceof Step) {
+        player = ((Step) node).getPlayerId();
+      }
+      int nodeChangeIndex = getNextChange(node);
+      if (nodeChangeIndex > nextChangeIndex) {
+        break;
+      }
+    }
+    return player;
   }
 
   public Optional<HistoryNode> getNearestLeafAtOrBefore(HistoryNode node) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1074,7 +1074,7 @@ class BattleCalculatorPanel extends JPanel {
     final AttackerAndDefenderSelector.AttackerAndDefender attAndDef =
         AttackerAndDefenderSelector.builder()
             .players(data.getPlayerList().getPlayers())
-            .currentPlayer(data.getSequence().getStep().getPlayerId())
+            .currentPlayer(data.getHistory().getCurrentPlayer())
             .relationshipTracker(data.getRelationshipTracker())
             .territory(location)
             .build()


### PR DESCRIPTION
## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|When using the battle calculator from game history, the attacker corresponding to the active player in history will be selected by default.<!--END_RELEASE_NOTE-->
