### PR TITLE
Infra: fix ansible shell task

### DIFF
--- a/infrastructure/ansible/roles/certbot/tasks/main.yml
+++ b/infrastructure/ansible/roles/certbot/tasks/main.yml
@@ -11,11 +11,12 @@
       - python3-certbot-nginx
 
 - name: run certbot to get certs
-  command: |
-     certbot certonly \
+  shell:
+    cmd: |
+       certbot certonly \
          --nginx -n \
          -m tripleabuilderbot@gmail.com \
          -d {{ inventory_hostname }} \
          --agree-tos \
          --rsa-key-size 4096
-  creates: /etc/letsencrypt/live/{{ inventory_hostname }}/cert.pem
+    creates: /etc/letsencrypt/live/{{ inventory_hostname }}/cert.pem


### PR DESCRIPTION
'creates' belongs on the ansible 'shell' task, not 'command' task.
This update fixes this.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
