### PR TITLE
ProAI: Improve territoryHasLocalNavalSuperiority().

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -1485,7 +1485,8 @@ class ProPurchaseAi {
         }
       }
       final boolean hasLocalNavalSuperiority =
-          ProBattleUtils.territoryHasLocalNavalSuperiority(proData, t, player, Map.of(), List.of());
+          ProBattleUtils.territoryHasLocalNavalSuperiority(
+              proData, calc, t, player, Map.of(), List.of());
       if (!hasLocalNavalSuperiority) {
         needDefenders = 1;
       }
@@ -1834,7 +1835,7 @@ class ProPurchaseAi {
 
           // If I have naval attack/defense superiority then break
           if (ProBattleUtils.territoryHasLocalNavalSuperiority(
-              proData, t, player, purchaseTerritories, unitsToPlace)) {
+              proData, calc, t, player, purchaseTerritories, unitsToPlace)) {
             break;
           }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -388,7 +388,9 @@ public final class ProBattleUtils {
             + myUnits.size()
             + ", hasSuperiority="
             + hasSuperiority);
-    if (!hasSuperiority) return false;
+    if (!hasSuperiority) {
+      return false;
+    }
 
     // Find current naval attack strength
     double attackStrengthDifference =
@@ -408,7 +410,9 @@ public final class ProBattleUtils {
             + enemyUnitsInSeaTerritories.size()
             + ", hasSuperiority="
             + hasSuperiority);
-    if (!hasSuperiority) return false;
+    if (!hasSuperiority) {
+      return false;
+    }
 
     if (strongestEnemyDefenseFleet != null) {
       // To really have naval attack superiority, ensure there's also a positive attack TUV against


### PR DESCRIPTION
## Change Summary & Additional Notes
In addition to estimating strength differences, check that we also have a positive TUV to attack the strongest defensive enemy flee that's nearby.
This prevents a situation where the AI does not expand its fleet yet does not attack due to its fleet not being strong enough.

An example of this is on the save here on: https://github.com/triplea-game/triplea/issues/10785, where this situation causes a stalemate. With this fix, I confirmed that the above game gets out of the stalemate with the expected result of the AI with more production eventually winning.

It also gets out of the stalemate if I save the above game at turn 50, winning in less than 10 turns: 
[autosave_round_odd_new100-50.tsvg.zip](https://github.com/triplea-game/triplea/files/8997593/autosave_round_odd_new100-50.tsvg.zip)


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
