### PR TITLE
Add prefs for two combat warnings.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -269,14 +269,11 @@ class AaInMoveUtil implements Serializable {
       }
     } else {
       // Since we are not firing on the last step, check the start as well, to prevent the user from
-      // moving to and from
-      // AA sites one at a time
+      // moving to and from AA sites one at a time
       // if there was a battle fought there then don't fire, this covers the case where we fight,
-      // and "Always On AA"
-      // wants to fire after the battle.
+      // and "Always On AA" wants to fire after the battle.
       // TODO: there is a bug in which if you move an air unit to a battle site in the middle of non
-      // combat, it wont
-      // fire
+      // combat, it wont fire
       if (route.getStart().anyUnitsMatch(hasAa)
           && !getBattleTracker().wasBattleFought(route.getStart())) {
         territoriesWhereAaWillFire.add(route.getStart());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -77,6 +77,10 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new IntegerClientSetting("FASTER_ARROW_KEY_SCROLL_MULTIPLIER", 2);
   public static final ClientSetting<Boolean> spaceBarConfirmsCasualties =
       new BooleanClientSetting("SPACE_BAR_CONFIRMS_CASUALTIES", true);
+  public static final ClientSetting<Boolean> showAaFlyoverWarning =
+      new BooleanClientSetting("SHOW_AA_FLYOVER_WARNING", true);
+  public static final ClientSetting<Boolean> showPotentialScrambleWarning =
+      new BooleanClientSetting("SHOW_POTENTIAL_SCRAMBLE_WARNING", true);
 
   /** URI of the lobby, can be toggled in settings to switch to a different lobby. */
   public static final ClientSetting<URI> lobbyUri =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -258,7 +258,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       SettingType.TESTING,
       "Toggles whether to use the new serialization mechanisms. This mechanism is still "
           + "under development and potentially may break saved games and network games.\n"
-          + " All players in the same game must have it set to the same value."
+          + "All players in the same game must have it set to the same value. "
           + "Restart to fully activate") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -115,13 +115,33 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
   },
 
   SPACE_BAR_CONFIRMS_CASUALTIES_BINDING(
-      "Space bar confirms Casualties",
+      "Space bar confirms casualties",
       SettingType.COMBAT,
       "When set to true casualty confirmation can be accepted by pressing space bar.\n"
           + "When set to false, the confirm casualty button has to always be clicked.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
       return booleanRadioButtons(ClientSetting.spaceBarConfirmsCasualties);
+    }
+  },
+
+  SHOW_AA_FLYOVER_WARNING(
+      "AA flyover warning",
+      SettingType.COMBAT,
+      "Warn about AA firing when moving over territories with AA defense") {
+    @Override
+    public SelectionComponent<JComponent> newSelectionComponent() {
+      return booleanRadioButtons(ClientSetting.showAaFlyoverWarning);
+    }
+  },
+
+  SHOW_POTENTIAL_SCRAMBLE_WARNING(
+      "Scramble warning",
+      SettingType.COMBAT,
+      "Warn about potential scrambling planes when you attack a territory") {
+    @Override
+    public SelectionComponent<JComponent> newSelectionComponent() {
+      return booleanRadioButtons(ClientSetting.showPotentialScrambleWarning);
     }
   },
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -846,10 +846,10 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
         ConfirmDialogType.YES_NO);
   }
 
-  public boolean getOk(final String message) {
+  public boolean getOk(final Object message, final String title) {
     messageAndDialogThreadPool.waitForAll();
     return EventThreadJOptionPane.showConfirmDialog(
-        this, message, message, ConfirmDialogType.OK_CANCEL);
+        this, message, title, ConfirmDialogType.OK_CANCEL);
   }
 
   /** Displays a message to the user informing them of the results of rolling for technologies. */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -56,6 +56,8 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import javax.swing.BorderFactory;
+import javax.swing.JCheckBox;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -561,7 +563,8 @@ public class MovePanel extends AbstractMovePanel {
         }
 
         private boolean confirmEndPoint(final Territory territory) {
-          if (!ClientSetting.showBetaFeatures.getValueOrThrow() || !willStartBattle(territory)) {
+          if (!ClientSetting.showPotentialScrambleWarning.getValueOrThrow()
+              || !willStartBattle(territory)) {
             return true;
           }
           if (!Properties.getScrambleRulesInEffect(getData().getProperties())) {
@@ -600,13 +603,20 @@ public class MovePanel extends AbstractMovePanel {
           // multiple units present. Without it, an extra row is added based on a too narrow
           // width initially.
           panel.setSize(new Dimension(400, 100));
+          JCheckBox dontWarnAgain = new JCheckBox("Don't show this warning again");
+          dontWarnAgain.setBorder(BorderFactory.createEmptyBorder(20, 0, 0, 0));
+          JPanel outer =
+              new JPanelBuilder().borderLayout().addCenter(panel).addSouth(dontWarnAgain).build();
           final int option =
               JOptionPane.showConfirmDialog(
                   JOptionPane.getFrameForComponent(MovePanel.this),
-                  panel,
+                  outer,
                   "Scramble Warning",
                   JOptionPane.OK_CANCEL_OPTION,
                   JOptionPane.WARNING_MESSAGE);
+          if (dontWarnAgain.isSelected()) {
+            ClientSetting.showPotentialScrambleWarning.setValue(false);
+          }
           return option == JOptionPane.OK_OPTION;
         }
       };

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -48,6 +48,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
 import javax.swing.ButtonModel;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -55,6 +58,7 @@ import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.java.concurrency.AsyncRunner;
 import org.triplea.sound.SoundPath;
+import org.triplea.swing.jpanel.JPanelBuilder;
 import org.triplea.util.Tuple;
 
 /**
@@ -706,18 +710,32 @@ public class TripleAPlayer extends AbstractBasePlayer {
 
   @Override
   public boolean confirmMoveInFaceOfAa(final Collection<Territory> aaFiringTerritories) {
-    final String question =
+    if (!ClientSetting.showAaFlyoverWarning.getValueOrThrow()) {
+      return true;
+    }
+    String question =
         "Your units will be fired on in: "
             + MyFormatter.defaultNamedToTextList(aaFiringTerritories)
             + ".  Do you still want to move?";
-    return ui.getOk(question);
+    JCheckBox dontWarnAgain = new JCheckBox("Don't show this warning again");
+    JPanel panel =
+        new JPanelBuilder()
+            .borderLayout()
+            .addCenter(new JLabel(question))
+            .addSouth(dontWarnAgain)
+            .build();
+    boolean result = ui.getOk(panel, question);
+    if (dontWarnAgain.isSelected()) {
+      ClientSetting.showAaFlyoverWarning.setValue(false);
+    }
+    return result;
   }
 
   @Override
   public boolean confirmMoveKamikaze() {
     final String question =
         "Not all air units in destination territory can land, do you still want to move?";
-    return ui.getOk(question);
+    return ui.getOk(question, question);
   }
 
   @Override


### PR DESCRIPTION
## Change Summary & Additional Notes

The following two similar warnings are given their own prefs:
  1. Warning about flying over an enemy territory that has AA
  2. Warning about attacking a territory to which planes can scramble

A "Don't show this warning" checkbox is added to each of the dialogs, as well as a corresponding pref setting (one for each).
Additionally, the second warning is now controlled by this preference setting, rather than the "beta features" setting.

<img width="677" alt="Screen Shot 2022-07-03 at 4 03 47 PM" src="https://user-images.githubusercontent.com/17648/177056110-d38e2f31-e7e9-4e38-be63-04db3270666b.png"><img width="648" alt="Screen Shot 2022-07-03 at 4 26 05 PM" src="https://user-images.githubusercontent.com/17648/177056159-74422fa1-9d65-48bc-a491-d1ba823e5da5.png"><img width="1132" alt="Screen Shot 2022-07-03 at 4 24 03 PM" src="https://user-images.githubusercontent.com/17648/177056236-4e7ddaa3-de43-4f41-b3fa-66e1b031fb0a.png">

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->NEW|Prefs for AI flyover and scrambling, the latter being moved out of beta features.<!--END_RELEASE_NOTE-->
