### PR TITLE
Attempt to fix Comparator exception.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
@@ -8,6 +8,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,7 @@ public final class DebugMenu extends JMenu {
     frameVisitors.forEach(tripleAFrameConsumer -> tripleAFrameConsumer.accept(frame));
 
     debugOptions.stream()
-        .sorted()
+        .sorted(Comparator.comparing(DebugOption::getName))
         .forEach(
             option -> {
               final JMenu playerDebugMenu = new JMenu(option.getName());


### PR DESCRIPTION
## Change Summary & Additional Notes
Attempt to fix: https://github.com/triplea-game/triplea/issues/10817.

I assume `sorted(Comparator)` does not require the elements to implement Comparable.

Unfortunately, I don't have a repro for this, so can't easily test...

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
