### PR TITLE
Infra: run all commands with 'become' (root)

### DIFF
--- a/infrastructure/ansible.cfg
+++ b/infrastructure/ansible.cfg
@@ -21,3 +21,7 @@ retries = 5
 
 [persistent_connection]
 connect_timeout = 30
+
+[privilege_escalation]
+become = true
+


### PR DESCRIPTION
An update to ansible.cfg such that ansible will automatically
add a "become: true" to all commands. This means we run all
commands with "sudo" (effectively root). In practice this has
no effect because right now we connect to all servers as root
and run ansible commands as root user anyways.

This update is helpful if we ever change our connection user,
if we ever connect and run ansible commands as a user that is not
root.

When running deployments from local, we can use the 'admin'
user and our pre-installed keys to successfully run deployments.
In such a case our SSH user does change and having the 'become: true'
is useful. Notably, some commands require 'sudo' and we are able
to run them now only because we are connected as root.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
