### PR TITLE
Remove getPropertyMap() on attachments in favor of getPropertyOrNull().

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
@@ -32,7 +32,7 @@ public interface DynamicallyModifiable {
   default Optional<MutableProperty<?>> getProperty(final String name) {
     checkNotNull(name);
 
-    return Optional.ofNullable(((TriggerAttachment) this).getPropertyMapFunction().apply(name));
+    return Optional.ofNullable(getPropertyMapFunction().apply(name));
   }
 
   default Function<String, MutableProperty<?>> getPropertyMapFunction() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
@@ -2,10 +2,7 @@ package games.strategy.engine.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import games.strategy.triplea.attachments.TriggerAttachment;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * An interface to implement by objects that are dynamically being modified. This will most likely
@@ -21,7 +18,7 @@ public interface DynamicallyModifiable {
    * @return A map of all properties supported by this object. The key is the property name. The
    *     value is the property.
    */
-  Map<String, MutableProperty<?>> getPropertyMap();
+  MutableProperty<?> getPropertyOrNull(String name);
 
   /**
    * Gets the property with the specified name.
@@ -32,11 +29,7 @@ public interface DynamicallyModifiable {
   default Optional<MutableProperty<?>> getProperty(final String name) {
     checkNotNull(name);
 
-    return Optional.ofNullable(getPropertyMapFunction().apply(name));
-  }
-
-  default Function<String, MutableProperty<?>> getPropertyMapFunction() {
-    return (propertyName) -> getPropertyMap().get(propertyName);
+    return Optional.ofNullable(getPropertyOrNull(name));
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
@@ -45,4 +45,9 @@ public interface DynamicallyModifiable {
     return getProperty(name)
         .orElseThrow(() -> new IllegalArgumentException("unknown property named '" + name + "'"));
   }
+
+  default void setPropertyOrThrow(String name, String value)
+      throws MutableProperty.InvalidValueException {
+    getPropertyOrThrow(name).setValue(value);
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
@@ -2,8 +2,10 @@ package games.strategy.engine.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import games.strategy.triplea.attachments.TriggerAttachment;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * An interface to implement by objects that are dynamically being modified. This will most likely
@@ -30,7 +32,11 @@ public interface DynamicallyModifiable {
   default Optional<MutableProperty<?>> getProperty(final String name) {
     checkNotNull(name);
 
-    return Optional.ofNullable(getPropertyMap().get(name));
+    return Optional.ofNullable(((TriggerAttachment) this).getPropertyMapFunction().apply(name));
+  }
+
+  default Function<String, MutableProperty<?>> getPropertyMapFunction() {
+    return (propertyName) -> getPropertyMap().get(propertyName);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
@@ -44,9 +44,4 @@ public interface DynamicallyModifiable {
     return getProperty(name)
         .orElseThrow(() -> new IllegalArgumentException("unknown property named '" + name + "'"));
   }
-
-  default void setPropertyOrThrow(String name, String value)
-      throws MutableProperty.InvalidValueException {
-    getPropertyOrThrow(name).setValue(value);
-  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
@@ -10,13 +10,12 @@ import java.util.Optional;
  */
 public interface DynamicallyModifiable {
   /**
-   * Gets a map of all properties supported by this object.
+   * Gets the property with the specified name or null.
    *
    * <p><b>NOTE:</b> Clients probably shouldn't call this method directly. Consider calling {@link
    * #getProperty(String)} or {@link #getPropertyOrThrow(String)} instead.
    *
-   * @return A map of all properties supported by this object. The key is the property name. The
-   *     value is the property.
+   * @return The property with the specified name or null if the property doesn't exist.
    */
   MutableProperty<?> getPropertyOrNull(String name);
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -223,8 +223,11 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     }
   }
 
-  @Override
-  public Map<String, MutableProperty<?>> getPropertyMap() {
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
+  private Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("owner", MutableProperty.ofSimple(this::setOwner, this::getOwner))
         .put("uid", MutableProperty.ofReadOnlySimple(this::getId))

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -13,7 +12,6 @@ import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -223,61 +221,64 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     }
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  private Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put("owner", MutableProperty.ofSimple(this::setOwner, this::getOwner))
-        .put("uid", MutableProperty.ofReadOnlySimple(this::getId))
-        .put("hits", MutableProperty.ofSimple(this::setHits, this::getHits))
-        .put("type", MutableProperty.ofReadOnlySimple(this::getType))
-        .put(
-            "transportedBy",
-            MutableProperty.ofSimple(this::setTransportedBy, this::getTransportedBy))
-        .put("unloaded", MutableProperty.ofSimple(this::setUnloaded, this::getUnloaded))
-        .put(
-            "wasLoadedThisTurn",
-            MutableProperty.ofSimple(this::setWasLoadedThisTurn, this::getWasLoadedThisTurn))
-        .put("unloadedTo", MutableProperty.ofSimple(this::setUnloadedTo, this::getUnloadedTo))
-        .put(
-            "wasUnloadedInCombatPhase",
-            MutableProperty.ofSimple(
-                this::setWasUnloadedInCombatPhase, this::getWasUnloadedInCombatPhase))
-        .put("alreadyMoved", MutableProperty.ofSimple(this::setAlreadyMoved, this::getAlreadyMoved))
-        .put(
-            "bonusMovement",
-            MutableProperty.ofSimple(this::setBonusMovement, this::getBonusMovement))
-        .put("unitDamage", MutableProperty.ofSimple(this::setUnitDamage, this::getUnitDamage))
-        .put("submerged", MutableProperty.ofSimple(this::setSubmerged, this::getSubmerged))
-        .put(
-            "originalOwner",
-            MutableProperty.ofSimple(this::setOriginalOwner, this::getOriginalOwner))
-        .put("wasInCombat", MutableProperty.ofSimple(this::setWasInCombat, this::getWasInCombat))
-        .put(
-            "wasLoadedAfterCombat",
-            MutableProperty.ofSimple(this::setWasLoadedAfterCombat, this::getWasLoadedAfterCombat))
-        .put(
-            "wasAmphibious",
-            MutableProperty.ofSimple(this::setWasAmphibious, this::getWasAmphibious))
-        .put(
-            "originatedFrom",
-            MutableProperty.ofSimple(this::setOriginatedFrom, this::getOriginatedFrom))
-        .put("wasScrambled", MutableProperty.ofSimple(this::setWasScrambled, this::getWasScrambled))
-        .put(
-            "maxScrambleCount",
-            MutableProperty.ofSimple(this::setMaxScrambleCount, this::getMaxScrambleCount))
-        .put(
-            "wasInAirBattle",
-            MutableProperty.ofSimple(this::setWasInAirBattle, this::getWasInAirBattle))
-        .put("disabled", MutableProperty.ofSimple(this::setDisabled, this::getDisabled))
-        .put("launched", MutableProperty.ofSimple(this::setLaunched, this::getLaunched))
-        .put("airborne", MutableProperty.ofSimple(this::setAirborne, this::getAirborne))
-        .put(
-            "chargedFlatFuelCost",
-            MutableProperty.ofSimple(this::setChargedFlatFuelCost, this::getChargedFlatFuelCost))
-        .build();
+    switch (propertyName) {
+      case "owner":
+        return MutableProperty.ofSimple(this::setOwner, this::getOwner);
+      case "uid":
+        return MutableProperty.ofReadOnlySimple(this::getId);
+      case "hits":
+        return MutableProperty.ofSimple(this::setHits, this::getHits);
+      case "type":
+        return MutableProperty.ofReadOnlySimple(this::getType);
+      case "transportedBy":
+        return MutableProperty.ofSimple(this::setTransportedBy, this::getTransportedBy);
+      case "unloaded":
+        return MutableProperty.ofSimple(this::setUnloaded, this::getUnloaded);
+      case "wasLoadedThisTurn":
+        return MutableProperty.ofSimple(this::setWasLoadedThisTurn, this::getWasLoadedThisTurn);
+      case "unloadedTo":
+        return MutableProperty.ofSimple(this::setUnloadedTo, this::getUnloadedTo);
+      case "wasUnloadedInCombatPhase":
+        return MutableProperty.ofSimple(
+            this::setWasUnloadedInCombatPhase, this::getWasUnloadedInCombatPhase);
+      case "alreadyMoved":
+        return MutableProperty.ofSimple(this::setAlreadyMoved, this::getAlreadyMoved);
+      case "bonusMovement":
+        return MutableProperty.ofSimple(this::setBonusMovement, this::getBonusMovement);
+      case "unitDamage":
+        return MutableProperty.ofSimple(this::setUnitDamage, this::getUnitDamage);
+      case "submerged":
+        return MutableProperty.ofSimple(this::setSubmerged, this::getSubmerged);
+      case "originalOwner":
+        return MutableProperty.ofSimple(this::setOriginalOwner, this::getOriginalOwner);
+      case "wasInCombat":
+        return MutableProperty.ofSimple(this::setWasInCombat, this::getWasInCombat);
+      case "wasLoadedAfterCombat":
+        return MutableProperty.ofSimple(
+            this::setWasLoadedAfterCombat, this::getWasLoadedAfterCombat);
+      case "wasAmphibious":
+        return MutableProperty.ofSimple(this::setWasAmphibious, this::getWasAmphibious);
+      case "originatedFrom":
+        return MutableProperty.ofSimple(this::setOriginatedFrom, this::getOriginatedFrom);
+      case "wasScrambled":
+        return MutableProperty.ofSimple(this::setWasScrambled, this::getWasScrambled);
+      case "maxScrambleCount":
+        return MutableProperty.ofSimple(this::setMaxScrambleCount, this::getMaxScrambleCount);
+      case "wasInAirBattle":
+        return MutableProperty.ofSimple(this::setWasInAirBattle, this::getWasInAirBattle);
+      case "disabled":
+        return MutableProperty.ofSimple(this::setDisabled, this::getDisabled);
+      case "launched":
+        return MutableProperty.ofSimple(this::setLaunched, this::getLaunched);
+      case "airborne":
+        return MutableProperty.ofSimple(this::setAirborne, this::getAirborne);
+      case "chargedFlatFuelCost":
+        return MutableProperty.ofSimple(this::setChargedFlatFuelCost, this::getChargedFlatFuelCost);
+      default:
+        return null;
+    }
   }
 
   public int getUnitDamage() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -10,7 +10,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.IAttachment;
-import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.NamedAttachable;
 import games.strategy.engine.data.ProductionFrontier;
 import games.strategy.engine.data.ProductionFrontierList;
@@ -873,7 +872,6 @@ public final class GameParser {
       final Map<String, String> foreach)
       throws GameParseException {
     final List<Tuple<String, String>> results = new ArrayList<>();
-    final Map<String, MutableProperty<?>> propertyMap = attachment.getPropertyMap();
     for (final AttachmentList.Attachment.Option option : options) {
       final String optionName = option.getName();
       final String value = option.getValue();
@@ -900,7 +898,8 @@ public final class GameParser {
       final String finalValue =
           LegacyPropertyMapper.mapLegacyOptionValue(name, interpolatedValue).intern();
       try {
-        Optional.ofNullable(propertyMap.get(name))
+        attachment
+            .getProperty(name)
             .orElseThrow(
                 () ->
                     new GameParseException(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -376,43 +375,34 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     }
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            "conditions",
-            MutableProperty.of(
-                this::setConditions,
-                this::setConditions,
-                this::getConditions,
-                this::resetConditions))
-        .put(
-            "conditionType",
-            MutableProperty.ofString(
-                this::setConditionType, this::getConditionType, this::resetConditionType))
-        .put(
-            "invert",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool, this::setInvert, this::getInvert, () -> false))
-        .put(
-            "chance", MutableProperty.ofString(this::setChance, this::getChance, this::resetChance))
-        .put(
-            "chanceIncrementOnFailure",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt,
-                this::setChanceIncrementOnFailure,
-                this::getChanceIncrementOnFailure,
-                () -> 0))
-        .put(
-            "chanceDecrementOnSuccess",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt,
-                this::setChanceDecrementOnSuccess,
-                this::getChanceDecrementOnSuccess,
-                () -> 0))
-        .build();
+    switch (propertyName) {
+      case "conditions":
+        return MutableProperty.of(
+            this::setConditions, this::setConditions, this::getConditions, this::resetConditions);
+      case "conditionType":
+        return MutableProperty.ofString(
+            this::setConditionType, this::getConditionType, this::resetConditionType);
+      case "invert":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool, this::setInvert, this::getInvert, () -> false);
+      case "chance":
+        return MutableProperty.ofString(this::setChance, this::getChance, this::resetChance);
+      case "chanceIncrementOnFailure":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt,
+            this::setChanceIncrementOnFailure,
+            this::getChanceIncrementOnFailure,
+            () -> 0);
+      case "chanceDecrementOnSuccess":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt,
+            this::setChanceDecrementOnSuccess,
+            this::getChanceDecrementOnSuccess,
+            () -> 0);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -376,7 +376,10 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     }
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -338,7 +338,10 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     validateNames(movementRestrictionTerritories);
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.attachments;
 
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -10,7 +9,6 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.Constants;
 import java.util.Collection;
-import java.util.Map;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.IntegerMap;
@@ -338,96 +336,82 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     validateNames(movementRestrictionTerritories);
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .putAll(super.getPropertyMap())
-        .put(
-            "movementRestrictionType",
-            MutableProperty.ofString(
-                this::setMovementRestrictionType,
-                this::getMovementRestrictionType,
-                this::resetMovementRestrictionType))
-        .put(
-            "movementRestrictionTerritories",
-            MutableProperty.of(
-                this::setMovementRestrictionTerritories,
-                this::setMovementRestrictionTerritories,
-                this::getMovementRestrictionTerritories,
-                this::resetMovementRestrictionTerritories))
-        .put(
-            "placementAnyTerritory",
-            MutableProperty.of(
-                this::setPlacementAnyTerritory,
-                this::setPlacementAnyTerritory,
-                this::getPlacementAnyTerritory,
-                this::resetPlacementAnyTerritory))
-        .put(
-            "placementAnySeaZone",
-            MutableProperty.of(
-                this::setPlacementAnySeaZone,
-                this::setPlacementAnySeaZone,
-                this::getPlacementAnySeaZone,
-                this::resetPlacementAnySeaZone))
-        .put(
-            "placementCapturedTerritory",
-            MutableProperty.of(
-                this::setPlacementCapturedTerritory,
-                this::setPlacementCapturedTerritory,
-                this::getPlacementCapturedTerritory,
-                this::resetPlacementCapturedTerritory))
-        .put(
-            "unlimitedProduction",
-            MutableProperty.of(
-                this::setUnlimitedProduction,
-                this::setUnlimitedProduction,
-                this::getUnlimitedProduction,
-                this::resetUnlimitedProduction))
-        .put(
-            "placementInCapitalRestricted",
-            MutableProperty.of(
-                this::setPlacementInCapitalRestricted,
-                this::setPlacementInCapitalRestricted,
-                this::getPlacementInCapitalRestricted,
-                this::resetPlacementInCapitalRestricted))
-        .put(
-            "dominatingFirstRoundAttack",
-            MutableProperty.of(
-                this::setDominatingFirstRoundAttack,
-                this::setDominatingFirstRoundAttack,
-                this::getDominatingFirstRoundAttack,
-                this::resetDominatingFirstRoundAttack))
-        .put(
-            "negateDominatingFirstRoundAttack",
-            MutableProperty.of(
-                this::setNegateDominatingFirstRoundAttack,
-                this::setNegateDominatingFirstRoundAttack,
-                this::getNegateDominatingFirstRoundAttack,
-                this::resetNegateDominatingFirstRoundAttack))
-        .put(
-            "productionPerXTerritories",
-            MutableProperty.of(
-                this::setProductionPerXTerritories,
-                this::setProductionPerXTerritories,
-                this::getProductionPerXTerritories,
-                this::resetProductionPerXTerritories))
-        .put(
-            "placementPerTerritory",
-            MutableProperty.of(
-                this::setPlacementPerTerritory,
-                this::setPlacementPerTerritory,
-                this::getPlacementPerTerritory,
-                this::resetPlacementPerTerritory))
-        .put(
-            "maxPlacePerTerritory",
-            MutableProperty.of(
-                this::setMaxPlacePerTerritory,
-                this::setMaxPlacePerTerritory,
-                this::getMaxPlacePerTerritory,
-                this::resetMaxPlacePerTerritory))
-        .build();
+    switch (propertyName) {
+      case "movementRestrictionType":
+        return MutableProperty.ofString(
+            this::setMovementRestrictionType,
+            this::getMovementRestrictionType,
+            this::resetMovementRestrictionType);
+      case "movementRestrictionTerritories":
+        return MutableProperty.of(
+            this::setMovementRestrictionTerritories,
+            this::setMovementRestrictionTerritories,
+            this::getMovementRestrictionTerritories,
+            this::resetMovementRestrictionTerritories);
+      case "placementAnyTerritory":
+        return MutableProperty.of(
+            this::setPlacementAnyTerritory,
+            this::setPlacementAnyTerritory,
+            this::getPlacementAnyTerritory,
+            this::resetPlacementAnyTerritory);
+      case "placementAnySeaZone":
+        return MutableProperty.of(
+            this::setPlacementAnySeaZone,
+            this::setPlacementAnySeaZone,
+            this::getPlacementAnySeaZone,
+            this::resetPlacementAnySeaZone);
+      case "placementCapturedTerritory":
+        return MutableProperty.of(
+            this::setPlacementCapturedTerritory,
+            this::setPlacementCapturedTerritory,
+            this::getPlacementCapturedTerritory,
+            this::resetPlacementCapturedTerritory);
+      case "unlimitedProduction":
+        return MutableProperty.of(
+            this::setUnlimitedProduction,
+            this::setUnlimitedProduction,
+            this::getUnlimitedProduction,
+            this::resetUnlimitedProduction);
+      case "placementInCapitalRestricted":
+        return MutableProperty.of(
+            this::setPlacementInCapitalRestricted,
+            this::setPlacementInCapitalRestricted,
+            this::getPlacementInCapitalRestricted,
+            this::resetPlacementInCapitalRestricted);
+      case "dominatingFirstRoundAttack":
+        return MutableProperty.of(
+            this::setDominatingFirstRoundAttack,
+            this::setDominatingFirstRoundAttack,
+            this::getDominatingFirstRoundAttack,
+            this::resetDominatingFirstRoundAttack);
+      case "negateDominatingFirstRoundAttack":
+        return MutableProperty.of(
+            this::setNegateDominatingFirstRoundAttack,
+            this::setNegateDominatingFirstRoundAttack,
+            this::getNegateDominatingFirstRoundAttack,
+            this::resetNegateDominatingFirstRoundAttack);
+      case "productionPerXTerritories":
+        return MutableProperty.of(
+            this::setProductionPerXTerritories,
+            this::setProductionPerXTerritories,
+            this::getProductionPerXTerritories,
+            this::resetProductionPerXTerritories);
+      case "placementPerTerritory":
+        return MutableProperty.of(
+            this::setPlacementPerTerritory,
+            this::setPlacementPerTerritory,
+            this::getPlacementPerTerritory,
+            this::resetPlacementPerTerritory);
+      case "maxPlacePerTerritory":
+        return MutableProperty.of(
+            this::setMaxPlacePerTerritory,
+            this::setMaxPlacePerTerritory,
+            this::getMaxPlacePerTerritory,
+            this::resetMaxPlacePerTerritory);
+      default:
+        return super.getPropertyOrNull(propertyName);
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -409,7 +409,10 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     return territories;
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.attachments;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -409,41 +408,35 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     return territories;
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .putAll(super.getPropertyMap())
-        .put("countEach", MutableProperty.ofReadOnly(this::getCountEach))
-        .put("eachMultiple", MutableProperty.ofReadOnly(this::getEachMultiple))
-        .put(
-            "players",
-            MutableProperty.of(
-                this::setPlayers, this::setPlayers, this::getPlayers, this::resetPlayers))
-        .put(
-            "objectiveValue",
-            MutableProperty.of(
-                this::setObjectiveValue,
-                this::setObjectiveValue,
-                this::getObjectiveValue,
-                this::resetObjectiveValue))
-        .put(
-            "uses",
-            MutableProperty.of(this::setUses, this::setUses, this::getUses, this::resetUses))
-        .put(
-            "rounds",
-            MutableProperty.of(
-                this::setRounds, this::setRounds, this::getRounds, this::resetRounds))
-        .put(
-            "switch",
-            MutableProperty.of(
-                this::setSwitch, this::setSwitch, this::getSwitch, this::resetSwitch))
-        .put(
-            "gameProperty",
-            MutableProperty.ofString(
-                this::setGameProperty, this::getGameProperty, this::resetGameProperty))
-        .build();
+    switch (propertyName) {
+      case "countEach":
+        return MutableProperty.ofReadOnly(this::getCountEach);
+      case "eachMultiple":
+        return MutableProperty.ofReadOnly(this::getEachMultiple);
+      case "players":
+        return MutableProperty.of(
+            this::setPlayers, this::setPlayers, this::getPlayers, this::resetPlayers);
+      case "objectiveValue":
+        return MutableProperty.of(
+            this::setObjectiveValue,
+            this::setObjectiveValue,
+            this::getObjectiveValue,
+            this::resetObjectiveValue);
+      case "uses":
+        return MutableProperty.of(this::setUses, this::setUses, this::getUses, this::resetUses);
+      case "rounds":
+        return MutableProperty.of(
+            this::setRounds, this::setRounds, this::getRounds, this::resetRounds);
+      case "switch":
+        return MutableProperty.of(
+            this::setSwitch, this::setSwitch, this::getSwitch, this::resetSwitch);
+      case "gameProperty":
+        return MutableProperty.ofString(
+            this::setGameProperty, this::getGameProperty, this::resetGameProperty);
+      default:
+        return super.getPropertyOrNull(propertyName);
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.attachments;
 
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.DefaultAttachment;
@@ -278,40 +277,33 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   @Override
   public void validate(final GameState data) {}
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .putAll(super.getPropertyMap())
-        .put(
-            "uses",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt, this::setUses, this::getUses, () -> -1))
-        .put(
-            "usedThisRound",
-            MutableProperty.of(
-                this::setUsedThisRound,
-                this::setUsedThisRound,
-                this::getUsedThisRound,
-                this::resetUsedThisRound))
-        .put(
-            "notification",
-            MutableProperty.ofString(
-                this::setNotification, this::getNotification, this::resetNotification))
-        .put(
-            "when",
-            MutableProperty.of(this::setWhen, this::setWhen, this::getWhen, this::resetWhen))
-        .put(
-            "trigger",
-            MutableProperty.of(
-                l -> {
-                  throw new IllegalStateException("Can't set trigger directly");
-                },
-                this::setTrigger,
-                this::getTrigger,
-                this::resetTrigger))
-        .build();
+    switch (propertyName) {
+      case "uses":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt, this::setUses, this::getUses, () -> -1);
+      case "usedThisRound":
+        return MutableProperty.of(
+            this::setUsedThisRound,
+            this::setUsedThisRound,
+            this::getUsedThisRound,
+            this::resetUsedThisRound);
+      case "notification":
+        return MutableProperty.ofString(
+            this::setNotification, this::getNotification, this::resetNotification);
+      case "when":
+        return MutableProperty.of(this::setWhen, this::setWhen, this::getWhen, this::resetWhen);
+      case "trigger":
+        return MutableProperty.of(
+            l -> {
+              throw new IllegalStateException("Can't set trigger directly");
+            },
+            this::setTrigger,
+            this::getTrigger,
+            this::resetTrigger);
+      default:
+        return super.getPropertyOrNull(propertyName);
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -278,7 +278,10 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   @Override
   public void validate(final GameState data) {}
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.attachments;
 
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -209,46 +208,40 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     }
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .putAll(super.getPropertyMap())
-        .put("text", MutableProperty.ofString(this::setText, this::getText, this::resetText))
-        .put(
-            "costPU",
-            MutableProperty.of(
-                this::setCostPu, this::setCostPu, this::getCostPu, this::resetCostPu))
-        .put(
-            "costResources",
-            MutableProperty.of(
-                this::setCostResources,
-                this::setCostResources,
-                this::getCostResources,
-                this::resetCostResources))
-        .put(
-            "attemptsPerTurn",
-            MutableProperty.of(
-                this::setAttemptsPerTurn,
-                this::setAttemptsPerTurn,
-                this::getAttemptsPerTurn,
-                this::resetAttemptsPerTurn))
-        .put(
-            "attemptsLeftThisTurn",
-            MutableProperty.of(
-                this::setAttemptsLeftThisTurn,
-                this::setAttemptsLeftThisTurn,
-                this::getAttemptsLeftThisTurn,
-                this::resetAttemptsLeftThisTurn))
-        .put(
-            "actionAccept",
-            MutableProperty.of(
-                this::setActionAccept,
-                this::setActionAccept,
-                this::getActionAccept,
-                this::resetActionAccept))
-        .build();
+    switch (propertyName) {
+      case "text":
+        return MutableProperty.ofString(this::setText, this::getText, this::resetText);
+      case "costPU":
+        return MutableProperty.of(
+            this::setCostPu, this::setCostPu, this::getCostPu, this::resetCostPu);
+      case "costResources":
+        return MutableProperty.of(
+            this::setCostResources,
+            this::setCostResources,
+            this::getCostResources,
+            this::resetCostResources);
+      case "attemptsPerTurn":
+        return MutableProperty.of(
+            this::setAttemptsPerTurn,
+            this::setAttemptsPerTurn,
+            this::getAttemptsPerTurn,
+            this::resetAttemptsPerTurn);
+      case "attemptsLeftThisTurn":
+        return MutableProperty.of(
+            this::setAttemptsLeftThisTurn,
+            this::setAttemptsLeftThisTurn,
+            this::getAttemptsLeftThisTurn,
+            this::resetAttemptsLeftThisTurn);
+      case "actionAccept":
+        return MutableProperty.of(
+            this::setActionAccept,
+            this::setActionAccept,
+            this::getActionAccept,
+            this::resetActionAccept);
+      default:
+        return super.getPropertyOrNull(propertyName);
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -209,7 +209,10 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     }
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.attachments;
 
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
@@ -13,7 +12,6 @@ import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.Matches;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -178,36 +176,32 @@ public class CanalAttachment extends DefaultAttachment {
     }
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            "canalName",
-            MutableProperty.ofString(this::setCanalName, this::getCanalName, this::resetCanalName))
-        .put(
-            "landTerritories",
-            MutableProperty.of(
-                this::setLandTerritories,
-                this::setLandTerritories,
-                this::getLandTerritories,
-                this::resetLandTerritories))
-        .put(
-            "excludedUnits",
-            MutableProperty.of(
-                this::setExcludedUnits,
-                this::setExcludedUnits,
-                this::getExcludedUnits,
-                this::resetExcludedUnits))
-        .put(
-            "canNotMoveThroughDuringCombatMove",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool,
-                this::setCanNotMoveThroughDuringCombatMove,
-                this::getCanNotMoveThroughDuringCombatMove,
-                () -> false))
-        .build();
+    switch (propertyName) {
+      case "canalName":
+        return MutableProperty.ofString(
+            this::setCanalName, this::getCanalName, this::resetCanalName);
+      case "landTerritories":
+        return MutableProperty.of(
+            this::setLandTerritories,
+            this::setLandTerritories,
+            this::getLandTerritories,
+            this::resetLandTerritories);
+      case "excludedUnits":
+        return MutableProperty.of(
+            this::setExcludedUnits,
+            this::setExcludedUnits,
+            this::getExcludedUnits,
+            this::resetExcludedUnits);
+      case "canNotMoveThroughDuringCombatMove":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool,
+            this::setCanNotMoveThroughDuringCombatMove,
+            this::getCanNotMoveThroughDuringCombatMove,
+            () -> false);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -178,7 +178,10 @@ public class CanalAttachment extends DefaultAttachment {
     }
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.attachments;
 
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
@@ -17,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
@@ -438,121 +436,101 @@ public class PlayerAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            "vps",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt, this::setVps, this::getVps, () -> 0))
-        .put(
-            "captureVps",
-            MutableProperty.of(
-                this::setCaptureVps,
-                this::setCaptureVps,
-                this::getCaptureVps,
-                this::resetCaptureVps))
-        .put(
-            "retainCapitalNumber",
-            MutableProperty.of(
-                this::setRetainCapitalNumber,
-                this::setRetainCapitalNumber,
-                this::getRetainCapitalNumber,
-                this::resetRetainCapitalNumber))
-        .put(
-            "retainCapitalProduceNumber",
-            MutableProperty.of(
-                this::setRetainCapitalProduceNumber,
-                this::setRetainCapitalProduceNumber,
-                this::getRetainCapitalProduceNumber,
-                this::resetRetainCapitalProduceNumber))
-        .put(
-            "giveUnitControl",
-            MutableProperty.of(
-                this::setGiveUnitControl,
-                this::setGiveUnitControl,
-                this::getGiveUnitControl,
-                this::resetGiveUnitControl))
-        .put(
-            "giveUnitControlInAllTerritories",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool,
-                this::setGiveUnitControlInAllTerritories,
-                this::getGiveUnitControlInAllTerritories,
-                () -> false))
-        .put(
-            "captureUnitOnEnteringBy",
-            MutableProperty.of(
-                this::setCaptureUnitOnEnteringBy,
-                this::setCaptureUnitOnEnteringBy,
-                this::getCaptureUnitOnEnteringBy,
-                this::resetCaptureUnitOnEnteringBy))
-        .put(
-            "shareTechnology",
-            MutableProperty.of(
-                this::setShareTechnology,
-                this::setShareTechnology,
-                this::getShareTechnology,
-                this::resetShareTechnology))
-        .put(
-            "helpPayTechCost",
-            MutableProperty.of(
-                this::setHelpPayTechCost,
-                this::setHelpPayTechCost,
-                this::getHelpPayTechCost,
-                this::resetHelpPayTechCost))
-        .put(
-            "destroysPUs",
-            MutableProperty.of(
-                this::setDestroysPUs,
-                this::setDestroysPUs,
-                this::getDestroysPUs,
-                this::resetDestroysPUs))
-        .put(
-            "immuneToBlockade",
-            MutableProperty.of(
-                this::setImmuneToBlockade,
-                this::setImmuneToBlockade,
-                this::getImmuneToBlockade,
-                this::resetImmuneToBlockade))
-        .put(
-            "suicideAttackResources",
-            MutableProperty.of(
-                this::setSuicideAttackResources,
-                this::setSuicideAttackResources,
-                this::getSuicideAttackResources,
-                this::resetSuicideAttackResources))
-        .put(
-            "suicideAttackTargets",
-            MutableProperty.of(
-                this::setSuicideAttackTargets,
-                this::setSuicideAttackTargets,
-                this::getSuicideAttackTargets,
-                this::resetSuicideAttackTargets))
-        .put(
-            "placementLimit",
-            MutableProperty.of(
-                this::setPlacementLimit,
-                this::setPlacementLimit,
-                this::getPlacementLimit,
-                this::resetPlacementLimit))
-        .put(
-            "movementLimit",
-            MutableProperty.of(
-                this::setMovementLimit,
-                this::setMovementLimit,
-                this::getMovementLimit,
-                this::resetMovementLimit))
-        .put(
-            "attackingLimit",
-            MutableProperty.of(
-                this::setAttackingLimit,
-                this::setAttackingLimit,
-                this::getAttackingLimit,
-                this::resetAttackingLimit))
-        .build();
+    switch (propertyName) {
+      case "vps":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt, this::setVps, this::getVps, () -> 0);
+      case "captureVps":
+        return MutableProperty.of(
+            this::setCaptureVps, this::setCaptureVps, this::getCaptureVps, this::resetCaptureVps);
+      case "retainCapitalNumber":
+        return MutableProperty.of(
+            this::setRetainCapitalNumber,
+            this::setRetainCapitalNumber,
+            this::getRetainCapitalNumber,
+            this::resetRetainCapitalNumber);
+      case "retainCapitalProduceNumber":
+        return MutableProperty.of(
+            this::setRetainCapitalProduceNumber,
+            this::setRetainCapitalProduceNumber,
+            this::getRetainCapitalProduceNumber,
+            this::resetRetainCapitalProduceNumber);
+      case "giveUnitControl":
+        return MutableProperty.of(
+            this::setGiveUnitControl,
+            this::setGiveUnitControl,
+            this::getGiveUnitControl,
+            this::resetGiveUnitControl);
+      case "giveUnitControlInAllTerritories":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool,
+            this::setGiveUnitControlInAllTerritories,
+            this::getGiveUnitControlInAllTerritories,
+            () -> false);
+      case "captureUnitOnEnteringBy":
+        return MutableProperty.of(
+            this::setCaptureUnitOnEnteringBy,
+            this::setCaptureUnitOnEnteringBy,
+            this::getCaptureUnitOnEnteringBy,
+            this::resetCaptureUnitOnEnteringBy);
+      case "shareTechnology":
+        return MutableProperty.of(
+            this::setShareTechnology,
+            this::setShareTechnology,
+            this::getShareTechnology,
+            this::resetShareTechnology);
+      case "helpPayTechCost":
+        return MutableProperty.of(
+            this::setHelpPayTechCost,
+            this::setHelpPayTechCost,
+            this::getHelpPayTechCost,
+            this::resetHelpPayTechCost);
+      case "destroysPUs":
+        return MutableProperty.of(
+            this::setDestroysPUs,
+            this::setDestroysPUs,
+            this::getDestroysPUs,
+            this::resetDestroysPUs);
+      case "immuneToBlockade":
+        return MutableProperty.of(
+            this::setImmuneToBlockade,
+            this::setImmuneToBlockade,
+            this::getImmuneToBlockade,
+            this::resetImmuneToBlockade);
+      case "suicideAttackResources":
+        return MutableProperty.of(
+            this::setSuicideAttackResources,
+            this::setSuicideAttackResources,
+            this::getSuicideAttackResources,
+            this::resetSuicideAttackResources);
+      case "suicideAttackTargets":
+        return MutableProperty.of(
+            this::setSuicideAttackTargets,
+            this::setSuicideAttackTargets,
+            this::getSuicideAttackTargets,
+            this::resetSuicideAttackTargets);
+      case "placementLimit":
+        return MutableProperty.of(
+            this::setPlacementLimit,
+            this::setPlacementLimit,
+            this::getPlacementLimit,
+            this::resetPlacementLimit);
+      case "movementLimit":
+        return MutableProperty.of(
+            this::setMovementLimit,
+            this::setMovementLimit,
+            this::getMovementLimit,
+            this::resetMovementLimit);
+      case "attackingLimit":
+        return MutableProperty.of(
+            this::setAttackingLimit,
+            this::setAttackingLimit,
+            this::getAttackingLimit,
+            this::resetAttackingLimit);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -438,7 +438,10 @@ public class PlayerAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -194,6 +194,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
     }
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "relationshipChange":
@@ -203,7 +204,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
             this::getRelationshipChange,
             this::resetRelationshipChange);
       default:
-        return getPropertyMap().get(propertyName);
+        return super.getPropertyOrNull(propertyName);
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.attachments;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -196,20 +195,16 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   }
 
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .putAll(super.getPropertyMap())
-        .put(
-            "relationshipChange",
-            MutableProperty.of(
-                this::setRelationshipChange,
-                this::setRelationshipChange,
-                this::getRelationshipChange,
-                this::resetRelationshipChange))
-        .build();
+    switch (propertyName) {
+      case "relationshipChange":
+        return MutableProperty.of(
+            this::setRelationshipChange,
+            this::setRelationshipChange,
+            this::getRelationshipChange,
+            this::resetRelationshipChange);
+      default:
+        return getPropertyMap().get(propertyName);
+    }
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -195,7 +195,10 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
     }
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -441,7 +441,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return getPropertyMap().get(propertyName);
   }
 
-  public Map<String, MutableProperty<?>> getPropertyMap() {
+  private Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(
             "archeType",

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.attachments;
 
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
@@ -9,7 +8,6 @@ import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.RelationshipType;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.Constants;
-import java.util.Map;
 
 /** An attachment for instances of {@link RelationshipType}. */
 public class RelationshipTypeAttachment extends DefaultAttachment {
@@ -437,79 +435,65 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  private Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            "archeType",
-            MutableProperty.ofString(this::setArcheType, this::getArcheType, this::resetArcheType))
-        .put(
-            "canMoveLandUnitsOverOwnedLand",
-            MutableProperty.ofString(
-                this::setCanMoveLandUnitsOverOwnedLand,
-                this::getCanMoveLandUnitsOverOwnedLand,
-                this::resetCanMoveLandUnitsOverOwnedLand))
-        .put(
-            "canMoveAirUnitsOverOwnedLand",
-            MutableProperty.ofString(
-                this::setCanMoveAirUnitsOverOwnedLand,
-                this::getCanMoveAirUnitsOverOwnedLand,
-                this::resetCanMoveAirUnitsOverOwnedLand))
-        .put(
-            "alliancesCanChainTogether",
-            MutableProperty.ofString(
-                this::setAlliancesCanChainTogether,
-                this::getAlliancesCanChainTogether,
-                this::resetAlliancesCanChainTogether))
-        .put(
-            "isDefaultWarPosition",
-            MutableProperty.ofString(
-                this::setIsDefaultWarPosition,
-                this::getIsDefaultWarPosition,
-                this::resetIsDefaultWarPosition))
-        .put(
-            "upkeepCost",
-            MutableProperty.ofString(
-                this::setUpkeepCost, this::getUpkeepCost, this::resetUpkeepCost))
-        .put(
-            "canLandAirUnitsOnOwnedLand",
-            MutableProperty.ofString(
-                this::setCanLandAirUnitsOnOwnedLand,
-                this::getCanLandAirUnitsOnOwnedLand,
-                this::resetCanLandAirUnitsOnOwnedLand))
-        .put(
-            "canTakeOverOwnedTerritory",
-            MutableProperty.ofString(
-                this::setCanTakeOverOwnedTerritory,
-                this::getCanTakeOverOwnedTerritory,
-                this::resetCanTakeOverOwnedTerritory))
-        .put(
-            "givesBackOriginalTerritories",
-            MutableProperty.ofString(
-                this::setGivesBackOriginalTerritories,
-                this::getGivesBackOriginalTerritories,
-                this::resetGivesBackOriginalTerritories))
-        .put(
-            "canMoveIntoDuringCombatMove",
-            MutableProperty.ofString(
-                this::setCanMoveIntoDuringCombatMove,
-                this::getCanMoveIntoDuringCombatMove,
-                this::resetCanMoveIntoDuringCombatMove))
-        .put(
-            "canMoveThroughCanals",
-            MutableProperty.ofString(
-                this::setCanMoveThroughCanals,
-                this::getCanMoveThroughCanals,
-                this::resetCanMoveThroughCanals))
-        .put(
-            "rocketsCanFlyOver",
-            MutableProperty.ofString(
-                this::setRocketsCanFlyOver,
-                this::getRocketsCanFlyOver,
-                this::resetRocketsCanFlyOver))
-        .build();
+    switch (propertyName) {
+      case "archeType":
+        return MutableProperty.ofString(
+            this::setArcheType, this::getArcheType, this::resetArcheType);
+      case "canMoveLandUnitsOverOwnedLand":
+        return MutableProperty.ofString(
+            this::setCanMoveLandUnitsOverOwnedLand,
+            this::getCanMoveLandUnitsOverOwnedLand,
+            this::resetCanMoveLandUnitsOverOwnedLand);
+      case "canMoveAirUnitsOverOwnedLand":
+        return MutableProperty.ofString(
+            this::setCanMoveAirUnitsOverOwnedLand,
+            this::getCanMoveAirUnitsOverOwnedLand,
+            this::resetCanMoveAirUnitsOverOwnedLand);
+      case "alliancesCanChainTogether":
+        return MutableProperty.ofString(
+            this::setAlliancesCanChainTogether,
+            this::getAlliancesCanChainTogether,
+            this::resetAlliancesCanChainTogether);
+      case "isDefaultWarPosition":
+        return MutableProperty.ofString(
+            this::setIsDefaultWarPosition,
+            this::getIsDefaultWarPosition,
+            this::resetIsDefaultWarPosition);
+      case "upkeepCost":
+        return MutableProperty.ofString(
+            this::setUpkeepCost, this::getUpkeepCost, this::resetUpkeepCost);
+      case "canLandAirUnitsOnOwnedLand":
+        return MutableProperty.ofString(
+            this::setCanLandAirUnitsOnOwnedLand,
+            this::getCanLandAirUnitsOnOwnedLand,
+            this::resetCanLandAirUnitsOnOwnedLand);
+      case "canTakeOverOwnedTerritory":
+        return MutableProperty.ofString(
+            this::setCanTakeOverOwnedTerritory,
+            this::getCanTakeOverOwnedTerritory,
+            this::resetCanTakeOverOwnedTerritory);
+      case "givesBackOriginalTerritories":
+        return MutableProperty.ofString(
+            this::setGivesBackOriginalTerritories,
+            this::getGivesBackOriginalTerritories,
+            this::resetGivesBackOriginalTerritories);
+      case "canMoveIntoDuringCombatMove":
+        return MutableProperty.ofString(
+            this::setCanMoveIntoDuringCombatMove,
+            this::getCanMoveIntoDuringCombatMove,
+            this::resetCanMoveIntoDuringCombatMove);
+      case "canMoveThroughCanals":
+        return MutableProperty.ofString(
+            this::setCanMoveThroughCanals,
+            this::getCanMoveThroughCanals,
+            this::resetCanMoveThroughCanals);
+      case "rocketsCanFlyOver":
+        return MutableProperty.ofString(
+            this::setRocketsCanFlyOver, this::getRocketsCanFlyOver, this::resetRocketsCanFlyOver);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -437,7 +437,10 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -1045,7 +1045,10 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     validateNames(enemyPresenceTerritories);
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.attachments;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.BattleRecordsList;
 import games.strategy.engine.data.GameData;
@@ -1045,110 +1044,95 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     validateNames(enemyPresenceTerritories);
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .putAll(super.getPropertyMap())
-        .put(
-            "techs",
-            MutableProperty.of(this::setTechs, this::setTechs, this::getTechs, this::resetTechs))
-        .put("techCount", MutableProperty.ofReadOnly(this::getTechCount))
-        .put(
-            "relationship",
-            MutableProperty.of(
-                this::setRelationship,
-                this::setRelationship,
-                this::getRelationship,
-                this::resetRelationship))
-        .put(
-            "atWarPlayers",
-            MutableProperty.of(
-                this::setAtWarPlayers,
-                this::setAtWarPlayers,
-                this::getAtWarPlayers,
-                this::resetAtWarPlayers))
-        .put("atWarCount", MutableProperty.ofReadOnly(this::getAtWarCount))
-        .put(
-            "destroyedTUV",
-            MutableProperty.ofString(
-                this::setDestroyedTuv, this::getDestroyedTuv, this::resetDestroyedTuv))
-        .put(
-            "battle",
-            MutableProperty.of(
-                this::setBattle, this::setBattle, this::getBattle, this::resetBattle))
-        .put(
-            "alliedOwnershipTerritories",
-            MutableProperty.of(
-                this::setAlliedOwnershipTerritories,
-                this::setAlliedOwnershipTerritories,
-                this::getAlliedOwnershipTerritories,
-                this::resetAlliedOwnershipTerritories))
-        .put(
-            "directOwnershipTerritories",
-            MutableProperty.of(
-                this::setDirectOwnershipTerritories,
-                this::setDirectOwnershipTerritories,
-                this::getDirectOwnershipTerritories,
-                this::resetDirectOwnershipTerritories))
-        .put(
-            "alliedExclusionTerritories",
-            MutableProperty.of(
-                this::setAlliedExclusionTerritories,
-                this::setAlliedExclusionTerritories,
-                this::getAlliedExclusionTerritories,
-                this::resetAlliedExclusionTerritories))
-        .put(
-            "directExclusionTerritories",
-            MutableProperty.of(
-                this::setDirectExclusionTerritories,
-                this::setDirectExclusionTerritories,
-                this::getDirectExclusionTerritories,
-                this::resetDirectExclusionTerritories))
-        .put(
-            "enemyExclusionTerritories",
-            MutableProperty.of(
-                this::setEnemyExclusionTerritories,
-                this::setEnemyExclusionTerritories,
-                this::getEnemyExclusionTerritories,
-                this::resetEnemyExclusionTerritories))
-        .put(
-            "enemySurfaceExclusionTerritories",
-            MutableProperty.of(
-                this::setEnemySurfaceExclusionTerritories,
-                this::setEnemySurfaceExclusionTerritories,
-                this::getEnemySurfaceExclusionTerritories,
-                this::resetEnemySurfaceExclusionTerritories))
-        .put(
-            "directPresenceTerritories",
-            MutableProperty.of(
-                this::setDirectPresenceTerritories,
-                this::setDirectPresenceTerritories,
-                this::getDirectPresenceTerritories,
-                this::resetDirectPresenceTerritories))
-        .put(
-            "alliedPresenceTerritories",
-            MutableProperty.of(
-                this::setAlliedPresenceTerritories,
-                this::setAlliedPresenceTerritories,
-                this::getAlliedPresenceTerritories,
-                this::resetAlliedPresenceTerritories))
-        .put(
-            "enemyPresenceTerritories",
-            MutableProperty.of(
-                this::setEnemyPresenceTerritories,
-                this::setEnemyPresenceTerritories,
-                this::getEnemyPresenceTerritories,
-                this::resetEnemyPresenceTerritories))
-        .put(
-            "unitPresence",
-            MutableProperty.of(
-                this::setUnitPresence,
-                this::setUnitPresence,
-                this::getUnitPresence,
-                this::resetUnitPresence))
-        .build();
+    switch (propertyName) {
+      case "techs":
+        return MutableProperty.of(this::setTechs, this::setTechs, this::getTechs, this::resetTechs);
+      case "techCount":
+        return MutableProperty.ofReadOnly(this::getTechCount);
+      case "relationship":
+        return MutableProperty.of(
+            this::setRelationship,
+            this::setRelationship,
+            this::getRelationship,
+            this::resetRelationship);
+      case "atWarPlayers":
+        return MutableProperty.of(
+            this::setAtWarPlayers,
+            this::setAtWarPlayers,
+            this::getAtWarPlayers,
+            this::resetAtWarPlayers);
+      case "atWarCount":
+        return MutableProperty.ofReadOnly(this::getAtWarCount);
+      case "destroyedTUV":
+        return MutableProperty.ofString(
+            this::setDestroyedTuv, this::getDestroyedTuv, this::resetDestroyedTuv);
+      case "battle":
+        return MutableProperty.of(
+            this::setBattle, this::setBattle, this::getBattle, this::resetBattle);
+      case "alliedOwnershipTerritories":
+        return MutableProperty.of(
+            this::setAlliedOwnershipTerritories,
+            this::setAlliedOwnershipTerritories,
+            this::getAlliedOwnershipTerritories,
+            this::resetAlliedOwnershipTerritories);
+      case "directOwnershipTerritories":
+        return MutableProperty.of(
+            this::setDirectOwnershipTerritories,
+            this::setDirectOwnershipTerritories,
+            this::getDirectOwnershipTerritories,
+            this::resetDirectOwnershipTerritories);
+      case "alliedExclusionTerritories":
+        return MutableProperty.of(
+            this::setAlliedExclusionTerritories,
+            this::setAlliedExclusionTerritories,
+            this::getAlliedExclusionTerritories,
+            this::resetAlliedExclusionTerritories);
+      case "directExclusionTerritories":
+        return MutableProperty.of(
+            this::setDirectExclusionTerritories,
+            this::setDirectExclusionTerritories,
+            this::getDirectExclusionTerritories,
+            this::resetDirectExclusionTerritories);
+      case "enemyExclusionTerritories":
+        return MutableProperty.of(
+            this::setEnemyExclusionTerritories,
+            this::setEnemyExclusionTerritories,
+            this::getEnemyExclusionTerritories,
+            this::resetEnemyExclusionTerritories);
+      case "enemySurfaceExclusionTerritories":
+        return MutableProperty.of(
+            this::setEnemySurfaceExclusionTerritories,
+            this::setEnemySurfaceExclusionTerritories,
+            this::getEnemySurfaceExclusionTerritories,
+            this::resetEnemySurfaceExclusionTerritories);
+      case "directPresenceTerritories":
+        return MutableProperty.of(
+            this::setDirectPresenceTerritories,
+            this::setDirectPresenceTerritories,
+            this::getDirectPresenceTerritories,
+            this::resetDirectPresenceTerritories);
+      case "alliedPresenceTerritories":
+        return MutableProperty.of(
+            this::setAlliedPresenceTerritories,
+            this::setAlliedPresenceTerritories,
+            this::getAlliedPresenceTerritories,
+            this::resetAlliedPresenceTerritories);
+      case "enemyPresenceTerritories":
+        return MutableProperty.of(
+            this::setEnemyPresenceTerritories,
+            this::setEnemyPresenceTerritories,
+            this::getEnemyPresenceTerritories,
+            this::resetEnemyPresenceTerritories);
+      case "unitPresence":
+        return MutableProperty.of(
+            this::setUnitPresence,
+            this::setUnitPresence,
+            this::getUnitPresence,
+            this::resetUnitPresence);
+      default:
+        return super.getPropertyOrNull(propertyName);
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.attachments;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
@@ -886,180 +885,152 @@ public class TechAbilityAttachment extends DefaultAttachment {
     }
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            "attackBonus",
-            MutableProperty.of(
-                this::setAttackBonus,
-                this::setAttackBonus,
-                this::getAttackBonus,
-                this::resetAttackBonus))
-        .put(
-            "defenseBonus",
-            MutableProperty.of(
-                this::setDefenseBonus,
-                this::setDefenseBonus,
-                this::getDefenseBonus,
-                this::resetDefenseBonus))
-        .put(
-            "movementBonus",
-            MutableProperty.of(
-                this::setMovementBonus,
-                this::setMovementBonus,
-                this::getMovementBonus,
-                this::resetMovementBonus))
-        .put(
-            "radarBonus",
-            MutableProperty.of(
-                this::setRadarBonus,
-                this::setRadarBonus,
-                this::getRadarBonus,
-                this::resetRadarBonus))
-        .put(
-            "airAttackBonus",
-            MutableProperty.of(
-                this::setAirAttackBonus,
-                this::setAirAttackBonus,
-                this::getAirAttackBonus,
-                this::resetAirAttackBonus))
-        .put(
-            "airDefenseBonus",
-            MutableProperty.of(
-                this::setAirDefenseBonus,
-                this::setAirDefenseBonus,
-                this::getAirDefenseBonus,
-                this::resetAirDefenseBonus))
-        .put(
-            "productionBonus",
-            MutableProperty.of(
-                this::setProductionBonus,
-                this::setProductionBonus,
-                this::getProductionBonus,
-                this::resetProductionBonus))
-        .put(
-            "minimumTerritoryValueForProductionBonus",
-            MutableProperty.of(
-                this::setMinimumTerritoryValueForProductionBonus,
-                this::setMinimumTerritoryValueForProductionBonus,
-                this::getMinimumTerritoryValueForProductionBonus,
-                this::resetMinimumTerritoryValueForProductionBonus))
-        .put(
-            "repairDiscount",
-            MutableProperty.of(
-                this::setRepairDiscount,
-                this::setRepairDiscount,
-                this::getRepairDiscount,
-                this::resetRepairDiscount))
-        .put(
-            "warBondDiceSides",
-            MutableProperty.of(
-                this::setWarBondDiceSides,
-                this::setWarBondDiceSides,
-                this::getWarBondDiceSides,
-                this::resetWarBondDiceSides))
-        .put(
-            "warBondDiceNumber",
-            MutableProperty.of(
-                this::setWarBondDiceNumber,
-                this::setWarBondDiceNumber,
-                this::getWarBondDiceNumber,
-                this::resetWarBondDiceNumber))
-        .put(
-            "rocketDiceNumber",
-            MutableProperty.of(
-                this::setRocketDiceNumber,
-                this::setRocketDiceNumber,
-                this::getRocketDiceNumber,
-                this::resetRocketDiceNumber))
-        .put(
-            "rocketDistance",
-            MutableProperty.of(
-                this::setRocketDistance,
-                this::setRocketDistance,
-                this::getRocketDistance,
-                this::resetRocketDistance))
-        .put(
-            "rocketNumberPerTerritory",
-            MutableProperty.of(
-                this::setRocketNumberPerTerritory,
-                this::setRocketNumberPerTerritory,
-                this::getRocketNumberPerTerritory,
-                this::resetRocketNumberPerTerritory))
-        .put(
-            "unitAbilitiesGained",
-            MutableProperty.of(
-                this::setUnitAbilitiesGained,
-                this::setUnitAbilitiesGained,
-                this::getUnitAbilitiesGained,
-                this::resetUnitAbilitiesGained))
-        .put(
-            "airborneForces",
-            MutableProperty.of(
-                this::setAirborneForces,
-                this::setAirborneForces,
-                this::getAirborneForces,
-                this::resetAirborneForces))
-        .put(
-            "airborneCapacity",
-            MutableProperty.of(
-                this::setAirborneCapacity,
-                this::setAirborneCapacity,
-                this::getAirborneCapacity,
-                this::resetAirborneCapacity))
-        .put(
-            "airborneTypes",
-            MutableProperty.of(
-                this::setAirborneTypes,
-                this::setAirborneTypes,
-                this::getAirborneTypes,
-                this::resetAirborneTypes))
-        .put(
-            "airborneDistance",
-            MutableProperty.of(
-                this::setAirborneDistance,
-                this::setAirborneDistance,
-                this::getAirborneDistance,
-                this::resetAirborneDistance))
-        .put(
-            "airborneBases",
-            MutableProperty.of(
-                this::setAirborneBases,
-                this::setAirborneBases,
-                this::getAirborneBases,
-                this::resetAirborneBases))
-        .put(
-            "airborneTargettedByAA",
-            MutableProperty.of(
-                this::setAirborneTargettedByAa,
-                this::setAirborneTargettedByAa,
-                this::getAirborneTargettedByAa,
-                this::resetAirborneTargettedByAa))
-        .put(
-            "attackRollsBonus",
-            MutableProperty.of(
-                this::setAttackRollsBonus,
-                this::setAttackRollsBonus,
-                this::getAttackRollsBonus,
-                this::resetAttackRollsBonus))
-        .put(
-            "defenseRollsBonus",
-            MutableProperty.of(
-                this::setDefenseRollsBonus,
-                this::setDefenseRollsBonus,
-                this::getDefenseRollsBonus,
-                this::resetDefenseRollsBonus))
-        .put(
-            "bombingBonus",
-            MutableProperty.of(
-                this::setBombingBonus,
-                this::setBombingBonus,
-                this::getBombingBonus,
-                this::resetBombingBonus))
-        .build();
+    switch (propertyName) {
+      case "attackBonus":
+        return MutableProperty.of(
+            this::setAttackBonus,
+            this::setAttackBonus,
+            this::getAttackBonus,
+            this::resetAttackBonus);
+      case "defenseBonus":
+        return MutableProperty.of(
+            this::setDefenseBonus,
+            this::setDefenseBonus,
+            this::getDefenseBonus,
+            this::resetDefenseBonus);
+      case "movementBonus":
+        return MutableProperty.of(
+            this::setMovementBonus,
+            this::setMovementBonus,
+            this::getMovementBonus,
+            this::resetMovementBonus);
+      case "radarBonus":
+        return MutableProperty.of(
+            this::setRadarBonus, this::setRadarBonus, this::getRadarBonus, this::resetRadarBonus);
+      case "airAttackBonus":
+        return MutableProperty.of(
+            this::setAirAttackBonus,
+            this::setAirAttackBonus,
+            this::getAirAttackBonus,
+            this::resetAirAttackBonus);
+      case "airDefenseBonus":
+        return MutableProperty.of(
+            this::setAirDefenseBonus,
+            this::setAirDefenseBonus,
+            this::getAirDefenseBonus,
+            this::resetAirDefenseBonus);
+      case "productionBonus":
+        return MutableProperty.of(
+            this::setProductionBonus,
+            this::setProductionBonus,
+            this::getProductionBonus,
+            this::resetProductionBonus);
+      case "minimumTerritoryValueForProductionBonus":
+        return MutableProperty.of(
+            this::setMinimumTerritoryValueForProductionBonus,
+            this::setMinimumTerritoryValueForProductionBonus,
+            this::getMinimumTerritoryValueForProductionBonus,
+            this::resetMinimumTerritoryValueForProductionBonus);
+      case "repairDiscount":
+        return MutableProperty.of(
+            this::setRepairDiscount,
+            this::setRepairDiscount,
+            this::getRepairDiscount,
+            this::resetRepairDiscount);
+      case "warBondDiceSides":
+        return MutableProperty.of(
+            this::setWarBondDiceSides,
+            this::setWarBondDiceSides,
+            this::getWarBondDiceSides,
+            this::resetWarBondDiceSides);
+      case "warBondDiceNumber":
+        return MutableProperty.of(
+            this::setWarBondDiceNumber,
+            this::setWarBondDiceNumber,
+            this::getWarBondDiceNumber,
+            this::resetWarBondDiceNumber);
+      case "rocketDiceNumber":
+        return MutableProperty.of(
+            this::setRocketDiceNumber,
+            this::setRocketDiceNumber,
+            this::getRocketDiceNumber,
+            this::resetRocketDiceNumber);
+      case "rocketDistance":
+        return MutableProperty.of(
+            this::setRocketDistance,
+            this::setRocketDistance,
+            this::getRocketDistance,
+            this::resetRocketDistance);
+      case "rocketNumberPerTerritory":
+        return MutableProperty.of(
+            this::setRocketNumberPerTerritory,
+            this::setRocketNumberPerTerritory,
+            this::getRocketNumberPerTerritory,
+            this::resetRocketNumberPerTerritory);
+      case "unitAbilitiesGained":
+        return MutableProperty.of(
+            this::setUnitAbilitiesGained,
+            this::setUnitAbilitiesGained,
+            this::getUnitAbilitiesGained,
+            this::resetUnitAbilitiesGained);
+      case "airborneForces":
+        return MutableProperty.of(
+            this::setAirborneForces,
+            this::setAirborneForces,
+            this::getAirborneForces,
+            this::resetAirborneForces);
+      case "airborneCapacity":
+        return MutableProperty.of(
+            this::setAirborneCapacity,
+            this::setAirborneCapacity,
+            this::getAirborneCapacity,
+            this::resetAirborneCapacity);
+      case "airborneTypes":
+        return MutableProperty.of(
+            this::setAirborneTypes,
+            this::setAirborneTypes,
+            this::getAirborneTypes,
+            this::resetAirborneTypes);
+      case "airborneDistance":
+        return MutableProperty.of(
+            this::setAirborneDistance,
+            this::setAirborneDistance,
+            this::getAirborneDistance,
+            this::resetAirborneDistance);
+      case "airborneBases":
+        return MutableProperty.of(
+            this::setAirborneBases,
+            this::setAirborneBases,
+            this::getAirborneBases,
+            this::resetAirborneBases);
+      case "airborneTargettedByAA":
+        return MutableProperty.of(
+            this::setAirborneTargettedByAa,
+            this::setAirborneTargettedByAa,
+            this::getAirborneTargettedByAa,
+            this::resetAirborneTargettedByAa);
+      case "attackRollsBonus":
+        return MutableProperty.of(
+            this::setAttackRollsBonus,
+            this::setAttackRollsBonus,
+            this::getAttackRollsBonus,
+            this::resetAttackRollsBonus);
+      case "defenseRollsBonus":
+        return MutableProperty.of(
+            this::setDefenseRollsBonus,
+            this::setDefenseRollsBonus,
+            this::getDefenseRollsBonus,
+            this::resetDefenseRollsBonus);
+      case "bombingBonus":
+        return MutableProperty.of(
+            this::setBombingBonus,
+            this::setBombingBonus,
+            this::getBombingBonus,
+            this::resetBombingBonus);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -886,7 +886,10 @@ public class TechAbilityAttachment extends DefaultAttachment {
     }
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -319,7 +319,10 @@ public class TechAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.attachments;
 
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
@@ -319,96 +318,80 @@ public class TechAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            "techCost",
-            MutableProperty.of(
-                this::setTechCost, this::setTechCost, this::getTechCost, this::resetTechCost))
-        .put(
-            "heavyBomber",
-            MutableProperty.of(
-                this::setHeavyBomber,
-                this::setHeavyBomber,
-                this::getHeavyBomber,
-                this::resetHeavyBomber))
-        .put(
-            "longRangeAir",
-            MutableProperty.of(
-                this::setLongRangeAir,
-                this::setLongRangeAir,
-                this::getLongRangeAir,
-                this::resetLongRangeAir))
-        .put(
-            "jetPower",
-            MutableProperty.of(
-                this::setJetPower, this::setJetPower, this::getJetPower, this::resetJetPower))
-        .put(
-            "rocket",
-            MutableProperty.of(
-                this::setRocket, this::setRocket, this::getRocket, this::resetRocket))
-        .put(
-            "industrialTechnology",
-            MutableProperty.of(
-                this::setIndustrialTechnology,
-                this::setIndustrialTechnology,
-                this::getIndustrialTechnology,
-                this::resetIndustrialTechnology))
-        .put(
-            "superSub",
-            MutableProperty.of(
-                this::setSuperSub, this::setSuperSub, this::getSuperSub, this::resetSuperSub))
-        .put(
-            "destroyerBombard",
-            MutableProperty.of(
-                this::setDestroyerBombard,
-                this::setDestroyerBombard,
-                this::getDestroyerBombard,
-                this::resetDestroyerBombard))
-        .put(
-            "improvedArtillerySupport",
-            MutableProperty.of(
-                this::setImprovedArtillerySupport,
-                this::setImprovedArtillerySupport,
-                this::getImprovedArtillerySupport,
-                this::resetImprovedArtillerySupport))
-        .put(
-            "paratroopers",
-            MutableProperty.of(
-                this::setParatroopers,
-                this::setParatroopers,
-                this::getParatroopers,
-                this::resetParatroopers))
-        .put(
-            "increasedFactoryProduction",
-            MutableProperty.of(
-                this::setIncreasedFactoryProduction,
-                this::setIncreasedFactoryProduction,
-                this::getIncreasedFactoryProduction,
-                this::resetIncreasedFactoryProduction))
-        .put(
-            "warBonds",
-            MutableProperty.of(
-                this::setWarBonds, this::setWarBonds, this::getWarBonds, this::resetWarBonds))
-        .put(
-            "mechanizedInfantry",
-            MutableProperty.of(
-                this::setMechanizedInfantry,
-                this::setMechanizedInfantry,
-                this::getMechanizedInfantry,
-                this::resetMechanizedInfantry))
-        .put(
-            "aARadar",
-            MutableProperty.of(
-                this::setAaRadar, this::setAaRadar, this::getAaRadar, this::resetAaRadar))
-        .put(
-            "shipyards",
-            MutableProperty.of(
-                this::setShipyards, this::setShipyards, this::getShipyards, this::resetShipyards))
-        .build();
+    switch (propertyName) {
+      case "techCost":
+        return MutableProperty.of(
+            this::setTechCost, this::setTechCost, this::getTechCost, this::resetTechCost);
+      case "heavyBomber":
+        return MutableProperty.of(
+            this::setHeavyBomber,
+            this::setHeavyBomber,
+            this::getHeavyBomber,
+            this::resetHeavyBomber);
+      case "longRangeAir":
+        return MutableProperty.of(
+            this::setLongRangeAir,
+            this::setLongRangeAir,
+            this::getLongRangeAir,
+            this::resetLongRangeAir);
+      case "jetPower":
+        return MutableProperty.of(
+            this::setJetPower, this::setJetPower, this::getJetPower, this::resetJetPower);
+      case "rocket":
+        return MutableProperty.of(
+            this::setRocket, this::setRocket, this::getRocket, this::resetRocket);
+      case "industrialTechnology":
+        return MutableProperty.of(
+            this::setIndustrialTechnology,
+            this::setIndustrialTechnology,
+            this::getIndustrialTechnology,
+            this::resetIndustrialTechnology);
+      case "superSub":
+        return MutableProperty.of(
+            this::setSuperSub, this::setSuperSub, this::getSuperSub, this::resetSuperSub);
+      case "destroyerBombard":
+        return MutableProperty.of(
+            this::setDestroyerBombard,
+            this::setDestroyerBombard,
+            this::getDestroyerBombard,
+            this::resetDestroyerBombard);
+      case "improvedArtillerySupport":
+        return MutableProperty.of(
+            this::setImprovedArtillerySupport,
+            this::setImprovedArtillerySupport,
+            this::getImprovedArtillerySupport,
+            this::resetImprovedArtillerySupport);
+      case "paratroopers":
+        return MutableProperty.of(
+            this::setParatroopers,
+            this::setParatroopers,
+            this::getParatroopers,
+            this::resetParatroopers);
+      case "increasedFactoryProduction":
+        return MutableProperty.of(
+            this::setIncreasedFactoryProduction,
+            this::setIncreasedFactoryProduction,
+            this::getIncreasedFactoryProduction,
+            this::resetIncreasedFactoryProduction);
+      case "warBonds":
+        return MutableProperty.of(
+            this::setWarBonds, this::setWarBonds, this::getWarBonds, this::resetWarBonds);
+      case "mechanizedInfantry":
+        return MutableProperty.of(
+            this::setMechanizedInfantry,
+            this::setMechanizedInfantry,
+            this::getMechanizedInfantry,
+            this::resetMechanizedInfantry);
+      case "aARadar":
+        return MutableProperty.of(
+            this::setAaRadar, this::setAaRadar, this::getAaRadar, this::resetAaRadar);
+      case "shipyards":
+        return MutableProperty.of(
+            this::setShipyards, this::setShipyards, this::getShipyards, this::resetShipyards);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -741,7 +741,10 @@ public class TerritoryAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.attachments;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
@@ -23,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -741,124 +739,100 @@ public class TerritoryAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            "capital",
-            MutableProperty.ofString(this::setCapital, this::getCapital, this::resetCapital))
-        .put(
-            "originalFactory",
-            MutableProperty.of(
-                this::setOriginalFactory,
-                this::setOriginalFactory,
-                this::getOriginalFactory,
-                this::resetOriginalFactory))
-        .put(
-            "production",
-            MutableProperty.of(
-                this::setProduction,
-                this::setProduction,
-                this::getProduction,
-                this::resetProduction))
-        .put("productionOnly", MutableProperty.ofWriteOnlyString(this::setProductionOnly))
-        .put(
-            "victoryCity",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt, this::setVictoryCity, this::getVictoryCity, () -> 0))
-        .put(
-            "isImpassable",
-            MutableProperty.of(
-                this::setIsImpassable,
-                this::setIsImpassable,
-                this::getIsImpassable,
-                this::resetIsImpassable))
-        .put(
-            "originalOwner",
-            MutableProperty.of(
-                this::setOriginalOwner,
-                this::setOriginalOwner,
-                this::getOriginalOwner,
-                this::resetOriginalOwner))
-        .put(
-            "convoyRoute",
-            MutableProperty.of(
-                this::setConvoyRoute,
-                this::setConvoyRoute,
-                this::getConvoyRoute,
-                this::resetConvoyRoute))
-        .put(
-            "convoyAttached",
-            MutableProperty.of(
-                this::setConvoyAttached,
-                this::setConvoyAttached,
-                this::getConvoyAttached,
-                this::resetConvoyAttached))
-        .put(
-            "changeUnitOwners",
-            MutableProperty.of(
-                this::setChangeUnitOwners,
-                this::setChangeUnitOwners,
-                this::getChangeUnitOwners,
-                this::resetChangeUnitOwners))
-        .put(
-            "captureUnitOnEnteringBy",
-            MutableProperty.of(
-                this::setCaptureUnitOnEnteringBy,
-                this::setCaptureUnitOnEnteringBy,
-                this::getCaptureUnitOnEnteringBy,
-                this::resetCaptureUnitOnEnteringBy))
-        .put(
-            "navalBase",
-            MutableProperty.of(
-                this::setNavalBase, this::setNavalBase, this::getNavalBase, this::resetNavalBase))
-        .put(
-            "airBase",
-            MutableProperty.of(
-                this::setAirBase, this::setAirBase, this::getAirBase, this::resetAirBase))
-        .put(
-            "kamikazeZone",
-            MutableProperty.of(
-                this::setKamikazeZone,
-                this::setKamikazeZone,
-                this::getKamikazeZone,
-                this::resetKamikazeZone))
-        .put(
-            "unitProduction",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt,
-                this::setUnitProduction,
-                this::getUnitProduction,
-                () -> 0))
-        .put(
-            "blockadeZone",
-            MutableProperty.of(
-                this::setBlockadeZone,
-                this::setBlockadeZone,
-                this::getBlockadeZone,
-                this::resetBlockadeZone))
-        .put(
-            "territoryEffect",
-            MutableProperty.of(
-                this::setTerritoryEffect,
-                this::setTerritoryEffect,
-                this::getTerritoryEffect,
-                this::resetTerritoryEffect))
-        .put(
-            "whenCapturedByGoesTo",
-            MutableProperty.of(
-                this::setWhenCapturedByGoesTo,
-                this::setWhenCapturedByGoesTo,
-                this::getWhenCapturedByGoesTo,
-                this::resetWhenCapturedByGoesTo))
-        .put(
-            "resources",
-            MutableProperty.of(
-                this::setResources, this::setResources, this::getResources, this::resetResources))
-        .build();
+    switch (propertyName) {
+      case "capital":
+        return MutableProperty.ofString(this::setCapital, this::getCapital, this::resetCapital);
+      case "originalFactory":
+        return MutableProperty.of(
+            this::setOriginalFactory,
+            this::setOriginalFactory,
+            this::getOriginalFactory,
+            this::resetOriginalFactory);
+      case "production":
+        return MutableProperty.of(
+            this::setProduction, this::setProduction, this::getProduction, this::resetProduction);
+      case "productionOnly":
+        return MutableProperty.ofWriteOnlyString(this::setProductionOnly);
+      case "victoryCity":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt, this::setVictoryCity, this::getVictoryCity, () -> 0);
+      case "isImpassable":
+        return MutableProperty.of(
+            this::setIsImpassable,
+            this::setIsImpassable,
+            this::getIsImpassable,
+            this::resetIsImpassable);
+      case "originalOwner":
+        return MutableProperty.of(
+            this::setOriginalOwner,
+            this::setOriginalOwner,
+            this::getOriginalOwner,
+            this::resetOriginalOwner);
+      case "convoyRoute":
+        return MutableProperty.of(
+            this::setConvoyRoute,
+            this::setConvoyRoute,
+            this::getConvoyRoute,
+            this::resetConvoyRoute);
+      case "convoyAttached":
+        return MutableProperty.of(
+            this::setConvoyAttached,
+            this::setConvoyAttached,
+            this::getConvoyAttached,
+            this::resetConvoyAttached);
+      case "changeUnitOwners":
+        return MutableProperty.of(
+            this::setChangeUnitOwners,
+            this::setChangeUnitOwners,
+            this::getChangeUnitOwners,
+            this::resetChangeUnitOwners);
+      case "captureUnitOnEnteringBy":
+        return MutableProperty.of(
+            this::setCaptureUnitOnEnteringBy,
+            this::setCaptureUnitOnEnteringBy,
+            this::getCaptureUnitOnEnteringBy,
+            this::resetCaptureUnitOnEnteringBy);
+      case "navalBase":
+        return MutableProperty.of(
+            this::setNavalBase, this::setNavalBase, this::getNavalBase, this::resetNavalBase);
+      case "airBase":
+        return MutableProperty.of(
+            this::setAirBase, this::setAirBase, this::getAirBase, this::resetAirBase);
+      case "kamikazeZone":
+        return MutableProperty.of(
+            this::setKamikazeZone,
+            this::setKamikazeZone,
+            this::getKamikazeZone,
+            this::resetKamikazeZone);
+      case "unitProduction":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt, this::setUnitProduction, this::getUnitProduction, () -> 0);
+      case "blockadeZone":
+        return MutableProperty.of(
+            this::setBlockadeZone,
+            this::setBlockadeZone,
+            this::getBlockadeZone,
+            this::resetBlockadeZone);
+      case "territoryEffect":
+        return MutableProperty.of(
+            this::setTerritoryEffect,
+            this::setTerritoryEffect,
+            this::getTerritoryEffect,
+            this::resetTerritoryEffect);
+      case "whenCapturedByGoesTo":
+        return MutableProperty.of(
+            this::setWhenCapturedByGoesTo,
+            this::setWhenCapturedByGoesTo,
+            this::getWhenCapturedByGoesTo,
+            this::resetWhenCapturedByGoesTo);
+      case "resources":
+        return MutableProperty.of(
+            this::setResources, this::setResources, this::getResources, this::resetResources);
+      default:
+        return null;
+    }
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.attachments;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
@@ -206,44 +205,38 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  private Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            COMBAT_DEFENSE_EFFECT,
-            MutableProperty.of(
-                this::setCombatDefenseEffect,
-                this::setCombatDefenseEffect,
-                this::getCombatDefenseEffect,
-                this::resetCombatDefenseEffect))
-        .put(
-            COMBAT_OFFENSE_EFFECT,
-            MutableProperty.of(
-                this::setCombatOffenseEffect,
-                this::setCombatOffenseEffect,
-                this::getCombatOffenseEffect,
-                this::resetCombatOffenseEffect))
-        .put(
-            "movementCostModifier",
-            MutableProperty.of(
-                this::setMovementCostModifier,
-                this::setMovementCostModifier,
-                this::getMovementCostModifier,
-                this::resetMovementCostModifier))
-        .put(
-            "noBlitz",
-            MutableProperty.of(
-                this::setNoBlitz, this::setNoBlitz, this::getNoBlitz, this::resetNoBlitz))
-        .put(
-            "unitsNotAllowed",
-            MutableProperty.of(
-                this::setUnitsNotAllowed,
-                this::setUnitsNotAllowed,
-                this::getUnitsNotAllowed,
-                this::resetUnitsNotAllowed))
-        .build();
+    switch (propertyName) {
+      case COMBAT_DEFENSE_EFFECT:
+        return MutableProperty.of(
+            this::setCombatDefenseEffect,
+            this::setCombatDefenseEffect,
+            this::getCombatDefenseEffect,
+            this::resetCombatDefenseEffect);
+      case COMBAT_OFFENSE_EFFECT:
+        return MutableProperty.of(
+            this::setCombatOffenseEffect,
+            this::setCombatOffenseEffect,
+            this::getCombatOffenseEffect,
+            this::resetCombatOffenseEffect);
+      case "movementCostModifier":
+        return MutableProperty.of(
+            this::setMovementCostModifier,
+            this::setMovementCostModifier,
+            this::getMovementCostModifier,
+            this::resetMovementCostModifier);
+      case "noBlitz":
+        return MutableProperty.of(
+            this::setNoBlitz, this::setNoBlitz, this::getNoBlitz, this::resetNoBlitz);
+      case "unitsNotAllowed":
+        return MutableProperty.of(
+            this::setUnitsNotAllowed,
+            this::setUnitsNotAllowed,
+            this::getUnitsNotAllowed,
+            this::resetUnitsNotAllowed);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -210,7 +210,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
     return getPropertyMap().get(propertyName);
   }
 
-  public Map<String, MutableProperty<?>> getPropertyMap() {
+  private Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(
             COMBAT_DEFENSE_EFFECT,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -206,7 +206,10 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2744,5 +2745,159 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
                 this::getTerritoryEffectProperty,
                 this::resetTerritoryEffectProperty))
         .build();
+  }
+
+  @Override
+  public Function<String, MutableProperty<?>> getPropertyMapFunction() {
+    return (propertyName) -> {
+      switch (propertyName) {
+        case "frontier":
+          return MutableProperty.of(
+              this::setFrontier, this::setFrontier, this::getFrontier, this::resetFrontier);
+        case "productionRule":
+          return MutableProperty.of(
+              this::setProductionRule,
+              this::setProductionRule,
+              this::getProductionRule,
+              this::resetProductionRule);
+        case "tech":
+          return MutableProperty.of(this::setTech, this::setTech, this::getTech, this::resetTech);
+        case "availableTech":
+          return MutableProperty.of(
+              this::setAvailableTech,
+              this::setAvailableTech,
+              this::getAvailableTech,
+              this::resetAvailableTech);
+        case "placement":
+          return MutableProperty.of(
+              this::setPlacement, this::setPlacement, this::getPlacement, this::resetPlacement);
+        case "removeUnits":
+          return MutableProperty.of(
+              this::setRemoveUnits,
+              this::setRemoveUnits,
+              this::getRemoveUnits,
+              this::resetRemoveUnits);
+        case "purchase":
+          return MutableProperty.of(
+              this::setPurchase, this::setPurchase, this::getPurchase, this::resetPurchase);
+        case "resource":
+          return MutableProperty.ofString(
+              this::setResource, this::getResource, this::resetResource);
+        case "resourceCount":
+          return MutableProperty.of(
+              this::setResourceCount,
+              this::setResourceCount,
+              this::getResourceCount,
+              this::resetResourceCount);
+        case "support":
+          return MutableProperty.of(
+              this::setSupport, this::setSupport, this::getSupport, this::resetSupport);
+        case "relationshipChange":
+          return MutableProperty.of(
+              this::setRelationshipChange,
+              this::setRelationshipChange,
+              this::getRelationshipChange,
+              this::resetRelationshipChange);
+        case "victory":
+          return MutableProperty.ofString(this::setVictory, this::getVictory, this::resetVictory);
+        case "activateTrigger":
+          return MutableProperty.of(
+              this::setActivateTrigger,
+              this::setActivateTrigger,
+              this::getActivateTrigger,
+              this::resetActivateTrigger);
+        case "changeOwnership":
+          return MutableProperty.of(
+              this::setChangeOwnership,
+              this::setChangeOwnership,
+              this::getChangeOwnership,
+              this::resetChangeOwnership);
+        case "unitType":
+          return MutableProperty.of(
+              this::setUnitType, this::setUnitType, this::getUnitType, this::resetUnitType);
+        case "unitAttachmentName":
+          return MutableProperty.of(
+              this::setUnitAttachmentName,
+              this::setUnitAttachmentName,
+              this::getUnitAttachmentName,
+              this::resetUnitAttachmentName);
+        case "unitProperty":
+          return MutableProperty.of(
+              this::setUnitProperty,
+              this::setUnitProperty,
+              this::getUnitProperty,
+              this::resetUnitProperty);
+        case "territories":
+          return MutableProperty.of(
+              this::setTerritories,
+              this::setTerritories,
+              this::getTerritories,
+              this::resetTerritories);
+        case "territoryAttachmentName":
+          return MutableProperty.of(
+              this::setTerritoryAttachmentName,
+              this::setTerritoryAttachmentName,
+              this::getTerritoryAttachmentName,
+              this::resetTerritoryAttachmentName);
+        case "territoryProperty":
+          return MutableProperty.of(
+              this::setTerritoryProperty,
+              this::setTerritoryProperty,
+              this::getTerritoryProperty,
+              this::resetTerritoryProperty);
+        case "players":
+          return MutableProperty.of(
+              this::setPlayers, this::setPlayers, this::getPlayers, this::resetPlayers);
+        case "playerAttachmentName":
+          return MutableProperty.of(
+              this::setPlayerAttachmentName,
+              this::setPlayerAttachmentName,
+              this::getPlayerAttachmentName,
+              this::resetPlayerAttachmentName);
+        case "playerProperty":
+          return MutableProperty.of(
+              this::setPlayerProperty,
+              this::setPlayerProperty,
+              this::getPlayerProperty,
+              this::resetPlayerProperty);
+        case "relationshipTypes":
+          return MutableProperty.of(
+              this::setRelationshipTypes,
+              this::setRelationshipTypes,
+              this::getRelationshipTypes,
+              this::resetRelationshipTypes);
+        case "relationshipTypeAttachmentName":
+          return MutableProperty.of(
+              this::setRelationshipTypeAttachmentName,
+              this::setRelationshipTypeAttachmentName,
+              this::getRelationshipTypeAttachmentName,
+              this::resetRelationshipTypeAttachmentName);
+        case "relationshipTypeProperty":
+          return MutableProperty.of(
+              this::setRelationshipTypeProperty,
+              this::setRelationshipTypeProperty,
+              this::getRelationshipTypeProperty,
+              this::resetRelationshipTypeProperty);
+        case "territoryEffects":
+          return MutableProperty.of(
+              this::setTerritoryEffects,
+              this::setTerritoryEffects,
+              this::getTerritoryEffects,
+              this::resetTerritoryEffects);
+        case "territoryEffectAttachmentName":
+          return MutableProperty.of(
+              this::setTerritoryEffectAttachmentName,
+              this::setTerritoryEffectAttachmentName,
+              this::getTerritoryEffectAttachmentName,
+              this::resetTerritoryEffectAttachmentName);
+        case "territoryEffectProperty":
+          return MutableProperty.of(
+              this::setTerritoryEffectProperty,
+              this::setTerritoryEffectProperty,
+              this::getTerritoryEffectProperty,
+              this::resetTerritoryEffectProperty);
+      }
+      return getPropertyMapFunction().apply(propertyName);
+    };
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -48,7 +48,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2568,337 +2567,154 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @Override
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .putAll(super.getPropertyMap())
-        .put(
-            "frontier",
-            MutableProperty.of(
-                this::setFrontier, this::setFrontier, this::getFrontier, this::resetFrontier))
-        .put(
-            "productionRule",
-            MutableProperty.of(
-                this::setProductionRule,
-                this::setProductionRule,
-                this::getProductionRule,
-                this::resetProductionRule))
-        .put(
-            "tech",
-            MutableProperty.of(this::setTech, this::setTech, this::getTech, this::resetTech))
-        .put(
-            "availableTech",
-            MutableProperty.of(
-                this::setAvailableTech,
-                this::setAvailableTech,
-                this::getAvailableTech,
-                this::resetAvailableTech))
-        .put(
-            "placement",
-            MutableProperty.of(
-                this::setPlacement, this::setPlacement, this::getPlacement, this::resetPlacement))
-        .put(
-            "removeUnits",
-            MutableProperty.of(
-                this::setRemoveUnits,
-                this::setRemoveUnits,
-                this::getRemoveUnits,
-                this::resetRemoveUnits))
-        .put(
-            "purchase",
-            MutableProperty.of(
-                this::setPurchase, this::setPurchase, this::getPurchase, this::resetPurchase))
-        .put(
-            "resource",
-            MutableProperty.ofString(this::setResource, this::getResource, this::resetResource))
-        .put(
-            "resourceCount",
-            MutableProperty.of(
-                this::setResourceCount,
-                this::setResourceCount,
-                this::getResourceCount,
-                this::resetResourceCount))
-        .put(
-            "support",
-            MutableProperty.of(
-                this::setSupport, this::setSupport, this::getSupport, this::resetSupport))
-        .put(
-            "relationshipChange",
-            MutableProperty.of(
-                this::setRelationshipChange,
-                this::setRelationshipChange,
-                this::getRelationshipChange,
-                this::resetRelationshipChange))
-        .put(
-            "victory",
-            MutableProperty.ofString(this::setVictory, this::getVictory, this::resetVictory))
-        .put(
-            "activateTrigger",
-            MutableProperty.of(
-                this::setActivateTrigger,
-                this::setActivateTrigger,
-                this::getActivateTrigger,
-                this::resetActivateTrigger))
-        .put(
-            "changeOwnership",
-            MutableProperty.of(
-                this::setChangeOwnership,
-                this::setChangeOwnership,
-                this::getChangeOwnership,
-                this::resetChangeOwnership))
-        .put(
-            "unitType",
-            MutableProperty.of(
-                this::setUnitType, this::setUnitType, this::getUnitType, this::resetUnitType))
-        .put(
-            "unitAttachmentName",
-            MutableProperty.of(
-                this::setUnitAttachmentName,
-                this::setUnitAttachmentName,
-                this::getUnitAttachmentName,
-                this::resetUnitAttachmentName))
-        .put(
-            "unitProperty",
-            MutableProperty.of(
-                this::setUnitProperty,
-                this::setUnitProperty,
-                this::getUnitProperty,
-                this::resetUnitProperty))
-        .put(
-            "territories",
-            MutableProperty.of(
-                this::setTerritories,
-                this::setTerritories,
-                this::getTerritories,
-                this::resetTerritories))
-        .put(
-            "territoryAttachmentName",
-            MutableProperty.of(
-                this::setTerritoryAttachmentName,
-                this::setTerritoryAttachmentName,
-                this::getTerritoryAttachmentName,
-                this::resetTerritoryAttachmentName))
-        .put(
-            "territoryProperty",
-            MutableProperty.of(
-                this::setTerritoryProperty,
-                this::setTerritoryProperty,
-                this::getTerritoryProperty,
-                this::resetTerritoryProperty))
-        .put(
-            "players",
-            MutableProperty.of(
-                this::setPlayers, this::setPlayers, this::getPlayers, this::resetPlayers))
-        .put(
-            "playerAttachmentName",
-            MutableProperty.of(
-                this::setPlayerAttachmentName,
-                this::setPlayerAttachmentName,
-                this::getPlayerAttachmentName,
-                this::resetPlayerAttachmentName))
-        .put(
-            "playerProperty",
-            MutableProperty.of(
-                this::setPlayerProperty,
-                this::setPlayerProperty,
-                this::getPlayerProperty,
-                this::resetPlayerProperty))
-        .put(
-            "relationshipTypes",
-            MutableProperty.of(
-                this::setRelationshipTypes,
-                this::setRelationshipTypes,
-                this::getRelationshipTypes,
-                this::resetRelationshipTypes))
-        .put(
-            "relationshipTypeAttachmentName",
-            MutableProperty.of(
-                this::setRelationshipTypeAttachmentName,
-                this::setRelationshipTypeAttachmentName,
-                this::getRelationshipTypeAttachmentName,
-                this::resetRelationshipTypeAttachmentName))
-        .put(
-            "relationshipTypeProperty",
-            MutableProperty.of(
-                this::setRelationshipTypeProperty,
-                this::setRelationshipTypeProperty,
-                this::getRelationshipTypeProperty,
-                this::resetRelationshipTypeProperty))
-        .put(
-            "territoryEffects",
-            MutableProperty.of(
-                this::setTerritoryEffects,
-                this::setTerritoryEffects,
-                this::getTerritoryEffects,
-                this::resetTerritoryEffects))
-        .put(
-            "territoryEffectAttachmentName",
-            MutableProperty.of(
-                this::setTerritoryEffectAttachmentName,
-                this::setTerritoryEffectAttachmentName,
-                this::getTerritoryEffectAttachmentName,
-                this::resetTerritoryEffectAttachmentName))
-        .put(
-            "territoryEffectProperty",
-            MutableProperty.of(
-                this::setTerritoryEffectProperty,
-                this::setTerritoryEffectProperty,
-                this::getTerritoryEffectProperty,
-                this::resetTerritoryEffectProperty))
-        .build();
-  }
-
-  @Override
-  public Function<String, MutableProperty<?>> getPropertyMapFunction() {
-    return (propertyName) -> {
-      switch (propertyName) {
-        case "frontier":
-          return MutableProperty.of(
-              this::setFrontier, this::setFrontier, this::getFrontier, this::resetFrontier);
-        case "productionRule":
-          return MutableProperty.of(
-              this::setProductionRule,
-              this::setProductionRule,
-              this::getProductionRule,
-              this::resetProductionRule);
-        case "tech":
-          return MutableProperty.of(this::setTech, this::setTech, this::getTech, this::resetTech);
-        case "availableTech":
-          return MutableProperty.of(
-              this::setAvailableTech,
-              this::setAvailableTech,
-              this::getAvailableTech,
-              this::resetAvailableTech);
-        case "placement":
-          return MutableProperty.of(
-              this::setPlacement, this::setPlacement, this::getPlacement, this::resetPlacement);
-        case "removeUnits":
-          return MutableProperty.of(
-              this::setRemoveUnits,
-              this::setRemoveUnits,
-              this::getRemoveUnits,
-              this::resetRemoveUnits);
-        case "purchase":
-          return MutableProperty.of(
-              this::setPurchase, this::setPurchase, this::getPurchase, this::resetPurchase);
-        case "resource":
-          return MutableProperty.ofString(
-              this::setResource, this::getResource, this::resetResource);
-        case "resourceCount":
-          return MutableProperty.of(
-              this::setResourceCount,
-              this::setResourceCount,
-              this::getResourceCount,
-              this::resetResourceCount);
-        case "support":
-          return MutableProperty.of(
-              this::setSupport, this::setSupport, this::getSupport, this::resetSupport);
-        case "relationshipChange":
-          return MutableProperty.of(
-              this::setRelationshipChange,
-              this::setRelationshipChange,
-              this::getRelationshipChange,
-              this::resetRelationshipChange);
-        case "victory":
-          return MutableProperty.ofString(this::setVictory, this::getVictory, this::resetVictory);
-        case "activateTrigger":
-          return MutableProperty.of(
-              this::setActivateTrigger,
-              this::setActivateTrigger,
-              this::getActivateTrigger,
-              this::resetActivateTrigger);
-        case "changeOwnership":
-          return MutableProperty.of(
-              this::setChangeOwnership,
-              this::setChangeOwnership,
-              this::getChangeOwnership,
-              this::resetChangeOwnership);
-        case "unitType":
-          return MutableProperty.of(
-              this::setUnitType, this::setUnitType, this::getUnitType, this::resetUnitType);
-        case "unitAttachmentName":
-          return MutableProperty.of(
-              this::setUnitAttachmentName,
-              this::setUnitAttachmentName,
-              this::getUnitAttachmentName,
-              this::resetUnitAttachmentName);
-        case "unitProperty":
-          return MutableProperty.of(
-              this::setUnitProperty,
-              this::setUnitProperty,
-              this::getUnitProperty,
-              this::resetUnitProperty);
-        case "territories":
-          return MutableProperty.of(
-              this::setTerritories,
-              this::setTerritories,
-              this::getTerritories,
-              this::resetTerritories);
-        case "territoryAttachmentName":
-          return MutableProperty.of(
-              this::setTerritoryAttachmentName,
-              this::setTerritoryAttachmentName,
-              this::getTerritoryAttachmentName,
-              this::resetTerritoryAttachmentName);
-        case "territoryProperty":
-          return MutableProperty.of(
-              this::setTerritoryProperty,
-              this::setTerritoryProperty,
-              this::getTerritoryProperty,
-              this::resetTerritoryProperty);
-        case "players":
-          return MutableProperty.of(
-              this::setPlayers, this::setPlayers, this::getPlayers, this::resetPlayers);
-        case "playerAttachmentName":
-          return MutableProperty.of(
-              this::setPlayerAttachmentName,
-              this::setPlayerAttachmentName,
-              this::getPlayerAttachmentName,
-              this::resetPlayerAttachmentName);
-        case "playerProperty":
-          return MutableProperty.of(
-              this::setPlayerProperty,
-              this::setPlayerProperty,
-              this::getPlayerProperty,
-              this::resetPlayerProperty);
-        case "relationshipTypes":
-          return MutableProperty.of(
-              this::setRelationshipTypes,
-              this::setRelationshipTypes,
-              this::getRelationshipTypes,
-              this::resetRelationshipTypes);
-        case "relationshipTypeAttachmentName":
-          return MutableProperty.of(
-              this::setRelationshipTypeAttachmentName,
-              this::setRelationshipTypeAttachmentName,
-              this::getRelationshipTypeAttachmentName,
-              this::resetRelationshipTypeAttachmentName);
-        case "relationshipTypeProperty":
-          return MutableProperty.of(
-              this::setRelationshipTypeProperty,
-              this::setRelationshipTypeProperty,
-              this::getRelationshipTypeProperty,
-              this::resetRelationshipTypeProperty);
-        case "territoryEffects":
-          return MutableProperty.of(
-              this::setTerritoryEffects,
-              this::setTerritoryEffects,
-              this::getTerritoryEffects,
-              this::resetTerritoryEffects);
-        case "territoryEffectAttachmentName":
-          return MutableProperty.of(
-              this::setTerritoryEffectAttachmentName,
-              this::setTerritoryEffectAttachmentName,
-              this::getTerritoryEffectAttachmentName,
-              this::resetTerritoryEffectAttachmentName);
-        case "territoryEffectProperty":
-          return MutableProperty.of(
-              this::setTerritoryEffectProperty,
-              this::setTerritoryEffectProperty,
-              this::getTerritoryEffectProperty,
-              this::resetTerritoryEffectProperty);
-        default:
-          return getPropertyMapFunction().apply(propertyName);
-      }
-    };
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    switch (propertyName) {
+      case "frontier":
+        return MutableProperty.of(
+            this::setFrontier, this::setFrontier, this::getFrontier, this::resetFrontier);
+      case "productionRule":
+        return MutableProperty.of(
+            this::setProductionRule,
+            this::setProductionRule,
+            this::getProductionRule,
+            this::resetProductionRule);
+      case "tech":
+        return MutableProperty.of(this::setTech, this::setTech, this::getTech, this::resetTech);
+      case "availableTech":
+        return MutableProperty.of(
+            this::setAvailableTech,
+            this::setAvailableTech,
+            this::getAvailableTech,
+            this::resetAvailableTech);
+      case "placement":
+        return MutableProperty.of(
+            this::setPlacement, this::setPlacement, this::getPlacement, this::resetPlacement);
+      case "removeUnits":
+        return MutableProperty.of(
+            this::setRemoveUnits,
+            this::setRemoveUnits,
+            this::getRemoveUnits,
+            this::resetRemoveUnits);
+      case "purchase":
+        return MutableProperty.of(
+            this::setPurchase, this::setPurchase, this::getPurchase, this::resetPurchase);
+      case "resource":
+        return MutableProperty.ofString(this::setResource, this::getResource, this::resetResource);
+      case "resourceCount":
+        return MutableProperty.of(
+            this::setResourceCount,
+            this::setResourceCount,
+            this::getResourceCount,
+            this::resetResourceCount);
+      case "support":
+        return MutableProperty.of(
+            this::setSupport, this::setSupport, this::getSupport, this::resetSupport);
+      case "relationshipChange":
+        return MutableProperty.of(
+            this::setRelationshipChange,
+            this::setRelationshipChange,
+            this::getRelationshipChange,
+            this::resetRelationshipChange);
+      case "victory":
+        return MutableProperty.ofString(this::setVictory, this::getVictory, this::resetVictory);
+      case "activateTrigger":
+        return MutableProperty.of(
+            this::setActivateTrigger,
+            this::setActivateTrigger,
+            this::getActivateTrigger,
+            this::resetActivateTrigger);
+      case "changeOwnership":
+        return MutableProperty.of(
+            this::setChangeOwnership,
+            this::setChangeOwnership,
+            this::getChangeOwnership,
+            this::resetChangeOwnership);
+      case "unitType":
+        return MutableProperty.of(
+            this::setUnitType, this::setUnitType, this::getUnitType, this::resetUnitType);
+      case "unitAttachmentName":
+        return MutableProperty.of(
+            this::setUnitAttachmentName,
+            this::setUnitAttachmentName,
+            this::getUnitAttachmentName,
+            this::resetUnitAttachmentName);
+      case "unitProperty":
+        return MutableProperty.of(
+            this::setUnitProperty,
+            this::setUnitProperty,
+            this::getUnitProperty,
+            this::resetUnitProperty);
+      case "territories":
+        return MutableProperty.of(
+            this::setTerritories,
+            this::setTerritories,
+            this::getTerritories,
+            this::resetTerritories);
+      case "territoryAttachmentName":
+        return MutableProperty.of(
+            this::setTerritoryAttachmentName,
+            this::setTerritoryAttachmentName,
+            this::getTerritoryAttachmentName,
+            this::resetTerritoryAttachmentName);
+      case "territoryProperty":
+        return MutableProperty.of(
+            this::setTerritoryProperty,
+            this::setTerritoryProperty,
+            this::getTerritoryProperty,
+            this::resetTerritoryProperty);
+      case "players":
+        return MutableProperty.of(
+            this::setPlayers, this::setPlayers, this::getPlayers, this::resetPlayers);
+      case "playerAttachmentName":
+        return MutableProperty.of(
+            this::setPlayerAttachmentName,
+            this::setPlayerAttachmentName,
+            this::getPlayerAttachmentName,
+            this::resetPlayerAttachmentName);
+      case "playerProperty":
+        return MutableProperty.of(
+            this::setPlayerProperty,
+            this::setPlayerProperty,
+            this::getPlayerProperty,
+            this::resetPlayerProperty);
+      case "relationshipTypes":
+        return MutableProperty.of(
+            this::setRelationshipTypes,
+            this::setRelationshipTypes,
+            this::getRelationshipTypes,
+            this::resetRelationshipTypes);
+      case "relationshipTypeAttachmentName":
+        return MutableProperty.of(
+            this::setRelationshipTypeAttachmentName,
+            this::setRelationshipTypeAttachmentName,
+            this::getRelationshipTypeAttachmentName,
+            this::resetRelationshipTypeAttachmentName);
+      case "relationshipTypeProperty":
+        return MutableProperty.of(
+            this::setRelationshipTypeProperty,
+            this::setRelationshipTypeProperty,
+            this::getRelationshipTypeProperty,
+            this::resetRelationshipTypeProperty);
+      case "territoryEffects":
+        return MutableProperty.of(
+            this::setTerritoryEffects,
+            this::setTerritoryEffects,
+            this::getTerritoryEffects,
+            this::resetTerritoryEffects);
+      case "territoryEffectAttachmentName":
+        return MutableProperty.of(
+            this::setTerritoryEffectAttachmentName,
+            this::setTerritoryEffectAttachmentName,
+            this::getTerritoryEffectAttachmentName,
+            this::resetTerritoryEffectAttachmentName);
+      case "territoryEffectProperty":
+        return MutableProperty.of(
+            this::setTerritoryEffectProperty,
+            this::setTerritoryEffectProperty,
+            this::getTerritoryEffectProperty,
+            this::resetTerritoryEffectProperty);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2896,8 +2896,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
               this::setTerritoryEffectProperty,
               this::getTerritoryEffectProperty,
               this::resetTerritoryEffectProperty);
+        default:
+          return getPropertyMapFunction().apply(propertyName);
       }
-      return getPropertyMapFunction().apply(propertyName);
     };
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2714,7 +2714,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
             this::getTerritoryEffectProperty,
             this::resetTerritoryEffectProperty);
       default:
-        return null;
+        return super.getPropertyOrNull(propertyName);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3538,7 +3538,10 @@ public class UnitAttachment extends DefaultAttachment {
         .collect(Collectors.joining(" or "));
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.attachments;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.DefaultNamed;
@@ -3538,699 +3537,580 @@ public class UnitAttachment extends DefaultAttachment {
         .collect(Collectors.joining(" or "));
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  private Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            "isAir",
-            MutableProperty.of(this::setIsAir, this::setIsAir, this::getIsAir, this::resetIsAir))
-        .put(
-            IS_SEA,
-            MutableProperty.of(this::setIsSea, this::setIsSea, this::getIsSea, this::resetIsSea))
-        .put(
-            "movement",
-            MutableProperty.of(
-                this::setMovement, this::setMovement, this::getMovement, this::resetMovement))
-        .put(
-            "canBlitz",
-            MutableProperty.of(
-                this::setCanBlitz, this::setCanBlitz, this::getCanBlitz, this::resetCanBlitz))
-        .put(
-            "isKamikaze",
-            MutableProperty.of(
-                this::setIsKamikaze,
-                this::setIsKamikaze,
-                this::getIsKamikaze,
-                this::resetIsKamikaze))
-        .put(
-            "canInvadeOnlyFrom",
-            MutableProperty.of(
-                this::setCanInvadeOnlyFrom,
-                this::setCanInvadeOnlyFrom,
-                this::getCanInvadeOnlyFrom,
-                this::resetCanInvadeOnlyFrom))
-        .put(
-            "fuelCost",
-            MutableProperty.of(
-                this::setFuelCost, this::setFuelCost, this::getFuelCost, this::resetFuelCost))
-        .put(
-            "fuelFlatCost",
-            MutableProperty.of(
-                this::setFuelFlatCost,
-                this::setFuelFlatCost,
-                this::getFuelFlatCost,
-                this::resetFuelFlatCost))
-        .put(
-            "canNotMoveDuringCombatMove",
-            MutableProperty.of(
-                this::setCanNotMoveDuringCombatMove,
-                this::setCanNotMoveDuringCombatMove,
-                this::getCanNotMoveDuringCombatMove,
-                this::resetCanNotMoveDuringCombatMove))
-        .put(
-            "movementLimit",
-            MutableProperty.of(
-                this::setMovementLimit,
-                this::setMovementLimit,
-                this::getMovementLimit,
-                this::resetMovementLimit))
-        .put(
-            ATTACK_STRENGTH,
-            MutableProperty.of(
-                this::setAttack, this::setAttack, this::getAttack, this::resetAttack))
-        .put(
-            DEFENSE_STRENGTH,
-            MutableProperty.of(
-                this::setDefense, this::setDefense, this::getDefense, this::resetDefense))
-        .put(
-            "isInfrastructure",
-            MutableProperty.of(
-                this::setIsInfrastructure,
-                this::setIsInfrastructure,
-                this::getIsInfrastructure,
-                this::resetIsInfrastructure))
-        .put(
-            "canBombard",
-            MutableProperty.of(
-                this::setCanBombard,
-                this::setCanBombard,
-                this::getCanBombard,
-                this::resetCanBombard))
-        .put(
-            BOMBARD,
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt, this::setBombard, this::getBombard, () -> -1))
-        .put("isSub", MutableProperty.<Boolean>ofWriteOnly(this::setIsSub, this::setIsSub))
-        .put(
-            "canEvade",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool, this::setCanEvade, this::getCanEvade, () -> false))
-        .put(
-            "isFirstStrike",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool,
-                this::setIsFirstStrike,
-                this::getIsFirstStrike,
-                () -> false))
-        .put(
-            "canNotTarget",
-            MutableProperty.of(
-                this::setCanNotTarget,
-                this::setCanNotTarget,
-                this::getCanNotTarget,
-                this::resetCanNotTarget))
-        .put(
-            "canNotBeTargetedBy",
-            MutableProperty.of(
-                this::setCanNotBeTargetedBy,
-                this::setCanNotBeTargetedBy,
-                this::getCanNotBeTargetedBy,
-                this::resetCanNotBeTargetedBy))
-        .put(
-            "canMoveThroughEnemies",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool,
-                this::setCanMoveThroughEnemies,
-                this::getCanMoveThroughEnemies,
-                () -> false))
-        .put(
-            "canBeMovedThroughByEnemies",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool,
-                this::setCanBeMovedThroughByEnemies,
-                this::getCanBeMovedThroughByEnemies,
-                () -> false))
-        .put(
-            "isDestroyer",
-            MutableProperty.of(
-                this::setIsDestroyer,
-                this::setIsDestroyer,
-                this::getIsDestroyer,
-                this::resetIsDestroyer))
-        .put(
-            "artillery",
-            MutableProperty.of(
-                this::setArtillery, this::setArtillery, this::getArtillery, this::resetArtillery))
-        .put(
-            "artillerySupportable",
-            MutableProperty.of(
-                this::setArtillerySupportable,
-                this::setArtillerySupportable,
-                this::getArtillerySupportable,
-                this::resetArtillerySupportable))
-        .put(
-            "unitSupportCount",
-            MutableProperty.of(
-                this::setUnitSupportCount,
-                this::setUnitSupportCount,
-                this::getUnitSupportCount,
-                this::resetUnitSupportCount))
-        .put(
-            IS_MARINE,
-            MutableProperty.of(
-                this::setIsMarine, this::setIsMarine, this::getIsMarine, this::resetIsMarine))
-        .put(
-            "isSuicide",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool, this::setIsSuicide, this::getIsSuicide, () -> false))
-        .put(
-            "isSuicideOnAttack",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool,
-                this::setIsSuicideOnAttack,
-                this::getIsSuicideOnAttack,
-                () -> false))
-        .put(
-            "isSuicideOnDefense",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getBool,
-                this::setIsSuicideOnDefense,
-                this::getIsSuicideOnDefense,
-                () -> false))
-        .put(
-            "isSuicideOnHit",
-            MutableProperty.of(
-                this::setIsSuicideOnHit,
-                this::setIsSuicideOnHit,
-                this::getIsSuicideOnHit,
-                this::resetIsSuicideOnHit))
-        .put(
-            "attackingLimit",
-            MutableProperty.of(
-                this::setAttackingLimit,
-                this::setAttackingLimit,
-                this::getAttackingLimit,
-                this::resetAttackingLimit))
-        .put(
-            ATTACK_ROLL,
-            MutableProperty.of(
-                this::setAttackRolls,
-                this::setAttackRolls,
-                this::getAttackRolls,
-                this::resetAttackRolls))
-        .put(
-            DEFENSE_ROLL,
-            MutableProperty.of(
-                this::setDefenseRolls,
-                this::setDefenseRolls,
-                this::getDefenseRolls,
-                this::resetDefenseRolls))
-        .put(
-            CHOOSE_BEST_ROLL,
-            MutableProperty.of(
-                this::setChooseBestRoll,
-                this::setChooseBestRoll,
-                this::getChooseBestRoll,
-                this::resetChooseBestRoll))
-        .put(
-            "isCombatTransport",
-            MutableProperty.of(
-                this::setIsCombatTransport,
-                this::setIsCombatTransport,
-                this::getIsCombatTransport,
-                this::resetIsCombatTransport))
-        .put(
-            "transportCapacity",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt,
-                this::setTransportCapacity,
-                this::getTransportCapacity,
-                () -> -1))
-        .put(
-            "transportCost",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt,
-                this::setTransportCost,
-                this::getTransportCost,
-                () -> -1))
-        .put(
-            "carrierCapacity",
-            MutableProperty.of(
-                this::setCarrierCapacity,
-                this::setCarrierCapacity,
-                this::getCarrierCapacity,
-                this::resetCarrierCapacity))
-        .put(
-            "carrierCost",
-            MutableProperty.of(
-                this::setCarrierCost,
-                this::setCarrierCost,
-                this::getCarrierCost,
-                this::resetCarrierCost))
-        .put(
-            "isAirTransport",
-            MutableProperty.of(
-                this::setIsAirTransport,
-                this::setIsAirTransport,
-                this::getIsAirTransport,
-                this::resetIsAirTransport))
-        .put(
-            "isAirTransportable",
-            MutableProperty.of(
-                this::setIsAirTransportable,
-                this::setIsAirTransportable,
-                this::getIsAirTransportable,
-                this::resetIsAirTransportable))
-        .put(
-            "isLandTransport",
-            MutableProperty.of(
-                this::setIsLandTransport,
-                this::setIsLandTransport,
-                this::getIsLandTransport,
-                this::resetIsLandTransport))
-        .put(
-            "isLandTransportable",
-            MutableProperty.of(
-                this::setIsLandTransportable,
-                this::setIsLandTransportable,
-                this::getIsLandTransportable,
-                this::resetIsLandTransportable))
-        .put(
-            "isAAforCombatOnly",
-            MutableProperty.of(
-                this::setIsAaForCombatOnly,
-                this::setIsAaForCombatOnly,
-                this::getIsAaForCombatOnly,
-                this::resetIsAaForCombatOnly))
-        .put(
-            "isAAforBombingThisUnitOnly",
-            MutableProperty.of(
-                this::setIsAaForBombingThisUnitOnly,
-                this::setIsAaForBombingThisUnitOnly,
-                this::getIsAaForBombingThisUnitOnly,
-                this::resetIsAaForBombingThisUnitOnly))
-        .put(
-            "isAAforFlyOverOnly",
-            MutableProperty.of(
-                this::setIsAaForFlyOverOnly,
-                this::setIsAaForFlyOverOnly,
-                this::getIsAaForFlyOverOnly,
-                this::resetIsAaForFlyOverOnly))
-        .put(
-            "isRocket",
-            MutableProperty.of(
-                this::setIsRocket, this::setIsRocket, this::getIsRocket, this::resetIsRocket))
-        .put(
-            ATTACK_AA,
-            MutableProperty.of(
-                this::setAttackAa, this::setAttackAa, this::getAttackAa, this::resetAttackAa))
-        .put(
-            OFFENSIVE_ATTACK_AA,
-            MutableProperty.of(
-                this::setOffensiveAttackAa,
-                this::setOffensiveAttackAa,
-                this::getOffensiveAttackAa,
-                this::resetOffensiveAttackAa))
-        .put(
-            ATTACK_AA_MAX_DIE_SIDES,
-            MutableProperty.of(
-                this::setAttackAaMaxDieSides,
-                this::setAttackAaMaxDieSides,
-                this::getAttackAaMaxDieSides,
-                this::resetAttackAaMaxDieSides))
-        .put(
-            OFFENSIVE_ATTACK_AA_MAX_DIE_SIDES,
-            MutableProperty.of(
-                this::setOffensiveAttackAaMaxDieSides,
-                this::setOffensiveAttackAaMaxDieSides,
-                this::getOffensiveAttackAaMaxDieSides,
-                this::resetOffensiveAttackAaMaxDieSides))
-        .put(
-            MAX_AA_ATTACKS,
-            MutableProperty.of(
-                this::setMaxAaAttacks,
-                this::setMaxAaAttacks,
-                this::getMaxAaAttacks,
-                this::resetMaxAaAttacks))
-        .put(
-            "maxRoundsAA",
-            MutableProperty.of(
-                this::setMaxRoundsAa,
-                this::setMaxRoundsAa,
-                this::getMaxRoundsAa,
-                this::resetMaxRoundsAa))
-        .put(
-            "typeAA", MutableProperty.ofString(this::setTypeAa, this::getTypeAa, this::resetTypeAa))
-        .put(
-            "targetsAA",
-            MutableProperty.of(
-                this::setTargetsAa, this::setTargetsAa, this::getTargetsAa, this::resetTargetsAa))
-        .put(
-            MAY_OVERSTACK_AA,
-            MutableProperty.of(
-                this::setMayOverStackAa,
-                this::setMayOverStackAa,
-                this::getMayOverStackAa,
-                this::resetMayOverStackAa))
-        .put(
-            "damageableAA",
-            MutableProperty.of(
-                this::setDamageableAa,
-                this::setDamageableAa,
-                this::getDamageableAa,
-                this::resetDamageableAa))
-        .put(
-            "willNotFireIfPresent",
-            MutableProperty.of(
-                this::setWillNotFireIfPresent,
-                this::setWillNotFireIfPresent,
-                this::getWillNotFireIfPresent,
-                this::resetWillNotFireIfPresent))
-        .put(
-            "isStrategicBomber",
-            MutableProperty.of(
-                this::setIsStrategicBomber,
-                this::setIsStrategicBomber,
-                this::getIsStrategicBomber,
-                this::resetIsStrategicBomber))
-        .put(
-            "bombingMaxDieSides",
-            MutableProperty.of(
-                this::setBombingMaxDieSides,
-                this::setBombingMaxDieSides,
-                this::getBombingMaxDieSides,
-                this::resetBombingMaxDieSides))
-        .put(
-            "bombingBonus",
-            MutableProperty.of(
-                this::setBombingBonus,
-                this::setBombingBonus,
-                this::getBombingBonus,
-                this::resetBombingBonus))
-        .put(
-            "canIntercept",
-            MutableProperty.of(
-                this::setCanIntercept,
-                this::setCanIntercept,
-                this::getCanIntercept,
-                this::resetCanIntercept))
-        .put(
-            "requiresAirbaseToIntercept",
-            MutableProperty.of(
-                this::setRequiresAirBaseToIntercept,
-                this::setRequiresAirBaseToIntercept,
-                this::getRequiresAirBaseToIntercept,
-                this::resetRequiresAirBaseToIntercept))
-        .put(
-            "canEscort",
-            MutableProperty.of(
-                this::setCanEscort, this::setCanEscort, this::getCanEscort, this::resetCanEscort))
-        .put(
-            "canAirBattle",
-            MutableProperty.of(
-                this::setCanAirBattle,
-                this::setCanAirBattle,
-                this::getCanAirBattle,
-                this::resetCanAirBattle))
-        .put(
-            "airDefense",
-            MutableProperty.of(
-                this::setAirDefense,
-                this::setAirDefense,
-                this::getAirDefense,
-                this::resetAirDefense))
-        .put(
-            "airAttack",
-            MutableProperty.of(
-                this::setAirAttack, this::setAirAttack, this::getAirAttack, this::resetAirAttack))
-        .put(
-            "bombingTargets",
-            MutableProperty.of(
-                this::setBombingTargets,
-                this::setBombingTargets,
-                this::getBombingTargets,
-                this::resetBombingTargets))
-        .put(
-            "canProduceUnits",
-            MutableProperty.of(
-                this::setCanProduceUnits,
-                this::setCanProduceUnits,
-                this::getCanProduceUnits,
-                this::resetCanProduceUnits))
-        .put(
-            "canProduceXUnits",
-            MutableProperty.of(
-                this::setCanProduceXUnits,
-                this::setCanProduceXUnits,
-                this::getCanProduceXUnits,
-                this::resetCanProduceXUnits))
-        .put(
-            "createsUnitsList",
-            MutableProperty.of(
-                this::setCreatesUnitsList,
-                this::setCreatesUnitsList,
-                this::getCreatesUnitsList,
-                this::resetCreatesUnitsList))
-        .put(
-            "createsResourcesList",
-            MutableProperty.of(
-                this::setCreatesResourcesList,
-                this::setCreatesResourcesList,
-                this::getCreatesResourcesList,
-                this::resetCreatesResourcesList))
-        .put(
-            "hitPoints",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt, this::setHitPoints, this::getHitPoints, () -> 1))
-        .put(
-            "canBeDamaged",
-            MutableProperty.of(
-                this::setCanBeDamaged,
-                this::setCanBeDamaged,
-                this::getCanBeDamaged,
-                this::resetCanBeDamaged))
-        .put(
-            "maxDamage",
-            MutableProperty.of(
-                this::setMaxDamage, this::setMaxDamage, this::getMaxDamage, this::resetMaxDamage))
-        .put(
-            "maxOperationalDamage",
-            MutableProperty.of(
-                this::setMaxOperationalDamage,
-                this::setMaxOperationalDamage,
-                this::getMaxOperationalDamage,
-                this::resetMaxOperationalDamage))
-        .put(
-            "canDieFromReachingMaxDamage",
-            MutableProperty.of(
-                this::setCanDieFromReachingMaxDamage,
-                this::setCanDieFromReachingMaxDamage,
-                this::getCanDieFromReachingMaxDamage,
-                this::resetCanDieFromReachingMaxDamage))
-        .put(
-            "isConstruction",
-            MutableProperty.of(
-                this::setIsConstruction,
-                this::setIsConstruction,
-                this::getIsConstruction,
-                this::resetIsConstruction))
-        .put(
-            "constructionType",
-            MutableProperty.ofString(
-                this::setConstructionType, this::getConstructionType, this::resetConstructionType))
-        .put(
-            "constructionsPerTerrPerTypePerTurn",
-            MutableProperty.of(
-                this::setConstructionsPerTerrPerTypePerTurn,
-                this::setConstructionsPerTerrPerTypePerTurn,
-                this::getConstructionsPerTerrPerTypePerTurn,
-                this::resetConstructionsPerTerrPerTypePerTurn))
-        .put(
-            "maxConstructionsPerTypePerTerr",
-            MutableProperty.of(
-                this::setMaxConstructionsPerTypePerTerr,
-                this::setMaxConstructionsPerTypePerTerr,
-                this::getMaxConstructionsPerTypePerTerr,
-                this::resetMaxConstructionsPerTypePerTerr))
-        .put(
-            "canOnlyBePlacedInTerritoryValuedAtX",
-            MutableProperty.of(
-                this::setCanOnlyBePlacedInTerritoryValuedAtX,
-                this::setCanOnlyBePlacedInTerritoryValuedAtX,
-                this::getCanOnlyBePlacedInTerritoryValuedAtX,
-                this::resetCanOnlyBePlacedInTerritoryValuedAtX))
-        .put(
-            "requiresUnits",
-            MutableProperty.of(
-                this::setRequiresUnits,
-                this::setRequiresUnits,
-                this::getRequiresUnits,
-                this::resetRequiresUnits))
-        .put(
-            "consumesUnits",
-            MutableProperty.of(
-                this::setConsumesUnits,
-                this::setConsumesUnits,
-                this::getConsumesUnits,
-                this::resetConsumesUnits))
-        .put(
-            "requiresUnitsToMove",
-            MutableProperty.of(
-                this::setRequiresUnitsToMove,
-                this::setRequiresUnitsToMove,
-                this::getRequiresUnitsToMove,
-                this::resetRequiresUnitsToMove))
-        .put(
-            "unitPlacementRestrictions",
-            MutableProperty.of(
-                this::setUnitPlacementRestrictions,
-                this::setUnitPlacementRestrictions,
-                this::getUnitPlacementRestrictions,
-                this::resetUnitPlacementRestrictions))
-        .put(
-            "maxBuiltPerPlayer",
-            MutableProperty.of(
-                this::setMaxBuiltPerPlayer,
-                this::setMaxBuiltPerPlayer,
-                this::getMaxBuiltPerPlayer,
-                this::resetMaxBuiltPerPlayer))
-        .put(
-            "placementLimit",
-            MutableProperty.of(
-                this::setPlacementLimit,
-                this::setPlacementLimit,
-                this::getPlacementLimit,
-                this::resetPlacementLimit))
-        .put(
-            "canScramble",
-            MutableProperty.of(
-                this::setCanScramble,
-                this::setCanScramble,
-                this::getCanScramble,
-                this::resetCanScramble))
-        .put(
-            "isAirBase",
-            MutableProperty.of(
-                this::setIsAirBase, this::setIsAirBase, this::getIsAirBase, this::resetIsAirBase))
-        .put(
-            "maxScrambleDistance",
-            MutableProperty.of(
-                this::setMaxScrambleDistance,
-                this::setMaxScrambleDistance,
-                this::getMaxScrambleDistance,
-                this::resetMaxScrambleDistance))
-        .put(
-            "maxScrambleCount",
-            MutableProperty.of(
-                this::setMaxScrambleCount,
-                this::setMaxScrambleCount,
-                this::getMaxScrambleCount,
-                this::resetMaxScrambleCount))
-        .put(
-            "maxInterceptCount",
-            MutableProperty.of(
-                this::setMaxInterceptCount,
-                this::setMaxInterceptCount,
-                this::getMaxInterceptCount,
-                this::resetMaxInterceptCount))
-        .put(
-            "blockade",
-            MutableProperty.of(
-                this::setBlockade, this::setBlockade, this::getBlockade, this::resetBlockade))
-        .put(
-            "repairsUnits",
-            MutableProperty.of(
-                this::setRepairsUnits,
-                this::setRepairsUnits,
-                this::getRepairsUnits,
-                this::resetRepairsUnits))
-        .put(
-            "givesMovement",
-            MutableProperty.of(
-                this::setGivesMovement,
-                this::setGivesMovement,
-                this::getGivesMovement,
-                this::resetGivesMovement))
-        .put(
-            "destroyedWhenCapturedBy",
-            MutableProperty.of(
-                this::setDestroyedWhenCapturedBy,
-                this::setDestroyedWhenCapturedBy,
-                this::getDestroyedWhenCapturedBy,
-                this::resetDestroyedWhenCapturedBy))
-        .put(
-            "whenHitPointsDamagedChangesInto",
-            MutableProperty.of(
-                this::setWhenHitPointsDamagedChangesInto,
-                this::setWhenHitPointsDamagedChangesInto,
-                this::getWhenHitPointsDamagedChangesInto,
-                this::resetWhenHitPointsDamagedChangesInto))
-        .put(
-            "whenHitPointsRepairedChangesInto",
-            MutableProperty.of(
-                this::setWhenHitPointsRepairedChangesInto,
-                this::setWhenHitPointsRepairedChangesInto,
-                this::getWhenHitPointsRepairedChangesInto,
-                this::resetWhenHitPointsRepairedChangesInto))
-        .put(
-            "whenCapturedChangesInto",
-            MutableProperty.of(
-                this::setWhenCapturedChangesInto,
-                this::setWhenCapturedChangesInto,
-                this::getWhenCapturedChangesInto,
-                this::resetWhenCapturedChangesInto))
-        .put(
-            "whenCapturedSustainsDamage",
-            MutableProperty.ofMapper(
-                DefaultAttachment::getInt,
-                this::setWhenCapturedSustainsDamage,
-                this::getWhenCapturedSustainsDamage,
-                () -> 0))
-        .put(
-            "canBeCapturedOnEnteringBy",
-            MutableProperty.of(
-                this::setCanBeCapturedOnEnteringBy,
-                this::setCanBeCapturedOnEnteringBy,
-                this::getCanBeCapturedOnEnteringBy,
-                this::resetCanBeCapturedOnEnteringBy))
-        .put(
-            "canBeGivenByTerritoryTo",
-            MutableProperty.of(
-                this::setCanBeGivenByTerritoryTo,
-                this::setCanBeGivenByTerritoryTo,
-                this::getCanBeGivenByTerritoryTo,
-                this::resetCanBeGivenByTerritoryTo))
-        .put(
-            "whenCombatDamaged",
-            MutableProperty.of(
-                this::setWhenCombatDamaged,
-                this::setWhenCombatDamaged,
-                this::getWhenCombatDamaged,
-                this::resetWhenCombatDamaged))
-        .put(
-            "receivesAbilityWhenWith",
-            MutableProperty.of(
-                this::setReceivesAbilityWhenWith,
-                this::setReceivesAbilityWhenWith,
-                this::getReceivesAbilityWhenWith,
-                this::resetReceivesAbilityWhenWith))
-        .put(
-            "special",
-            MutableProperty.of(
-                this::setSpecial, this::setSpecial, this::getSpecial, this::resetSpecial))
-        .put("tuv", MutableProperty.of(this::setTuv, this::setTuv, this::getTuv, this::resetTuv))
-        .put(
-            "isFactory",
-            MutableProperty.<Boolean>ofWriteOnly(this::setIsFactory, this::setIsFactory))
-        .put("isAA", MutableProperty.<Boolean>ofWriteOnly(this::setIsAa, this::setIsAa))
-        .put(
-            "destroyedWhenCapturedFrom",
-            MutableProperty.ofWriteOnlyString(this::setDestroyedWhenCapturedFrom))
-        .put(
-            "unitPlacementOnlyAllowedIn",
-            MutableProperty.ofWriteOnlyString(this::setUnitPlacementOnlyAllowedIn))
-        .put(
-            "isAAmovement",
-            MutableProperty.<Boolean>ofWriteOnly(this::setIsAaMovement, this::setIsAaMovement))
-        .put("isTwoHit", MutableProperty.<Boolean>ofWriteOnly(this::setIsTwoHit, this::setIsTwoHit))
-        .put(
-            "canRetreatOnStalemate",
-            MutableProperty.of(
-                this::setCanRetreatOnStalemate, this::setCanRetreatOnStalemate,
-                this::getCanRetreatOnStalemate, this::resetCanRetreatOnStalemate))
-        .build();
+    switch (propertyName) {
+      case "isAir":
+        return MutableProperty.of(this::setIsAir, this::setIsAir, this::getIsAir, this::resetIsAir);
+      case IS_SEA:
+        return MutableProperty.of(this::setIsSea, this::setIsSea, this::getIsSea, this::resetIsSea);
+      case "movement":
+        return MutableProperty.of(
+            this::setMovement, this::setMovement, this::getMovement, this::resetMovement);
+      case "canBlitz":
+        return MutableProperty.of(
+            this::setCanBlitz, this::setCanBlitz, this::getCanBlitz, this::resetCanBlitz);
+      case "isKamikaze":
+        return MutableProperty.of(
+            this::setIsKamikaze, this::setIsKamikaze, this::getIsKamikaze, this::resetIsKamikaze);
+      case "canInvadeOnlyFrom":
+        return MutableProperty.of(
+            this::setCanInvadeOnlyFrom,
+            this::setCanInvadeOnlyFrom,
+            this::getCanInvadeOnlyFrom,
+            this::resetCanInvadeOnlyFrom);
+      case "fuelCost":
+        return MutableProperty.of(
+            this::setFuelCost, this::setFuelCost, this::getFuelCost, this::resetFuelCost);
+      case "fuelFlatCost":
+        return MutableProperty.of(
+            this::setFuelFlatCost,
+            this::setFuelFlatCost,
+            this::getFuelFlatCost,
+            this::resetFuelFlatCost);
+      case "canNotMoveDuringCombatMove":
+        return MutableProperty.of(
+            this::setCanNotMoveDuringCombatMove,
+            this::setCanNotMoveDuringCombatMove,
+            this::getCanNotMoveDuringCombatMove,
+            this::resetCanNotMoveDuringCombatMove);
+      case "movementLimit":
+        return MutableProperty.of(
+            this::setMovementLimit,
+            this::setMovementLimit,
+            this::getMovementLimit,
+            this::resetMovementLimit);
+      case ATTACK_STRENGTH:
+        return MutableProperty.of(
+            this::setAttack, this::setAttack, this::getAttack, this::resetAttack);
+      case DEFENSE_STRENGTH:
+        return MutableProperty.of(
+            this::setDefense, this::setDefense, this::getDefense, this::resetDefense);
+      case "isInfrastructure":
+        return MutableProperty.of(
+            this::setIsInfrastructure,
+            this::setIsInfrastructure,
+            this::getIsInfrastructure,
+            this::resetIsInfrastructure);
+      case "canBombard":
+        return MutableProperty.of(
+            this::setCanBombard, this::setCanBombard, this::getCanBombard, this::resetCanBombard);
+      case BOMBARD:
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt, this::setBombard, this::getBombard, () -> -1);
+      case "isSub":
+        return MutableProperty.<Boolean>ofWriteOnly(this::setIsSub, this::setIsSub);
+      case "canEvade":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool, this::setCanEvade, this::getCanEvade, () -> false);
+      case "isFirstStrike":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool,
+            this::setIsFirstStrike,
+            this::getIsFirstStrike,
+            () -> false);
+      case "canNotTarget":
+        return MutableProperty.of(
+            this::setCanNotTarget,
+            this::setCanNotTarget,
+            this::getCanNotTarget,
+            this::resetCanNotTarget);
+      case "canNotBeTargetedBy":
+        return MutableProperty.of(
+            this::setCanNotBeTargetedBy,
+            this::setCanNotBeTargetedBy,
+            this::getCanNotBeTargetedBy,
+            this::resetCanNotBeTargetedBy);
+      case "canMoveThroughEnemies":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool,
+            this::setCanMoveThroughEnemies,
+            this::getCanMoveThroughEnemies,
+            () -> false);
+      case "canBeMovedThroughByEnemies":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool,
+            this::setCanBeMovedThroughByEnemies,
+            this::getCanBeMovedThroughByEnemies,
+            () -> false);
+      case "isDestroyer":
+        return MutableProperty.of(
+            this::setIsDestroyer,
+            this::setIsDestroyer,
+            this::getIsDestroyer,
+            this::resetIsDestroyer);
+      case "artillery":
+        return MutableProperty.of(
+            this::setArtillery, this::setArtillery, this::getArtillery, this::resetArtillery);
+      case "artillerySupportable":
+        return MutableProperty.of(
+            this::setArtillerySupportable,
+            this::setArtillerySupportable,
+            this::getArtillerySupportable,
+            this::resetArtillerySupportable);
+      case "unitSupportCount":
+        return MutableProperty.of(
+            this::setUnitSupportCount,
+            this::setUnitSupportCount,
+            this::getUnitSupportCount,
+            this::resetUnitSupportCount);
+      case IS_MARINE:
+        return MutableProperty.of(
+            this::setIsMarine, this::setIsMarine, this::getIsMarine, this::resetIsMarine);
+      case "isSuicide":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool, this::setIsSuicide, this::getIsSuicide, () -> false);
+      case "isSuicideOnAttack":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool,
+            this::setIsSuicideOnAttack,
+            this::getIsSuicideOnAttack,
+            () -> false);
+      case "isSuicideOnDefense":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getBool,
+            this::setIsSuicideOnDefense,
+            this::getIsSuicideOnDefense,
+            () -> false);
+      case "isSuicideOnHit":
+        return MutableProperty.of(
+            this::setIsSuicideOnHit,
+            this::setIsSuicideOnHit,
+            this::getIsSuicideOnHit,
+            this::resetIsSuicideOnHit);
+      case "attackingLimit":
+        return MutableProperty.of(
+            this::setAttackingLimit,
+            this::setAttackingLimit,
+            this::getAttackingLimit,
+            this::resetAttackingLimit);
+      case ATTACK_ROLL:
+        return MutableProperty.of(
+            this::setAttackRolls,
+            this::setAttackRolls,
+            this::getAttackRolls,
+            this::resetAttackRolls);
+      case DEFENSE_ROLL:
+        return MutableProperty.of(
+            this::setDefenseRolls,
+            this::setDefenseRolls,
+            this::getDefenseRolls,
+            this::resetDefenseRolls);
+      case CHOOSE_BEST_ROLL:
+        return MutableProperty.of(
+            this::setChooseBestRoll,
+            this::setChooseBestRoll,
+            this::getChooseBestRoll,
+            this::resetChooseBestRoll);
+      case "isCombatTransport":
+        return MutableProperty.of(
+            this::setIsCombatTransport,
+            this::setIsCombatTransport,
+            this::getIsCombatTransport,
+            this::resetIsCombatTransport);
+      case "transportCapacity":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt,
+            this::setTransportCapacity,
+            this::getTransportCapacity,
+            () -> -1);
+      case "transportCost":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt, this::setTransportCost, this::getTransportCost, () -> -1);
+      case "carrierCapacity":
+        return MutableProperty.of(
+            this::setCarrierCapacity,
+            this::setCarrierCapacity,
+            this::getCarrierCapacity,
+            this::resetCarrierCapacity);
+      case "carrierCost":
+        return MutableProperty.of(
+            this::setCarrierCost,
+            this::setCarrierCost,
+            this::getCarrierCost,
+            this::resetCarrierCost);
+      case "isAirTransport":
+        return MutableProperty.of(
+            this::setIsAirTransport,
+            this::setIsAirTransport,
+            this::getIsAirTransport,
+            this::resetIsAirTransport);
+      case "isAirTransportable":
+        return MutableProperty.of(
+            this::setIsAirTransportable,
+            this::setIsAirTransportable,
+            this::getIsAirTransportable,
+            this::resetIsAirTransportable);
+      case "isLandTransport":
+        return MutableProperty.of(
+            this::setIsLandTransport,
+            this::setIsLandTransport,
+            this::getIsLandTransport,
+            this::resetIsLandTransport);
+      case "isLandTransportable":
+        return MutableProperty.of(
+            this::setIsLandTransportable,
+            this::setIsLandTransportable,
+            this::getIsLandTransportable,
+            this::resetIsLandTransportable);
+      case "isAAforCombatOnly":
+        return MutableProperty.of(
+            this::setIsAaForCombatOnly,
+            this::setIsAaForCombatOnly,
+            this::getIsAaForCombatOnly,
+            this::resetIsAaForCombatOnly);
+      case "isAAforBombingThisUnitOnly":
+        return MutableProperty.of(
+            this::setIsAaForBombingThisUnitOnly,
+            this::setIsAaForBombingThisUnitOnly,
+            this::getIsAaForBombingThisUnitOnly,
+            this::resetIsAaForBombingThisUnitOnly);
+      case "isAAforFlyOverOnly":
+        return MutableProperty.of(
+            this::setIsAaForFlyOverOnly,
+            this::setIsAaForFlyOverOnly,
+            this::getIsAaForFlyOverOnly,
+            this::resetIsAaForFlyOverOnly);
+      case "isRocket":
+        return MutableProperty.of(
+            this::setIsRocket, this::setIsRocket, this::getIsRocket, this::resetIsRocket);
+      case ATTACK_AA:
+        return MutableProperty.of(
+            this::setAttackAa, this::setAttackAa, this::getAttackAa, this::resetAttackAa);
+      case OFFENSIVE_ATTACK_AA:
+        return MutableProperty.of(
+            this::setOffensiveAttackAa,
+            this::setOffensiveAttackAa,
+            this::getOffensiveAttackAa,
+            this::resetOffensiveAttackAa);
+      case ATTACK_AA_MAX_DIE_SIDES:
+        return MutableProperty.of(
+            this::setAttackAaMaxDieSides,
+            this::setAttackAaMaxDieSides,
+            this::getAttackAaMaxDieSides,
+            this::resetAttackAaMaxDieSides);
+      case OFFENSIVE_ATTACK_AA_MAX_DIE_SIDES:
+        return MutableProperty.of(
+            this::setOffensiveAttackAaMaxDieSides,
+            this::setOffensiveAttackAaMaxDieSides,
+            this::getOffensiveAttackAaMaxDieSides,
+            this::resetOffensiveAttackAaMaxDieSides);
+      case MAX_AA_ATTACKS:
+        return MutableProperty.of(
+            this::setMaxAaAttacks,
+            this::setMaxAaAttacks,
+            this::getMaxAaAttacks,
+            this::resetMaxAaAttacks);
+      case "maxRoundsAA":
+        return MutableProperty.of(
+            this::setMaxRoundsAa,
+            this::setMaxRoundsAa,
+            this::getMaxRoundsAa,
+            this::resetMaxRoundsAa);
+      case "typeAA":
+        return MutableProperty.ofString(this::setTypeAa, this::getTypeAa, this::resetTypeAa);
+      case "targetsAA":
+        return MutableProperty.of(
+            this::setTargetsAa, this::setTargetsAa, this::getTargetsAa, this::resetTargetsAa);
+      case MAY_OVERSTACK_AA:
+        return MutableProperty.of(
+            this::setMayOverStackAa,
+            this::setMayOverStackAa,
+            this::getMayOverStackAa,
+            this::resetMayOverStackAa);
+      case "damageableAA":
+        return MutableProperty.of(
+            this::setDamageableAa,
+            this::setDamageableAa,
+            this::getDamageableAa,
+            this::resetDamageableAa);
+      case "willNotFireIfPresent":
+        return MutableProperty.of(
+            this::setWillNotFireIfPresent,
+            this::setWillNotFireIfPresent,
+            this::getWillNotFireIfPresent,
+            this::resetWillNotFireIfPresent);
+      case "isStrategicBomber":
+        return MutableProperty.of(
+            this::setIsStrategicBomber,
+            this::setIsStrategicBomber,
+            this::getIsStrategicBomber,
+            this::resetIsStrategicBomber);
+      case "bombingMaxDieSides":
+        return MutableProperty.of(
+            this::setBombingMaxDieSides,
+            this::setBombingMaxDieSides,
+            this::getBombingMaxDieSides,
+            this::resetBombingMaxDieSides);
+      case "bombingBonus":
+        return MutableProperty.of(
+            this::setBombingBonus,
+            this::setBombingBonus,
+            this::getBombingBonus,
+            this::resetBombingBonus);
+      case "canIntercept":
+        return MutableProperty.of(
+            this::setCanIntercept,
+            this::setCanIntercept,
+            this::getCanIntercept,
+            this::resetCanIntercept);
+      case "requiresAirbaseToIntercept":
+        return MutableProperty.of(
+            this::setRequiresAirBaseToIntercept,
+            this::setRequiresAirBaseToIntercept,
+            this::getRequiresAirBaseToIntercept,
+            this::resetRequiresAirBaseToIntercept);
+      case "canEscort":
+        return MutableProperty.of(
+            this::setCanEscort, this::setCanEscort, this::getCanEscort, this::resetCanEscort);
+      case "canAirBattle":
+        return MutableProperty.of(
+            this::setCanAirBattle,
+            this::setCanAirBattle,
+            this::getCanAirBattle,
+            this::resetCanAirBattle);
+      case "airDefense":
+        return MutableProperty.of(
+            this::setAirDefense, this::setAirDefense, this::getAirDefense, this::resetAirDefense);
+      case "airAttack":
+        return MutableProperty.of(
+            this::setAirAttack, this::setAirAttack, this::getAirAttack, this::resetAirAttack);
+      case "bombingTargets":
+        return MutableProperty.of(
+            this::setBombingTargets,
+            this::setBombingTargets,
+            this::getBombingTargets,
+            this::resetBombingTargets);
+      case "canProduceUnits":
+        return MutableProperty.of(
+            this::setCanProduceUnits,
+            this::setCanProduceUnits,
+            this::getCanProduceUnits,
+            this::resetCanProduceUnits);
+      case "canProduceXUnits":
+        return MutableProperty.of(
+            this::setCanProduceXUnits,
+            this::setCanProduceXUnits,
+            this::getCanProduceXUnits,
+            this::resetCanProduceXUnits);
+      case "createsUnitsList":
+        return MutableProperty.of(
+            this::setCreatesUnitsList,
+            this::setCreatesUnitsList,
+            this::getCreatesUnitsList,
+            this::resetCreatesUnitsList);
+      case "createsResourcesList":
+        return MutableProperty.of(
+            this::setCreatesResourcesList,
+            this::setCreatesResourcesList,
+            this::getCreatesResourcesList,
+            this::resetCreatesResourcesList);
+      case "hitPoints":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt, this::setHitPoints, this::getHitPoints, () -> 1);
+      case "canBeDamaged":
+        return MutableProperty.of(
+            this::setCanBeDamaged,
+            this::setCanBeDamaged,
+            this::getCanBeDamaged,
+            this::resetCanBeDamaged);
+      case "maxDamage":
+        return MutableProperty.of(
+            this::setMaxDamage, this::setMaxDamage, this::getMaxDamage, this::resetMaxDamage);
+      case "maxOperationalDamage":
+        return MutableProperty.of(
+            this::setMaxOperationalDamage,
+            this::setMaxOperationalDamage,
+            this::getMaxOperationalDamage,
+            this::resetMaxOperationalDamage);
+      case "canDieFromReachingMaxDamage":
+        return MutableProperty.of(
+            this::setCanDieFromReachingMaxDamage,
+            this::setCanDieFromReachingMaxDamage,
+            this::getCanDieFromReachingMaxDamage,
+            this::resetCanDieFromReachingMaxDamage);
+      case "isConstruction":
+        return MutableProperty.of(
+            this::setIsConstruction,
+            this::setIsConstruction,
+            this::getIsConstruction,
+            this::resetIsConstruction);
+      case "constructionType":
+        return MutableProperty.ofString(
+            this::setConstructionType, this::getConstructionType, this::resetConstructionType);
+      case "constructionsPerTerrPerTypePerTurn":
+        return MutableProperty.of(
+            this::setConstructionsPerTerrPerTypePerTurn,
+            this::setConstructionsPerTerrPerTypePerTurn,
+            this::getConstructionsPerTerrPerTypePerTurn,
+            this::resetConstructionsPerTerrPerTypePerTurn);
+      case "maxConstructionsPerTypePerTerr":
+        return MutableProperty.of(
+            this::setMaxConstructionsPerTypePerTerr,
+            this::setMaxConstructionsPerTypePerTerr,
+            this::getMaxConstructionsPerTypePerTerr,
+            this::resetMaxConstructionsPerTypePerTerr);
+      case "canOnlyBePlacedInTerritoryValuedAtX":
+        return MutableProperty.of(
+            this::setCanOnlyBePlacedInTerritoryValuedAtX,
+            this::setCanOnlyBePlacedInTerritoryValuedAtX,
+            this::getCanOnlyBePlacedInTerritoryValuedAtX,
+            this::resetCanOnlyBePlacedInTerritoryValuedAtX);
+      case "requiresUnits":
+        return MutableProperty.of(
+            this::setRequiresUnits,
+            this::setRequiresUnits,
+            this::getRequiresUnits,
+            this::resetRequiresUnits);
+      case "consumesUnits":
+        return MutableProperty.of(
+            this::setConsumesUnits,
+            this::setConsumesUnits,
+            this::getConsumesUnits,
+            this::resetConsumesUnits);
+      case "requiresUnitsToMove":
+        return MutableProperty.of(
+            this::setRequiresUnitsToMove,
+            this::setRequiresUnitsToMove,
+            this::getRequiresUnitsToMove,
+            this::resetRequiresUnitsToMove);
+      case "unitPlacementRestrictions":
+        return MutableProperty.of(
+            this::setUnitPlacementRestrictions,
+            this::setUnitPlacementRestrictions,
+            this::getUnitPlacementRestrictions,
+            this::resetUnitPlacementRestrictions);
+      case "maxBuiltPerPlayer":
+        return MutableProperty.of(
+            this::setMaxBuiltPerPlayer,
+            this::setMaxBuiltPerPlayer,
+            this::getMaxBuiltPerPlayer,
+            this::resetMaxBuiltPerPlayer);
+      case "placementLimit":
+        return MutableProperty.of(
+            this::setPlacementLimit,
+            this::setPlacementLimit,
+            this::getPlacementLimit,
+            this::resetPlacementLimit);
+      case "canScramble":
+        return MutableProperty.of(
+            this::setCanScramble,
+            this::setCanScramble,
+            this::getCanScramble,
+            this::resetCanScramble);
+      case "isAirBase":
+        return MutableProperty.of(
+            this::setIsAirBase, this::setIsAirBase, this::getIsAirBase, this::resetIsAirBase);
+      case "maxScrambleDistance":
+        return MutableProperty.of(
+            this::setMaxScrambleDistance,
+            this::setMaxScrambleDistance,
+            this::getMaxScrambleDistance,
+            this::resetMaxScrambleDistance);
+      case "maxScrambleCount":
+        return MutableProperty.of(
+            this::setMaxScrambleCount,
+            this::setMaxScrambleCount,
+            this::getMaxScrambleCount,
+            this::resetMaxScrambleCount);
+      case "maxInterceptCount":
+        return MutableProperty.of(
+            this::setMaxInterceptCount,
+            this::setMaxInterceptCount,
+            this::getMaxInterceptCount,
+            this::resetMaxInterceptCount);
+      case "blockade":
+        return MutableProperty.of(
+            this::setBlockade, this::setBlockade, this::getBlockade, this::resetBlockade);
+      case "repairsUnits":
+        return MutableProperty.of(
+            this::setRepairsUnits,
+            this::setRepairsUnits,
+            this::getRepairsUnits,
+            this::resetRepairsUnits);
+      case "givesMovement":
+        return MutableProperty.of(
+            this::setGivesMovement,
+            this::setGivesMovement,
+            this::getGivesMovement,
+            this::resetGivesMovement);
+      case "destroyedWhenCapturedBy":
+        return MutableProperty.of(
+            this::setDestroyedWhenCapturedBy,
+            this::setDestroyedWhenCapturedBy,
+            this::getDestroyedWhenCapturedBy,
+            this::resetDestroyedWhenCapturedBy);
+      case "whenHitPointsDamagedChangesInto":
+        return MutableProperty.of(
+            this::setWhenHitPointsDamagedChangesInto,
+            this::setWhenHitPointsDamagedChangesInto,
+            this::getWhenHitPointsDamagedChangesInto,
+            this::resetWhenHitPointsDamagedChangesInto);
+      case "whenHitPointsRepairedChangesInto":
+        return MutableProperty.of(
+            this::setWhenHitPointsRepairedChangesInto,
+            this::setWhenHitPointsRepairedChangesInto,
+            this::getWhenHitPointsRepairedChangesInto,
+            this::resetWhenHitPointsRepairedChangesInto);
+      case "whenCapturedChangesInto":
+        return MutableProperty.of(
+            this::setWhenCapturedChangesInto,
+            this::setWhenCapturedChangesInto,
+            this::getWhenCapturedChangesInto,
+            this::resetWhenCapturedChangesInto);
+      case "whenCapturedSustainsDamage":
+        return MutableProperty.ofMapper(
+            DefaultAttachment::getInt,
+            this::setWhenCapturedSustainsDamage,
+            this::getWhenCapturedSustainsDamage,
+            () -> 0);
+      case "canBeCapturedOnEnteringBy":
+        return MutableProperty.of(
+            this::setCanBeCapturedOnEnteringBy,
+            this::setCanBeCapturedOnEnteringBy,
+            this::getCanBeCapturedOnEnteringBy,
+            this::resetCanBeCapturedOnEnteringBy);
+      case "canBeGivenByTerritoryTo":
+        return MutableProperty.of(
+            this::setCanBeGivenByTerritoryTo,
+            this::setCanBeGivenByTerritoryTo,
+            this::getCanBeGivenByTerritoryTo,
+            this::resetCanBeGivenByTerritoryTo);
+      case "whenCombatDamaged":
+        return MutableProperty.of(
+            this::setWhenCombatDamaged,
+            this::setWhenCombatDamaged,
+            this::getWhenCombatDamaged,
+            this::resetWhenCombatDamaged);
+      case "receivesAbilityWhenWith":
+        return MutableProperty.of(
+            this::setReceivesAbilityWhenWith,
+            this::setReceivesAbilityWhenWith,
+            this::getReceivesAbilityWhenWith,
+            this::resetReceivesAbilityWhenWith);
+      case "special":
+        return MutableProperty.of(
+            this::setSpecial, this::setSpecial, this::getSpecial, this::resetSpecial);
+      case "tuv":
+        return MutableProperty.of(this::setTuv, this::setTuv, this::getTuv, this::resetTuv);
+      case "isFactory":
+        return MutableProperty.<Boolean>ofWriteOnly(this::setIsFactory, this::setIsFactory);
+      case "isAA":
+        return MutableProperty.<Boolean>ofWriteOnly(this::setIsAa, this::setIsAa);
+      case "destroyedWhenCapturedFrom":
+        return MutableProperty.ofWriteOnlyString(this::setDestroyedWhenCapturedFrom);
+      case "unitPlacementOnlyAllowedIn":
+        return MutableProperty.ofWriteOnlyString(this::setUnitPlacementOnlyAllowedIn);
+      case "isAAmovement":
+        return MutableProperty.<Boolean>ofWriteOnly(this::setIsAaMovement, this::setIsAaMovement);
+      case "isTwoHit":
+        return MutableProperty.<Boolean>ofWriteOnly(this::setIsTwoHit, this::setIsTwoHit);
+      case "canRetreatOnStalemate":
+        return MutableProperty.of(
+            this::setCanRetreatOnStalemate, this::setCanRetreatOnStalemate,
+            this::getCanRetreatOnStalemate, this::resetCanRetreatOnStalemate);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3542,7 +3542,7 @@ public class UnitAttachment extends DefaultAttachment {
     return getPropertyMap().get(propertyName);
   }
 
-  public Map<String, MutableProperty<?>> getPropertyMap() {
+  private Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(
             "isAir",

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -425,7 +425,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     return getPropertyMap().get(propertyName);
   }
 
-  public Map<String, MutableProperty<?>> getPropertyMap() {
+  private Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(
             UNIT_TYPE,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.attachments;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
@@ -17,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -421,51 +419,50 @@ public class UnitSupportAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  private Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put(
-            UNIT_TYPE,
-            MutableProperty.of(
-                this::setUnitType, this::setUnitType, this::getUnitType, this::resetUnitType))
-        .put("offence", MutableProperty.ofReadOnly(this::getOffence))
-        .put("defence", MutableProperty.ofReadOnly(this::getDefence))
-        .put("roll", MutableProperty.ofReadOnly(this::getRoll))
-        .put("strength", MutableProperty.ofReadOnly(this::getStrength))
-        .put("aaRoll", MutableProperty.ofReadOnly(this::getAaRoll))
-        .put("aaStrength", MutableProperty.ofReadOnly(this::getAaStrength))
-        .put(
-            BONUS,
-            MutableProperty.of(this::setBonus, this::setBonus, this::getBonus, this::resetBonus))
-        .put(
-            "number",
-            MutableProperty.of(
-                this::setNumber, this::setNumber, this::getNumber, this::resetNumber))
-        .put("allied", MutableProperty.ofReadOnly(this::getAllied))
-        .put("enemy", MutableProperty.ofReadOnly(this::getEnemy))
-        .put(
-            BONUS_TYPE,
-            MutableProperty.of(
-                this::setBonusType, this::setBonusType, this::getBonusType, this::resetBonusType))
-        .put(
-            "players",
-            MutableProperty.of(
-                this::setPlayers, this::setPlayers, this::getPlayers, this::resetPlayers))
-        .put(
-            "impArtTech",
-            MutableProperty.of(
-                this::setImpArtTech,
-                this::setImpArtTech,
-                this::getImpArtTech,
-                this::resetImpArtTech))
-        .put(DICE, MutableProperty.ofString(this::setDice, this::getDice, this::resetDice))
-        .put("side", MutableProperty.ofString(this::setSide, this::getSide, this::resetSide))
-        .put(
-            "faction",
-            MutableProperty.ofString(this::setFaction, this::getFaction, this::resetFaction))
-        .build();
+    switch (propertyName) {
+      case UNIT_TYPE:
+        return MutableProperty.of(
+            this::setUnitType, this::setUnitType, this::getUnitType, this::resetUnitType);
+      case "offence":
+        return MutableProperty.ofReadOnly(this::getOffence);
+      case "defence":
+        return MutableProperty.ofReadOnly(this::getDefence);
+      case "roll":
+        return MutableProperty.ofReadOnly(this::getRoll);
+      case "strength":
+        return MutableProperty.ofReadOnly(this::getStrength);
+      case "aaRoll":
+        return MutableProperty.ofReadOnly(this::getAaRoll);
+      case "aaStrength":
+        return MutableProperty.ofReadOnly(this::getAaStrength);
+      case BONUS:
+        return MutableProperty.of(this::setBonus, this::setBonus, this::getBonus, this::resetBonus);
+      case "number":
+        return MutableProperty.of(
+            this::setNumber, this::setNumber, this::getNumber, this::resetNumber);
+      case "allied":
+        return MutableProperty.ofReadOnly(this::getAllied);
+      case "enemy":
+        return MutableProperty.ofReadOnly(this::getEnemy);
+      case BONUS_TYPE:
+        return MutableProperty.of(
+            this::setBonusType, this::setBonusType, this::getBonusType, this::resetBonusType);
+      case "players":
+        return MutableProperty.of(
+            this::setPlayers, this::setPlayers, this::getPlayers, this::resetPlayers);
+      case "impArtTech":
+        return MutableProperty.of(
+            this::setImpArtTech, this::setImpArtTech, this::getImpArtTech, this::resetImpArtTech);
+      case DICE:
+        return MutableProperty.ofString(this::setDice, this::getDice, this::resetDice);
+      case "side":
+        return MutableProperty.ofString(this::setSide, this::getSide, this::resetSide);
+      case "faction":
+        return MutableProperty.ofString(this::setFaction, this::getFaction, this::resetFaction);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -421,7 +421,10 @@ public class UnitSupportAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -172,7 +172,10 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
         Matches.abstractUserActionAttachmentCanBeAttempted(testedConditions));
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.attachments;
 
-import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -173,19 +172,15 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   }
 
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .putAll(super.getPropertyMap())
-        .put(
-            "activateTrigger",
-            MutableProperty.of(
-                this::setActivateTrigger,
-                this::setActivateTrigger,
-                this::getActivateTrigger,
-                this::resetActivateTrigger))
-        .build();
+    switch (propertyName) {
+      case "activateTrigger":
+        return MutableProperty.of(
+            this::setActivateTrigger,
+            this::setActivateTrigger,
+            this::getActivateTrigger,
+            this::resetActivateTrigger);
+      default:
+        return getPropertyMap().get(propertyName);
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -171,6 +171,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
         Matches.abstractUserActionAttachmentCanBeAttempted(testedConditions));
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "activateTrigger":
@@ -180,7 +181,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
             this::getActivateTrigger,
             this::resetActivateTrigger);
       default:
-        return getPropertyMap().get(propertyName);
+        return super.getPropertyOrNull(propertyName);
     }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,9 +43,8 @@ final class DefaultAttachmentTest {
       @Override
       public void validate(final GameState data) {}
 
-      @Override
-      public Map<String, MutableProperty<?>> getPropertyMap() {
-        return Map.of();
+      public MutableProperty<?> getPropertyOrNull(String propertyName) {
+        return null;
       }
 
       @Override

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
@@ -43,6 +43,7 @@ final class DefaultAttachmentTest {
       @Override
       public void validate(final GameState data) {}
 
+      @Override
       public MutableProperty<?> getPropertyOrNull(String propertyName) {
         return null;
       }

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -3,9 +3,7 @@ package games.strategy.engine.data;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Runnables;
-import java.util.Map;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
@@ -66,12 +64,11 @@ public final class FakeAttachment implements IAttachment {
   }
 
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put("name", MutableProperty.ofString(this::setName, this::getName, Runnables.doNothing()))
-        .build();
+    switch (propertyName) {
+      case "name":
+        return MutableProperty.ofString(this::setName, this::getName, Runnables.doNothing());
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -63,6 +63,7 @@ public final class FakeAttachment implements IAttachment {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "name":

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -65,7 +65,10 @@ public final class FakeAttachment implements IAttachment {
     throw new UnsupportedOperationException();
   }
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("name", MutableProperty.ofString(this::setName, this::getName, Runnables.doNothing()))

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
@@ -41,6 +41,7 @@ public class TestAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
+  @Override
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "value":

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
@@ -1,8 +1,5 @@
 package games.strategy.engine.data;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-
 /** Fake attachment used for testing. */
 public class TestAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 4886924951201479496L;
@@ -45,12 +42,11 @@ public class TestAttachment extends DefaultAttachment {
   public void validate(final GameState data) {}
 
   public MutableProperty<?> getPropertyOrNull(String propertyName) {
-    return getPropertyMap().get(propertyName);
-  }
-
-  public Map<String, MutableProperty<?>> getPropertyMap() {
-    return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put("value", MutableProperty.ofString(this::setValue, this::getValue, this::resetValue))
-        .build();
+    switch (propertyName) {
+      case "value":
+        return MutableProperty.ofString(this::setValue, this::getValue, this::resetValue);
+      default:
+        return null;
+    }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
@@ -44,7 +44,10 @@ public class TestAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) {}
 
-  @Override
+  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+    return getPropertyMap().get(propertyName);
+  }
+
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("value", MutableProperty.ofString(this::setValue, this::getValue, this::resetValue))

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -571,8 +571,8 @@ class TriggerAttachmentTest {
 
       gameData.getResourceList().addResource(new Resource(Constants.PUS, gameData));
 
-      triggerAttachment.setPropertyOrThrow("resource").setValue(Constants.PUS);
-      triggerAttachment.setPropertyOrThrow("resourceCount").setValue("23");
+      triggerAttachment.setPropertyOrThrow("resource", Constants.PUS);
+      triggerAttachment.setPropertyOrThrow("resourceCount", "23");
 
       TriggerAttachment.triggerResourceChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(1)).addChange(not(argThat(Change::isEmpty)));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -128,7 +128,7 @@ class TriggerAttachmentTest {
       final NotificationMessages notificationMessages = mock(NotificationMessages.class);
       when(notificationMessages.getMessage(notificationMessageKey)).thenReturn(notificationMessage);
 
-      triggerAttachment.getPropertyOrThrow("notification").setValue(notificationMessageKey);
+      triggerAttachment.setPropertyOrThrow("notification", notificationMessageKey);
 
       TriggerAttachment.triggerNotifications(
           satisfiedTriggers, bridge, defaultFireTriggerParams, notificationMessages);
@@ -187,14 +187,12 @@ class TriggerAttachmentTest {
       gamePlayer.addAttachment("rulesAttachment", new RulesAttachment(null, null, gameData));
       gameData.getPlayerList().addPlayerId(gamePlayer);
 
-      triggerAttachment
-          .getPropertyOrThrow("playerAttachmentName")
-          .setValue("rulesAttachment:RulesAttachment");
+      triggerAttachment.setPropertyOrThrow(
+          "playerAttachmentName", "rulesAttachment:RulesAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment
-          .getPropertyOrThrow("playerProperty")
-          .setValue("someNewValue:productionPerXTerritories");
-      triggerAttachment.getPropertyOrThrow("players").setValue("somePlayer");
+      triggerAttachment.setPropertyOrThrow(
+          "playerProperty", "someNewValue:productionPerXTerritories");
+      triggerAttachment.setPropertyOrThrow("players", "somePlayer");
 
       TriggerAttachment.triggerPlayerPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -214,14 +212,13 @@ class TriggerAttachmentTest {
           "relationshipTypeAttachment", new RelationshipTypeAttachment(null, null, gameData));
       gameData.getRelationshipTypeList().addRelationshipType(relationshipType);
 
-      triggerAttachment
-          .getPropertyOrThrow("relationshipTypeAttachmentName")
-          .setValue("relationshipTypeAttachment:RelationshipTypeAttachment");
+      triggerAttachment.setPropertyOrThrow(
+          "relationshipTypeAttachmentName",
+          "relationshipTypeAttachment:RelationshipTypeAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment
-          .getPropertyOrThrow("relationshipTypeProperty")
-          .setValue("true:canMoveLandUnitsOverOwnedLand");
-      triggerAttachment.getPropertyOrThrow("relationshipTypes").setValue("someRelationshipType");
+      triggerAttachment.setPropertyOrThrow(
+          "relationshipTypeProperty", "true:canMoveLandUnitsOverOwnedLand");
+      triggerAttachment.setPropertyOrThrow("relationshipTypes", "someRelationshipType");
 
       TriggerAttachment.triggerRelationshipTypePropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -240,12 +237,11 @@ class TriggerAttachmentTest {
       territory.addAttachment("territoryAttachment", new TerritoryAttachment(null, null, gameData));
       gameData.getMap().addTerritory(territory);
 
-      triggerAttachment
-          .getPropertyOrThrow("territoryAttachmentName")
-          .setValue("territoryAttachment:TerritoryAttachment");
+      triggerAttachment.setPropertyOrThrow(
+          "territoryAttachmentName", "territoryAttachment:TerritoryAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment.getPropertyOrThrow("territoryProperty").setValue("true:kamikazeZone");
-      triggerAttachment.getPropertyOrThrow("territories").setValue(territoryName);
+      triggerAttachment.setPropertyOrThrow("territoryProperty", "true:kamikazeZone");
+      triggerAttachment.setPropertyOrThrow("territories", territoryName);
 
       TriggerAttachment.triggerTerritoryPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -265,14 +261,12 @@ class TriggerAttachmentTest {
           "territoryEffectAttachment", new TerritoryEffectAttachment(null, null, gameData));
       gameData.getTerritoryEffectList().put(territoryEffectName, territoryEffect);
 
-      triggerAttachment
-          .getPropertyOrThrow("territoryEffectAttachmentName")
-          .setValue("territoryEffectAttachment:TerritoryEffectAttachment");
+      triggerAttachment.setPropertyOrThrow(
+          "territoryEffectAttachmentName", "territoryEffectAttachment:TerritoryEffectAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment
-          .getPropertyOrThrow("territoryEffectProperty")
-          .setValue("conscript:veteran:champion:unitsNotAllowed");
-      triggerAttachment.getPropertyOrThrow("territoryEffects").setValue("someTerritoryEffect");
+      triggerAttachment.setPropertyOrThrow(
+          "territoryEffectProperty", "conscript:veteran:champion:unitsNotAllowed");
+      triggerAttachment.setPropertyOrThrow("territoryEffects", "someTerritoryEffect");
 
       TriggerAttachment.triggerTerritoryEffectPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -290,12 +284,10 @@ class TriggerAttachmentTest {
       gameData.getUnitTypeList().addUnitType(unitType);
       unitType.addAttachment("unitAttachment", new UnitAttachment(null, null, gameData));
 
-      triggerAttachment
-          .getPropertyOrThrow("unitAttachmentName")
-          .setValue("unitAttachment:UnitAttachment");
+      triggerAttachment.setPropertyOrThrow("unitAttachmentName", "unitAttachment:UnitAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment.getPropertyOrThrow("unitProperty").setValue("4:movement");
-      triggerAttachment.getPropertyOrThrow("unitType").setValue("someUnit");
+      triggerAttachment.setPropertyOrThrow("unitProperty", "4:movement");
+      triggerAttachment.setPropertyOrThrow("unitType", "someUnit");
 
       TriggerAttachment.triggerUnitPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -329,9 +321,7 @@ class TriggerAttachmentTest {
       final BattleTracker battleTracker = mock(BattleTracker.class);
       when(battleDelegate.getBattleTracker()).thenReturn(battleTracker);
 
-      triggerAttachment
-          .getPropertyOrThrow("relationshipChange")
-          .setValue("Keoland:Furyondy:any:allied");
+      triggerAttachment.setPropertyOrThrow("relationshipChange", "Keoland:Furyondy:any:allied");
 
       TriggerAttachment.triggerRelationshipChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -359,9 +349,8 @@ class TriggerAttachmentTest {
       gameTechnologyFrontier.addAdvance(
           TechAdvance.findDefinedAdvanceAndCreateAdvance("heavyBomber", gameData));
 
-      triggerAttachment
-          .getPropertyOrThrow("availableTech")
-          .setValue("airCategory:longRangeAir:jetPower:heavyBomber");
+      triggerAttachment.setPropertyOrThrow(
+          "availableTech", "airCategory:longRangeAir:jetPower:heavyBomber");
 
       TriggerAttachment.triggerAvailableTechChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -386,7 +375,7 @@ class TriggerAttachmentTest {
       gameTechnologyFrontier.addAdvance(
           TechAdvance.findDefinedAdvanceAndCreateAdvance("heavyBomber", gameData));
 
-      triggerAttachment.getPropertyOrThrow("tech").setValue("longRangeAir:heavyBomber");
+      triggerAttachment.setPropertyOrThrow("tech", "longRangeAir:heavyBomber");
 
       TriggerAttachment.triggerTechChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(2)).addChange(not(argThat(Change::isEmpty)));
@@ -410,9 +399,7 @@ class TriggerAttachmentTest {
           new TriggerAttachment("triggerAttachment", gamePlayer, gameData);
       final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
-      triggerAttachment
-          .getPropertyOrThrow("frontier")
-          .setValue("Americans_Super_Carrier_production");
+      triggerAttachment.setPropertyOrThrow("frontier", "Americans_Super_Carrier_production");
 
       TriggerAttachment.triggerProductionChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -435,9 +422,7 @@ class TriggerAttachmentTest {
           new TriggerAttachment("triggerAttachment", gamePlayer, gameData);
       final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
-      triggerAttachment
-          .getPropertyOrThrow("support")
-          .setValue("supportAttachmentBattlefleet_Support");
+      triggerAttachment.setPropertyOrThrow("support", "supportAttachmentBattlefleet_Support");
 
       TriggerAttachment.triggerSupportChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
@@ -586,8 +571,8 @@ class TriggerAttachmentTest {
 
       gameData.getResourceList().addResource(new Resource(Constants.PUS, gameData));
 
-      triggerAttachment.getPropertyOrThrow("resource").setValue(Constants.PUS);
-      triggerAttachment.getPropertyOrThrow("resourceCount").setValue("23");
+      triggerAttachment.setPropertyOrThrow("resource").setValue(Constants.PUS);
+      triggerAttachment.setPropertyOrThrow("resourceCount").setValue("23");
 
       TriggerAttachment.triggerResourceChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(1)).addChange(not(argThat(Change::isEmpty)));
@@ -618,20 +603,17 @@ class TriggerAttachmentTest {
         gameTechnologyFrontier.addAdvance(
             TechAdvance.findDefinedAdvanceAndCreateAdvance("heavyBomber", gameData));
 
-        triggerToBeFiredTriggerAttachment
-            .getPropertyOrThrow("tech")
-            .setValue("longRangeAir:heavyBomber");
+        triggerToBeFiredTriggerAttachment.setPropertyOrThrow("tech", "longRangeAir:heavyBomber");
       }
 
       final TriggerAttachment activateTriggerTriggerAttachment =
           new TriggerAttachment("activateTrigger", null, gameData);
       final Set<TriggerAttachment> satisfiedTriggers = Set.of(activateTriggerTriggerAttachment);
 
-      activateTriggerTriggerAttachment
-          .getPropertyOrThrow("activateTrigger")
-          .setValue(
-              String.format(
-                  "%s:1:false:false:false:false", triggerToBeFiredTriggerAttachment.getName()));
+      activateTriggerTriggerAttachment.setPropertyOrThrow(
+          "activateTrigger",
+          String.format(
+              "%s:1:false:false:false:false", triggerToBeFiredTriggerAttachment.getName()));
 
       TriggerAttachment.triggerActivateTriggerOther(
           Map.of(), satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -650,7 +632,7 @@ class TriggerAttachmentTest {
       final String notificationMessageKey = "IndomitableCenterVictory";
       final String notificationMessage =
           "<body><h2>Victory!<br>The Indomitable Center Has Conquered!</h2>...</body>";
-      triggerAttachment.getPropertyOrThrow("victory").setValue(notificationMessageKey);
+      triggerAttachment.setPropertyOrThrow("victory", notificationMessageKey);
 
       final EndRoundDelegate endRoundDelegate = mock(EndRoundDelegate.class);
       when(endRoundDelegate.getName()).thenReturn("endRound");

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -128,7 +128,7 @@ class TriggerAttachmentTest {
       final NotificationMessages notificationMessages = mock(NotificationMessages.class);
       when(notificationMessages.getMessage(notificationMessageKey)).thenReturn(notificationMessage);
 
-      triggerAttachment.setPropertyOrThrow("notification", notificationMessageKey);
+      setPropertyOrThrow(triggerAttachment, "notification", notificationMessageKey);
 
       TriggerAttachment.triggerNotifications(
           satisfiedTriggers, bridge, defaultFireTriggerParams, notificationMessages);
@@ -187,12 +187,12 @@ class TriggerAttachmentTest {
       gamePlayer.addAttachment("rulesAttachment", new RulesAttachment(null, null, gameData));
       gameData.getPlayerList().addPlayerId(gamePlayer);
 
-      triggerAttachment.setPropertyOrThrow(
-          "playerAttachmentName", "rulesAttachment:RulesAttachment");
+      setPropertyOrThrow(
+          triggerAttachment, "playerAttachmentName", "rulesAttachment:RulesAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment.setPropertyOrThrow(
-          "playerProperty", "someNewValue:productionPerXTerritories");
-      triggerAttachment.setPropertyOrThrow("players", "somePlayer");
+      setPropertyOrThrow(
+          triggerAttachment, "playerProperty", "someNewValue:productionPerXTerritories");
+      setPropertyOrThrow(triggerAttachment, "players", "somePlayer");
 
       TriggerAttachment.triggerPlayerPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -212,13 +212,14 @@ class TriggerAttachmentTest {
           "relationshipTypeAttachment", new RelationshipTypeAttachment(null, null, gameData));
       gameData.getRelationshipTypeList().addRelationshipType(relationshipType);
 
-      triggerAttachment.setPropertyOrThrow(
+      setPropertyOrThrow(
+          triggerAttachment,
           "relationshipTypeAttachmentName",
           "relationshipTypeAttachment:RelationshipTypeAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment.setPropertyOrThrow(
-          "relationshipTypeProperty", "true:canMoveLandUnitsOverOwnedLand");
-      triggerAttachment.setPropertyOrThrow("relationshipTypes", "someRelationshipType");
+      setPropertyOrThrow(
+          triggerAttachment, "relationshipTypeProperty", "true:canMoveLandUnitsOverOwnedLand");
+      setPropertyOrThrow(triggerAttachment, "relationshipTypes", "someRelationshipType");
 
       TriggerAttachment.triggerRelationshipTypePropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -237,11 +238,11 @@ class TriggerAttachmentTest {
       territory.addAttachment("territoryAttachment", new TerritoryAttachment(null, null, gameData));
       gameData.getMap().addTerritory(territory);
 
-      triggerAttachment.setPropertyOrThrow(
-          "territoryAttachmentName", "territoryAttachment:TerritoryAttachment");
+      setPropertyOrThrow(
+          triggerAttachment, "territoryAttachmentName", "territoryAttachment:TerritoryAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment.setPropertyOrThrow("territoryProperty", "true:kamikazeZone");
-      triggerAttachment.setPropertyOrThrow("territories", territoryName);
+      setPropertyOrThrow(triggerAttachment, "territoryProperty", "true:kamikazeZone");
+      setPropertyOrThrow(triggerAttachment, "territories", territoryName);
 
       TriggerAttachment.triggerTerritoryPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -261,12 +262,16 @@ class TriggerAttachmentTest {
           "territoryEffectAttachment", new TerritoryEffectAttachment(null, null, gameData));
       gameData.getTerritoryEffectList().put(territoryEffectName, territoryEffect);
 
-      triggerAttachment.setPropertyOrThrow(
-          "territoryEffectAttachmentName", "territoryEffectAttachment:TerritoryEffectAttachment");
+      setPropertyOrThrow(
+          triggerAttachment,
+          "territoryEffectAttachmentName",
+          "territoryEffectAttachment:TerritoryEffectAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment.setPropertyOrThrow(
-          "territoryEffectProperty", "conscript:veteran:champion:unitsNotAllowed");
-      triggerAttachment.setPropertyOrThrow("territoryEffects", "someTerritoryEffect");
+      setPropertyOrThrow(
+          triggerAttachment,
+          "territoryEffectProperty",
+          "conscript:veteran:champion:unitsNotAllowed");
+      setPropertyOrThrow(triggerAttachment, "territoryEffects", "someTerritoryEffect");
 
       TriggerAttachment.triggerTerritoryEffectPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -284,10 +289,10 @@ class TriggerAttachmentTest {
       gameData.getUnitTypeList().addUnitType(unitType);
       unitType.addAttachment("unitAttachment", new UnitAttachment(null, null, gameData));
 
-      triggerAttachment.setPropertyOrThrow("unitAttachmentName", "unitAttachment:UnitAttachment");
+      setPropertyOrThrow(triggerAttachment, "unitAttachmentName", "unitAttachment:UnitAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      triggerAttachment.setPropertyOrThrow("unitProperty", "4:movement");
-      triggerAttachment.setPropertyOrThrow("unitType", "someUnit");
+      setPropertyOrThrow(triggerAttachment, "unitProperty", "4:movement");
+      setPropertyOrThrow(triggerAttachment, "unitType", "someUnit");
 
       TriggerAttachment.triggerUnitPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -321,7 +326,7 @@ class TriggerAttachmentTest {
       final BattleTracker battleTracker = mock(BattleTracker.class);
       when(battleDelegate.getBattleTracker()).thenReturn(battleTracker);
 
-      triggerAttachment.setPropertyOrThrow("relationshipChange", "Keoland:Furyondy:any:allied");
+      setPropertyOrThrow(triggerAttachment, "relationshipChange", "Keoland:Furyondy:any:allied");
 
       TriggerAttachment.triggerRelationshipChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -349,8 +354,8 @@ class TriggerAttachmentTest {
       gameTechnologyFrontier.addAdvance(
           TechAdvance.findDefinedAdvanceAndCreateAdvance("heavyBomber", gameData));
 
-      triggerAttachment.setPropertyOrThrow(
-          "availableTech", "airCategory:longRangeAir:jetPower:heavyBomber");
+      setPropertyOrThrow(
+          triggerAttachment, "availableTech", "airCategory:longRangeAir:jetPower:heavyBomber");
 
       TriggerAttachment.triggerAvailableTechChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -375,7 +380,7 @@ class TriggerAttachmentTest {
       gameTechnologyFrontier.addAdvance(
           TechAdvance.findDefinedAdvanceAndCreateAdvance("heavyBomber", gameData));
 
-      triggerAttachment.setPropertyOrThrow("tech", "longRangeAir:heavyBomber");
+      setPropertyOrThrow(triggerAttachment, "tech", "longRangeAir:heavyBomber");
 
       TriggerAttachment.triggerTechChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(2)).addChange(not(argThat(Change::isEmpty)));
@@ -399,7 +404,7 @@ class TriggerAttachmentTest {
           new TriggerAttachment("triggerAttachment", gamePlayer, gameData);
       final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
-      triggerAttachment.setPropertyOrThrow("frontier", "Americans_Super_Carrier_production");
+      setPropertyOrThrow(triggerAttachment, "frontier", "Americans_Super_Carrier_production");
 
       TriggerAttachment.triggerProductionChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -422,7 +427,7 @@ class TriggerAttachmentTest {
           new TriggerAttachment("triggerAttachment", gamePlayer, gameData);
       final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
-      triggerAttachment.setPropertyOrThrow("support", "supportAttachmentBattlefleet_Support");
+      setPropertyOrThrow(triggerAttachment, "support", "supportAttachmentBattlefleet_Support");
 
       TriggerAttachment.triggerSupportChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
@@ -571,8 +576,8 @@ class TriggerAttachmentTest {
 
       gameData.getResourceList().addResource(new Resource(Constants.PUS, gameData));
 
-      triggerAttachment.setPropertyOrThrow("resource", Constants.PUS);
-      triggerAttachment.setPropertyOrThrow("resourceCount", "23");
+      setPropertyOrThrow(triggerAttachment, "resource", Constants.PUS);
+      setPropertyOrThrow(triggerAttachment, "resourceCount", "23");
 
       TriggerAttachment.triggerResourceChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(1)).addChange(not(argThat(Change::isEmpty)));
@@ -603,14 +608,15 @@ class TriggerAttachmentTest {
         gameTechnologyFrontier.addAdvance(
             TechAdvance.findDefinedAdvanceAndCreateAdvance("heavyBomber", gameData));
 
-        triggerToBeFiredTriggerAttachment.setPropertyOrThrow("tech", "longRangeAir:heavyBomber");
+        setPropertyOrThrow(triggerToBeFiredTriggerAttachment, "tech", "longRangeAir:heavyBomber");
       }
 
       final TriggerAttachment activateTriggerTriggerAttachment =
           new TriggerAttachment("activateTrigger", null, gameData);
       final Set<TriggerAttachment> satisfiedTriggers = Set.of(activateTriggerTriggerAttachment);
 
-      activateTriggerTriggerAttachment.setPropertyOrThrow(
+      setPropertyOrThrow(
+          activateTriggerTriggerAttachment,
           "activateTrigger",
           String.format(
               "%s:1:false:false:false:false", triggerToBeFiredTriggerAttachment.getName()));
@@ -632,7 +638,7 @@ class TriggerAttachmentTest {
       final String notificationMessageKey = "IndomitableCenterVictory";
       final String notificationMessage =
           "<body><h2>Victory!<br>The Indomitable Center Has Conquered!</h2>...</body>";
-      triggerAttachment.setPropertyOrThrow("victory", notificationMessageKey);
+      setPropertyOrThrow(triggerAttachment, "victory", notificationMessageKey);
 
       final EndRoundDelegate endRoundDelegate = mock(EndRoundDelegate.class);
       when(endRoundDelegate.getName()).thenReturn("endRound");
@@ -764,5 +770,10 @@ class TriggerAttachmentTest {
 
       assertFalse(r.isPresent());
     }
+  }
+
+  void setPropertyOrThrow(TriggerAttachment attachment, String name, String value)
+      throws MutableProperty.InvalidValueException {
+    attachment.getPropertyOrThrow(name).setValue(value);
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -157,8 +157,8 @@ class TriggerAttachmentTest {
       productionFrontierList.addProductionFrontier(
           new ProductionFrontier("frontier", gameData, List.of(productionRule2)));
 
-      final Map<String, MutableProperty<?>> propertyMap = triggerAttachment.getPropertyMap();
-      final MutableProperty<?> productionRuleProperty = propertyMap.get("productionRule");
+      final MutableProperty<?> productionRuleProperty =
+          triggerAttachment.getPropertyOrThrow("productionRule");
       productionRuleProperty.setValue("frontier:rule1");
       productionRuleProperty.setValue("frontier:-rule2");
       productionRuleProperty.setValue("frontier:rule3");
@@ -187,11 +187,14 @@ class TriggerAttachmentTest {
       gamePlayer.addAttachment("rulesAttachment", new RulesAttachment(null, null, gameData));
       gameData.getPlayerList().addPlayerId(gamePlayer);
 
-      final Map<String, MutableProperty<?>> propertyMap = triggerAttachment.getPropertyMap();
-      propertyMap.get("playerAttachmentName").setValue("rulesAttachment:RulesAttachment");
+      triggerAttachment
+          .getPropertyOrThrow("playerAttachmentName")
+          .setValue("rulesAttachment:RulesAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      propertyMap.get("playerProperty").setValue("someNewValue:productionPerXTerritories");
-      propertyMap.get("players").setValue("somePlayer");
+      triggerAttachment
+          .getPropertyOrThrow("playerProperty")
+          .setValue("someNewValue:productionPerXTerritories");
+      triggerAttachment.getPropertyOrThrow("players").setValue("somePlayer");
 
       TriggerAttachment.triggerPlayerPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -211,13 +214,14 @@ class TriggerAttachmentTest {
           "relationshipTypeAttachment", new RelationshipTypeAttachment(null, null, gameData));
       gameData.getRelationshipTypeList().addRelationshipType(relationshipType);
 
-      final Map<String, MutableProperty<?>> propertyMap = triggerAttachment.getPropertyMap();
-      propertyMap
-          .get("relationshipTypeAttachmentName")
+      triggerAttachment
+          .getPropertyOrThrow("relationshipTypeAttachmentName")
           .setValue("relationshipTypeAttachment:RelationshipTypeAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      propertyMap.get("relationshipTypeProperty").setValue("true:canMoveLandUnitsOverOwnedLand");
-      propertyMap.get("relationshipTypes").setValue("someRelationshipType");
+      triggerAttachment
+          .getPropertyOrThrow("relationshipTypeProperty")
+          .setValue("true:canMoveLandUnitsOverOwnedLand");
+      triggerAttachment.getPropertyOrThrow("relationshipTypes").setValue("someRelationshipType");
 
       TriggerAttachment.triggerRelationshipTypePropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -236,13 +240,12 @@ class TriggerAttachmentTest {
       territory.addAttachment("territoryAttachment", new TerritoryAttachment(null, null, gameData));
       gameData.getMap().addTerritory(territory);
 
-      final Map<String, MutableProperty<?>> propertyMap = triggerAttachment.getPropertyMap();
-      propertyMap
-          .get("territoryAttachmentName")
+      triggerAttachment
+          .getPropertyOrThrow("territoryAttachmentName")
           .setValue("territoryAttachment:TerritoryAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      propertyMap.get("territoryProperty").setValue("true:kamikazeZone");
-      propertyMap.get("territories").setValue(territoryName);
+      triggerAttachment.getPropertyOrThrow("territoryProperty").setValue("true:kamikazeZone");
+      triggerAttachment.getPropertyOrThrow("territories").setValue(territoryName);
 
       TriggerAttachment.triggerTerritoryPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -262,15 +265,14 @@ class TriggerAttachmentTest {
           "territoryEffectAttachment", new TerritoryEffectAttachment(null, null, gameData));
       gameData.getTerritoryEffectList().put(territoryEffectName, territoryEffect);
 
-      final Map<String, MutableProperty<?>> propertyMap = triggerAttachment.getPropertyMap();
-      propertyMap
-          .get("territoryEffectAttachmentName")
+      triggerAttachment
+          .getPropertyOrThrow("territoryEffectAttachmentName")
           .setValue("territoryEffectAttachment:TerritoryEffectAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      propertyMap
-          .get("territoryEffectProperty")
+      triggerAttachment
+          .getPropertyOrThrow("territoryEffectProperty")
           .setValue("conscript:veteran:champion:unitsNotAllowed");
-      propertyMap.get("territoryEffects").setValue("someTerritoryEffect");
+      triggerAttachment.getPropertyOrThrow("territoryEffects").setValue("someTerritoryEffect");
 
       TriggerAttachment.triggerTerritoryEffectPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);
@@ -288,11 +290,12 @@ class TriggerAttachmentTest {
       gameData.getUnitTypeList().addUnitType(unitType);
       unitType.addAttachment("unitAttachment", new UnitAttachment(null, null, gameData));
 
-      final Map<String, MutableProperty<?>> propertyMap = triggerAttachment.getPropertyMap();
-      propertyMap.get("unitAttachmentName").setValue("unitAttachment:UnitAttachment");
+      triggerAttachment
+          .getPropertyOrThrow("unitAttachmentName")
+          .setValue("unitAttachment:UnitAttachment");
       // NOTE: The 'count' part is prepended in the game parser.
-      propertyMap.get("unitProperty").setValue("4:movement");
-      propertyMap.get("unitType").setValue("someUnit");
+      triggerAttachment.getPropertyOrThrow("unitProperty").setValue("4:movement");
+      triggerAttachment.getPropertyOrThrow("unitType").setValue("someUnit");
 
       TriggerAttachment.triggerUnitPropertyChange(
           satisfiedTriggers, bridge, defaultFireTriggerParams);


### PR DESCRIPTION
## Change Summary & Additional Notes
Avoid needing to create temporary immutable maps via getPropertyMap(), which shows up in profiles when loading maps.

The idea is we should remove all implementations of `getPropertyMap()`, instead having attachment classes implement `getPropertyOrNull()`, which doesn't require creating massive temporary maps. As a result, callers won't pay the cost of constructing these maps. Instead, they query the property they need which uses a switch statement instead of a map to look up properties, which is probably OK.

The idea is we could get rid of this cost during map parsing (e.g. 0.5s in this case on Imperialism 1974):
<img width="966" alt="Screen Shot 2022-06-26 at 4 30 18 PM" src="https://user-images.githubusercontent.com/17648/175832713-fbbb33d6-ee1e-4b7a-87bf-87f041f81c42.png">

With this change, the profile looks as follows:
<img width="974" alt="Screen Shot 2022-06-26 at 4 24 54 PM" src="https://user-images.githubusercontent.com/17648/175832634-19481069-2440-4e41-81dc-b2f5387afec9.png">

Note the time used by `getPropertyMap()` goes away.

Additionally, the new version is a reduction in LOC.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
