### PR TITLE
Fix regression introduced in #10709

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedPlayerTypes.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedPlayerTypes.java
@@ -58,8 +58,9 @@ public class HeadedPlayerTypes {
 
   public static Collection<PlayerTypes.Type> getPlayerTypes() {
     return Stream.of(
+            List.of(HUMAN_PLAYER),
             PlayerTypes.getBuiltInPlayerTypes(),
-            List.of(HUMAN_PLAYER, CLIENT_PLAYER, getDoesNothingType(), getFlowFieldType()))
+            List.of(CLIENT_PLAYER, getDoesNothingType(), getFlowFieldType()))
         .flatMap(Collection::stream)
         .filter(HeadedPlayerTypes::filterBetaPlayerType)
         .collect(Collectors.toList());

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedPlayerTypes.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedPlayerTypes.java
@@ -58,6 +58,7 @@ public class HeadedPlayerTypes {
 
   public static Collection<PlayerTypes.Type> getPlayerTypes() {
     return Stream.of(
+            // The first item in this list will be the default when hosting
             List.of(HUMAN_PLAYER),
             PlayerTypes.getBuiltInPlayerTypes(),
             List.of(CLIENT_PLAYER, getDoesNothingType(), getFlowFieldType()))


### PR DESCRIPTION
## Change Summary & Additional Notes

Closes #10734
The "null" mapping meant that the first item in the list was selected by default and the human player was no longer the first item after this change.
