### PR TITLE
Infra: Update certbot role to have a unique tag name

### DIFF
--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -21,7 +21,7 @@
     - {name: database/flyway/install, tags: flyway}
     - {name: nginx/install, tags: nginx}
     - {name: lobby_server, tags: lobby}
-    - {name: nginx/run_certbot, tags: nginx}
+    - {name: nginx/run_certbot, tags: certbot}
 
 - hosts: botHosts
   tags: [bot, bots]


### PR DESCRIPTION
This allows us to run just the certbot role on its own, or we can comma
delimit to run multiple roles (this update gives additional flexibility,
we do not need to always run the nginx & certbot roles together)

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
