### PR TITLE
Relax assertion to check for abs difference < 2.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -239,12 +239,6 @@ public final class UnitChooser extends JPanel {
                       unit.getOwner() != null,
                       "Contract problem: All units in UnitChooser are expected to have an owner,"
                           + " but now one appeared to have none.");
-
-                  Postconditions.assertState(
-                      unit.getOwner().getData() != null,
-                      "All units owners are expected to relate to a gameData object,"
-                          + " but now one appeared to have none.");
-
                   return Properties.getPartialAmphibiousRetreat(
                           unit.getOwner().getData().getProperties())
                       && unit.getWasAmphibious();
@@ -521,10 +515,6 @@ public final class UnitChooser extends JPanel {
       hitTexts.get(0).setValue(hitTexts.get(0).getMax());
     }
 
-    void selectNone() {
-      hitTexts.get(0).setValue(0);
-    }
-
     void setLeftToSelect(final int leftToSelect) {
       this.leftToSelect = leftToSelect < 0 ? category.getUnits().size() : leftToSelect;
       updateLeftToSelect();
@@ -687,7 +677,7 @@ public final class UnitChooser extends JPanel {
 
       final Graphics2D g2d = unitImageWithNonWithdrawableImage.createGraphics();
 
-      drawNonWithrawableImage(g2d);
+      drawNonWithdrawableImage(g2d);
       g2d.drawImage(undecoratedImage, 0, 0, null);
 
       g2d.dispose();
@@ -729,7 +719,7 @@ public final class UnitChooser extends JPanel {
       // The relation is controlled by getNonWithdrawableImageHeight. By the time of writing
       // this, getNonWithdrawableImageHeight makes the non-withdrawable image half as high as
       // the unit images.
-      // At the time of writing this, there are two variants of the non-whithdrawable image
+      // At the time of writing this, there are two variants of the non-withdrawable image
       // being 24 pixels resp. 32 pixels high.
       // So the unit image will be either 48 pixels or 32 pixels high.
 
@@ -737,7 +727,7 @@ public final class UnitChooser extends JPanel {
 
       double expectedHeight =
           getNonWithdrawableImageHeight(unitImageFactoryForDecoratedImages.getUnitImageHeight());
-      if (nonWithdrawableImage.getHeight() != expectedHeight) {
+      if (Math.abs(nonWithdrawableImage.getHeight() - expectedHeight) >= 2) {
         // Don't use Postconditions.assertState() as that turns a UI glitch into a game hang.
         log.warn(
             "Unexpected nonWithdrawableImage height {} != {}",
@@ -767,7 +757,7 @@ public final class UnitChooser extends JPanel {
       }
     }
 
-    private void drawNonWithrawableImage(final Graphics2D g2d) {
+    private void drawNonWithdrawableImage(final Graphics2D g2d) {
       g2d.drawImage(
           getNonWithdrawableImage(),
           getXofNonWithdrawableImage(),


### PR DESCRIPTION
## Change Summary & Additional Notes
This is a follow up to https://github.com/triplea-game/triplea/issues/10713 to prevent a warning from being displayed to the user.

Also, some other clean ups:
  - Fix some typos
  - Remove an impossible assert (players always have non-null data)
  - Remove an unused method

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
