### PR TITLE
Infra: Update name of prod server -> prod.triplea-game.org

### DIFF
--- a/infrastructure/ansible/inventory/production
+++ b/infrastructure/ansible/inventory/production
@@ -2,7 +2,7 @@
 forums.triplea-game.org
 
 [lobbyServer]
-prod2-lobby.triplea-game.org
+prod.triplea-game.org
 
 [botHosts]
 prod2-bot01.triplea-game.org  bot_prefix=1 bot_name=Dallas


### PR DESCRIPTION
There is a new DNS name simplifying the naming for the prod lobby server.
This updates config to use this new DNS alias name. The server has not
physically changed.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
