### PR TITLE
Infra: deploy database as part of lobby

### DIFF
--- a/infrastructure/ansible/inventory/production
+++ b/infrastructure/ansible/inventory/production
@@ -11,9 +11,6 @@ lobby_restart_on_new_deployment=false
 [letsEncrypt:children]
 lobbyServer
 
-[database:children]
-lobbyServer
-
 [botHosts]
 prod2-bot01.triplea-game.org  bot_prefix=1 bot_name=Dallas
 prod2-bot02.triplea-game.org  bot_prefix=2 bot_name=Atlanta

--- a/infrastructure/ansible/inventory/vagrant
+++ b/infrastructure/ansible/inventory/vagrant
@@ -1,9 +1,6 @@
 [vagrant_local]
 vagrant ansible_become=true ansible_ssh_user=vagrant ansible_user=vagrant ansible_host=127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=vagrant/.vagrant/machines/vagrantHost/virtualbox/private_key
 
-[database:children]
-vagrant_local
-
 [lobbyServer:children]
 vagrant_local
 

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -11,19 +11,15 @@
   roles:
     - nginx_forums_conf
 
-- hosts: database
-  tags: [database, postgres]
-  roles:
-    - database/postgres
-    - {name: database/flyway, tags: flyway}
-
 - hosts: lobbyServer
   tags: [lobby, lobby_server]
   roles:
     - java
-    - lobby_server
-    - nginx
+    - {name: database/postgres, tags: database}
+    - {name: database/flyway, tags: flyway}
+    - {name: nginx, tags: nginx}
     - postfix
+    - lobby_server
 
 - hosts: letsEncrypt
   tags: lobby


### PR DESCRIPTION
Simplifies playbook by removing the 'database' host
and simply deploying database to lobby. There other
implicit assumptiongs that database and lobby will
be on the same host, merging the roles to the same
hostgroup better agrees with this reality.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
