### PR TITLE
Fix NPE in ObjectivesPanel

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.ui;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import games.strategy.engine.data.Change;
@@ -66,14 +67,10 @@ class ObjectivePanel extends JPanel implements GameDataChangeListener {
   ObjectivePanel(final GameData data, final UiContext uiContext) {
     gameData = data;
     dummyDelegate = new ObjectiveDummyDelegateBridge(data);
-    resourceLoader = uiContext.getResourceLoader();
+    Preconditions.checkNotNull(uiContext);
+    resourceLoader = Preconditions.checkNotNull(uiContext.getResourceLoader());
     initLayout();
     gameData.addDataChangeListener(this);
-  }
-
-  @Override
-  public String getName() {
-    return ObjectiveProperties.getInstance(resourceLoader).getName();
   }
 
   public boolean isEmpty() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveProperties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveProperties.java
@@ -8,7 +8,6 @@ import java.util.Set;
 public class ObjectiveProperties extends PropertyFile {
   static final String GROUP_PROPERTY = "TABLEGROUP";
   private static final String PROPERTY_FILE = "objectives.properties";
-  private static final String OBJECTIVES_PANEL_NAME = "Objectives.Panel.Name";
 
   protected ObjectiveProperties(final ResourceLoader resourceLoader) {
     super(PROPERTY_FILE, resourceLoader);
@@ -17,10 +16,6 @@ public class ObjectiveProperties extends PropertyFile {
   public static ObjectiveProperties getInstance(final ResourceLoader resourceLoader) {
     return PropertyFile.getInstance(
         ObjectiveProperties.class, () -> new ObjectiveProperties(resourceLoader));
-  }
-
-  public String getName() {
-    return properties.getProperty(ObjectiveProperties.OBJECTIVES_PANEL_NAME, "Objectives");
   }
 
   public Set<Entry<Object, Object>> entrySet() {


### PR DESCRIPTION
NPE happens trying to launch any game. Problem is that 'getName' is called before
the constructor in this class, in this case 'resourceLoader' is not yet initiatilized
and we then go on to have a NPE in 'ObjectiveProperties'

The override of 'getName' for a swing component is generally not necessary, this override
can be removed entirely and it fixes this problem.

## Change Summary & Additional Notes

This is the NPE stack trace observed:
> 19:54:14.957 [Thread-4] ERROR g.s.e.f.s.launcher.LocalLauncher - Failed to start game
com.google.common.util.concurrent.UncheckedExecutionException: java.lang.NullPointerException
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2055)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3966)
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4863)
	at games.strategy.triplea.ui.PropertyFile.getInstance(PropertyFile.java:33)
	at games.strategy.triplea.ui.ObjectiveProperties.getInstance(ObjectiveProperties.java:18)
	at games.strategy.triplea.ui.ObjectivePanel.getName(ObjectivePanel.java:76)
	at java.desktop/javax.swing.plaf.nimbus.NimbusDefaults$LazyStyle.matches(NimbusDefaults.java:1480)
	at java.desktop/javax.swing.plaf.nimbus.NimbusDefaults$LazyStyle.matches(NimbusDefaults.java:1472)
	at java.desktop/javax.swing.plaf.nimbus.NimbusDefaults.getStyle(NimbusDefaults.java:1161)
	at java.desktop/javax.swing.plaf.nimbus.NimbusLookAndFeel$1.getStyle(NimbusLookAndFeel.java:112)
	at java.desktop/javax.swing.plaf.synth.SynthLookAndFeel.getStyle(SynthLookAndFeel.java:240)
	at java.desktop/javax.swing.plaf.synth.SynthLookAndFeel.updateStyle(SynthLookAndFeel.java:261)
	at java.desktop/javax.swing.plaf.synth.SynthPanelUI.updateStyle(SynthPanelUI.java:116)
	at java.desktop/javax.swing.plaf.synth.SynthPanelUI.installDefaults(SynthPanelUI.java:100)
	at java.desktop/javax.swing.plaf.basic.BasicPanelUI.installUI(BasicPanelUI.java:62)
	at java.desktop/javax.swing.plaf.synth.SynthPanelUI.installUI(SynthPanelUI.java:62)
	at java.desktop/javax.swing.JComponent.setUI(JComponent.java:685)
	at java.desktop/javax.swing.JPanel.setUI(JPanel.java:150)
	at java.desktop/javax.swing.JPanel.updateUI(JPanel.java:126)
	at java.desktop/javax.swing.JPanel.<init>(JPanel.java:86)
	at java.desktop/javax.swing.JPanel.<init>(JPanel.java:109)
	at java.desktop/javax.swing.JPanel.<init>(JPanel.java:117)
	at games.strategy.triplea.ui.ObjectivePanel.<init>(ObjectivePanel.java:66)
	at games.strategy.triplea.ui.TripleAFrame.<init>(TripleAFrame.java:384)
	at games.strategy.triplea.ui.TripleAFrame.lambda$create$7(TripleAFrame.java:469)
	at org.triplea.swing.SwingAction.lambda$invokeAndWaitResult$2(SwingAction.java:130)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:303)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Caused by: java.lang.NullPointerException: null
	at games.strategy.triplea.ui.PropertyFile.<init>(PropertyFile.java:21)
	at games.strategy.triplea.ui.ObjectiveProperties.<init>(ObjectiveProperties.java:14)
	at games.strategy.triplea.ui.ObjectiveProperties.lambda$getInstance$0(ObjectiveProperties.java:19)
	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4868)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3533)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2282)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2159)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049)
	... 38 common frames omitted
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
