### PR TITLE
Fix 'run_ansible': define variable and print ansible-playbook command

### DIFF
--- a/infrastructure/run_ansible
+++ b/infrastructure/run_ansible
@@ -3,6 +3,7 @@
 set -eu
 
 scriptDir="$(dirname "$0")"
+rootDir="$scriptDir/.."
 readonly ENVIRONMENT_VAGRANT=vagrant
 readonly ENVIRONMENT_PRODUCTION=production
 
@@ -91,6 +92,7 @@ fi
 # an ansible vault passphrase value to decrypt secrets.
 VAULT_PASSWORD_FILE_ARG=""
 if [ "$ENVIRONMENT" == "$ENVIRONMENT_PRODUCTION" ]; then
+  VAULT_PASSWORD_FILE="$rootDir/infrastructure/vault_password"
   if [ ! -f "$VAULT_PASSWORD_FILE" ]; then
     echo "Deployments to production environment requires vault password file: $VAULT_PASSWORD_FILE"
     exit 1
@@ -111,16 +113,17 @@ if [ "$ENVIRONMENT" == "$ENVIRONMENT_PRODUCTION" ]; then
 fi
 
 # Parse version number from product.properties, eg: "version = 2.5.234" -> "2.5.234"
-VERSION=$(sed 's/.*=\s*//' "$(find .. -path "*/src/main/*" -name "product.properties")")
+VERSION=$(sed 's/.*=\s*//' "$(find "$rootDir" -path "*/src/main/*" -name "product.properties")")
 "$scriptDir/.include/build_latest_artifacts" "$VERSION"
 export ANSIBLE_CFG="$scriptDir/ansible.cfg"
 
 # Run deployment
+set -x
 ansible-playbook \
   --extra-vars "build_version=$VERSION" \
    --inventory "$scriptDir/ansible/inventory/$ENVIRONMENT" $DRY_RUN_ARG \
    $VAULT_PASSWORD_FILE_ARG $TAGS_ARG $DIFF_ARG $VERBOSE_ARG "$scriptDir/ansible/site.yml"
-
+set +x
 # Do Cleanup
 if [ "$ENVIRONMENT" != "$ENVIRONMENT_VAGRANT" ]; then
   echo "Cleanup, removing old kernel patches.."


### PR DESCRIPTION
A variable was needed for the vault password file location and was
erronously removed previously. This update restores the variable.

We also fix some relative paths in 'run_ansible', instead of assuming
a current directory, we explicitly use a '$rootDir'

Last, use 'set -x' to print the ansible-playbook command.
Given that 'run_ansible' is just a wrapper around the ansible-playbook
command, it is particularly useful to see the ansible-playbook command
in its full as its being run.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
