### PR TITLE
Remove 'postgres' hosts from production inventory

### DIFF
--- a/infrastructure/ansible/inventory/production
+++ b/infrastructure/ansible/inventory/production
@@ -14,6 +14,6 @@ prod2-bot08.triplea-game.org  bot_prefix=8 bot_name=London
 prod2-bot09.triplea-game.org  bot_prefix=9 bot_name=Frankfurt
 
 [prod:children]
-postgresHosts
 lobbyServer
 botHosts
+


### PR DESCRIPTION
The hostgroup was merged into 'lobby' and was previously removed.
All references should have been previously been removed, this
update fixes the lingering mention of the 'postgres' hosts.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
