### PR TITLE
Infra: run auto-remove as part of common package installation

### DIFF
--- a/infrastructure/ansible/roles/system/apt_common_tools/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/apt_common_tools/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: apt install standard utilities and packages
   apt:
     state: present
+    autoremove: true
     name:
       # acl installed to help with: "Failed to set permissions on the temporary files
       # Ansible needs to create when becoming an unprivileged user"


### PR DESCRIPTION
While installing apt packages, this update adds an 'auto-remove'
that will help clean up unneeded packages.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
