### PR TITLE
Infra: ensure artifacts are built when deploying

### DIFF
--- a/infrastructure/.include/build_latest_artifacts
+++ b/infrastructure/.include/build_latest_artifacts
@@ -5,24 +5,48 @@
 # available to ansible.
 
 scriptDir="$(dirname "$0")"
-rootDir="$scriptDir/../../"
+rootDir="$scriptDir/../.."
+
+BUILD_VERSION=$("$rootDir/.build/get-build-version")
+MIGRATIONS_ZIP="$rootDir/spitfire-server/database/build/artifacts/migrations.zip"
+LOBBY_SERVER_ZIP="$rootDir/spitfire-server/dropwizard-server/build/artifacts/triplea-dropwizard-server-$BUILD_VERSION.zip"
+BOT_ZIP="$rootDir/game-app/game-headless/build/artifacts/triplea-game-headless-$BUILD_VERSION.zip"
+
+
 function main() {
   buildArtifacts
+  copyBuildArtifacts
 }
 
 function buildArtifacts() {
   (
     cd "$rootDir" || exit 1
+
+    # Run a clean if artifacts do not exist. We may have already built the artifact
+    # but with a different  SHA, in which case gradle will not generate them.
+    if [ ! -f "$MIGRATIONS_ZIP" ]; then
+      ./gradlew :spitfire-server:database:clean
+    fi
+    if [ ! -f "$LOBBY_SERVER_ZIP" ]; then
+      ./gradlew :spitfire-server:dropwizard-server:clean
+    fi
+    if [ ! -f "$BOT_ZIP" ]; then
+      ./gradlew :game-app:game-headless:clean
+    fi
+
     ./gradlew \
         :spitfire-server:dropwizard-server:release \
         :game-app:game-headless:release \
         :spitfire-server:database:release
         set +x
   )
+}
+
+function copyBuildArtifacts() {
   BUILD_VERSION=$("$rootDir/.build/get-build-version")
-  copyBuildArtifact "$rootDir/spitfire-server/database/build/artifacts/migrations.zip" "$scriptDir/../ansible/roles/lobby_server/files/"
-  copyBuildArtifact "$rootDir/spitfire-server/dropwizard-server/build/artifacts/triplea-dropwizard-server-$BUILD_VERSION.zip" "$scriptDir/../ansible/roles/lobby_server/files/"
-  copyBuildArtifact "$rootDir/game-app/game-headless/build/artifacts/triplea-game-headless-$BUILD_VERSION.zip" "$scriptDir/../ansible/roles/bot/files/"
+  copyBuildArtifact "$MIGRATIONS_ZIP" "$scriptDir/../ansible/roles/lobby_server/files/"
+  copyBuildArtifact "$LOBBY_SERVER_ZIP" "$scriptDir/../ansible/roles/lobby_server/files/"
+  copyBuildArtifact "$BOT_ZIP" "$scriptDir/../ansible/roles/bot/files/"
 }
 
 function copyBuildArtifact() {


### PR DESCRIPTION
This updates the build artifact script to ensure we always build
the expected artifacts. Gradle will not build artifacts if they
appear up-to-date. If the git-SHA then changes, the expected
artifact name could be different from existing artifacts (that
potentially were previously built but are not rebuilt because
they appear up to date).

So, this update checks if the expected artifact names exist,
if not, we do a clean to remove any previous artifacts and
then build fresh artifacts that then should have the expected
names.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
