### PR TITLE
Infra: use commit number as build number

### DIFF
--- a/.build/get-build-version
+++ b/.build/get-build-version
@@ -12,5 +12,5 @@ echo -n "$($scriptDir/get-product-version)+"
 # finish printing with commit number
 (
   cd $scriptDir || exit 1
-  git rev-list --count master
+  git rev-list --count HEAD
 )

--- a/.build/get-build-version
+++ b/.build/get-build-version
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Prints the current build version, this is the product version plus current git SHA
-# Example output: 2.6+e448c5f73b
+# Prints the current build version, this is the product version plus current commit number
+# Example output: 2.6+23400
 
 set -eu
 
@@ -9,8 +9,8 @@ scriptDir=$(dirname "$0")
 
 echo -n "$($scriptDir/get-product-version)+"
 
-# finish printing with  git SHA
+# finish printing with commit number
 (
   cd $scriptDir || exit 1
-  git rev-parse --short HEAD
+  git rev-list --count master
 )

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ subprojects {
     // and adds version number to packaged jar files.
     // ie:  [module-name]-[build-version].jar,
     // eg:  lobby-server-2.6+50370c.jar
-    version = getProductVersion() + "+" + getGitHash()
+    version = getProductVersion() + "+" + getCommitNumber()
 
     ext {
         apacheHttpComponentsVersion = '4.5.13'

--- a/gradle/scripts/version.gradle
+++ b/gradle/scripts/version.gradle
@@ -5,7 +5,7 @@ ext.getProductVersion = {
 ext.getCommitNumber = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'rev-list', '--count', 'master'
+        commandLine 'git', 'rev-list', '--count', 'HEAD'
         standardOutput = stdout
     }
     return stdout.toString().trim()

--- a/gradle/scripts/version.gradle
+++ b/gradle/scripts/version.gradle
@@ -2,10 +2,10 @@ ext.getProductVersion = {
     return project(':game-app').file("../.build/product-version.txt").text.trim();
 }
 
-ext.getGitHash = { ->
+ext.getCommitNumber = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        commandLine 'git', 'rev-list', '--count', 'master'
         standardOutput = stdout
     }
     return stdout.toString().trim()


### PR DESCRIPTION
Instead of using git commit sha, this update uses the commit number
instead. So we would have version numbers like "2.6+16243" instead
of "2.6+aed412"

A benefit of a commit number is it is deterministic like commit
sha, but also sequential. We still will be able to find a specific
code version by 'version number' since each build is tagged
and we can checkout the tag (so we do not lose a capability compared
to using git SHA, a version still uniquely identifies a build)

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
