### PR TITLE
Fix "Width (0) and height (0) must be non-zero" in unit panel.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -169,8 +169,8 @@ public class SimpleUnitPanel extends JPanel {
     if (scaleFactor == 1.0) {
       return icon;
     }
-    int width = (int) (icon.getIconWidth() * scaleFactor);
-    int height = (int) (icon.getIconHeight() * scaleFactor);
+    int width = Math.max(1, (int) (icon.getIconWidth() * scaleFactor));
+    int height = Math.max(1, (int) (icon.getIconHeight() * scaleFactor));
     return new ImageIcon(icon.getImage().getScaledInstance(width, height, Image.SCALE_SMOOTH));
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes
Fixes: https://github.com/triplea-game/triplea/issues/10820

Test: On TWW 3, add a "Pg" unit in UK and mouseover the territory. No error should happen.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
