### PR TITLE
Fix .github workflow do-release script

### DIFF
--- a/.build/build-installer
+++ b/.build/build-installer
@@ -6,6 +6,7 @@
 
 ## install install4j
 set -x
+scriptDir=$(dirname "$0")
 
 function main() {
   install_install4j
@@ -29,6 +30,8 @@ function install_install4j() {
 
 ## Runs gradle command that creates the installer executables, uses intall4j
 function build_installers() {
+  ## Set the build number in 'product.properties' before we build the game-headed release
+  $scriptDir/set-game-headed-build-number
   JAVA_OPTS=-Xmx4G ./gradlew \
       --no-daemon \
       --parallel \

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -16,20 +16,20 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}
-      - name: set build version variables
-        run: |
-          BUILD_NUMBER=$(.build/set-game-headed-build-number)
-          echo "product_version=$BUILD_NUMBER" | tee -a $GITHUB_ENV
-          echo "release_name=$(date +%Y-%B-%d) - $BUILD_NUMBER" | tee -a $GITHUB_ENV
       - name: Build Installers
         run: .build/build-installer
         env:
           INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
+      - name: set build version variables
+        run: |
+          BUILD_VERSION=$(.build/get-build-version)
+          echo "build_version=$BUILD_VERSION" | tee -a $GITHUB_ENV
+          echo "release_name=$(date +%Y-%B-%d) - $BUILD_VERSION" | tee -a $GITHUB_ENV
       - name: Create Github Release
         uses: ncipollo/release-action@v1
         with:        
           artifacts: build/artifacts/*
-          tag: ${{ env.product_version }} 
+          tag: ${{ env.build_version }}
           name: ${{ env.release_name }}
           prerelease: true
           commit: ${{ github.sha }}


### PR DESCRIPTION
BUILD_NUMBER variable was empty and this caused problems later
when we had an empty 'tag' name for the github release action.
Previously the 'set-build-number' script returned the version
number. That behavior was updated and hence it is now empty.

To correct this, we make use of the new scripts that can return
the build number (which do so in an idempotent and deterministic
way, without mutating other files as a side-effect).

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
