### PR TITLE
Run prod deployments in dry-mode

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -48,9 +48,8 @@ jobs:
           pip install ansible==2.9.13
           cd infrastructure
           echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
-          # TODO: deploy to production temporarily disabled, need to be sure this is 'safe'
-          # and won't disconnect users or otherwise cause problems
-          echo "Deploy to production temporarily disabled"
-          echo ./run_ansible --environment production
+          # TODO: temporily running prod deployment in dry run mode until we can avoid
+          # players being disconnected (need to avoid restarts)
+          ./run_ansible --dry-run --environment production
         env:
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}


### PR DESCRIPTION
Rather than skipping the prod deployment step, we can run it in dry-run mode.
Dry-run mode only reports changes it would make but makes no actual changes.
This will help us line up the prod server config while we work to eventually
having the 'dry-run' flag removed

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
