### PR TITLE
Infra: enhance build_latest_artifacts script to be runnable from arbitrary directories

### DIFF
--- a/infrastructure/.include/build_latest_artifacts
+++ b/infrastructure/.include/build_latest_artifacts
@@ -12,21 +12,24 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
+scriptDir="$(dirname "$0")"
+
 function main() {
   buildArtifacts
 }
 
 function buildArtifacts() {
   (
-    cd ..
+    cd "$scriptDir"/../.. || exit 1
     ./gradlew \
         :spitfire-server:dropwizard-server:release \
         :game-app:game-headless:release \
         :spitfire-server:database:release
+        set +x
   )
-  copyBuildArtifact "../spitfire-server/database/build/artifacts/migrations.zip" "ansible/roles/database/flyway/files/"
-  copyBuildArtifact "../spitfire-server/dropwizard-server/build/artifacts/triplea-dropwizard-server-$VERSION.zip" "ansible/roles/lobby_server/files/"
-  copyBuildArtifact "../game-app/game-headless/build/artifacts/triplea-game-headless-$VERSION.zip" "ansible/roles/bot/files/"
+  copyBuildArtifact "$scriptDir/../../spitfire-server/database/build/artifacts/migrations.zip" "$scriptDir/../ansible/roles/database/flyway/files/"
+  copyBuildArtifact "$scriptDir/../../spitfire-server/dropwizard-server/build/artifacts/triplea-dropwizard-server-$VERSION.zip" "$scriptDir/../ansible/roles/lobby_server/files/"
+  copyBuildArtifact "$scriptDir/../../game-app/game-headless/build/artifacts/triplea-game-headless-$VERSION.zip" "$scriptDir/../ansible/roles/bot/files/"
 }
 
 function copyBuildArtifact() {


### PR DESCRIPTION
No longer assume a current directory in 'build_latest_artifacts', this update changes paths to be relative to the script location and not relative to the current directory.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
