### PR TITLE
Infra: install lobby to /opt/lobby/<major.minor>

### DIFF
--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -4,9 +4,8 @@ lobby_full_version: "{{ build_version }}"
 
 # product version is just the major.minor, eg: 2.6
 lobby_product_version: "{{ product_version }}"
-
 lobby_name: "lobby_server_{{ lobby_product_version }}"
-lobby_server_home_folder: "/home/{{ lobby_server_user }}/{{ lobby_product_version }}"
+lobby_server_home_folder: "/opt/lobby/{{ lobby_product_version }}"
 
 lobby_ports:
   "default": "8080"

--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -1,11 +1,11 @@
-lobby_server_user: lobby_server
+lobby_user: lobby
 # Full version includes the build number, eg: 2.6+153432
 lobby_full_version: "{{ build_version }}"
 
 # product version is just the major.minor, eg: 2.6
 lobby_product_version: "{{ product_version }}"
-lobby_name: "lobby_server_{{ lobby_product_version }}"
-lobby_server_home_folder: "/opt/lobby/{{ lobby_product_version }}"
+lobby_name: "lobby_{{ lobby_product_version }}"
+lobby_home_folder: "/opt/lobby/{{ lobby_product_version }}"
 
 lobby_ports:
   "default": "8080"

--- a/infrastructure/ansible/roles/lobby_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/tasks/main.yml
@@ -45,30 +45,30 @@
 
 - name: create lobby service user group
   group:
-    name: "{{ lobby_server_user }}"
+    name: "{{ lobby_user }}"
 
 - name: create service user
   user:
-    name: "{{ lobby_server_user }}"
-    group: "{{ lobby_server_user }}"
+    name: "{{ lobby_user }}"
+    group: "{{ lobby_user }}"
     create_home: no
     system: yes
 
 - name: ensure deployment folder exists
   file:
     state: directory
-    path: "{{ lobby_server_home_folder }}"
+    path: "{{ lobby_home_folder }}"
     mode: "0755"
-    owner: "{{ lobby_server_user }}"
-    group: "{{ lobby_server_user }}"
+    owner: "{{ lobby_user }}"
+    group: "{{ lobby_user }}"
 
 - name: extract lobby_server zip file
   register: deploy_artifact
   unarchive:
     src: "{{ lobby_artifact }}"
-    dest: "{{ lobby_server_home_folder }}/"
-    owner: "{{ lobby_server_user }}"
-    group: "{{ lobby_server_user }}"
+    dest: "{{ lobby_home_folder }}/"
+    owner: "{{ lobby_user }}"
+    group: "{{ lobby_user }}"
 
 - name: install systemd service script
   register: service_script
@@ -88,7 +88,7 @@
 - name: drop a version file in lobby home
   template:
     src: version.txt
-    dest: "{{ lobby_server_home_folder }}/version.txt"
+    dest: "{{ lobby_home_folder }}/version.txt"
     mode: "0644"
-    owner: "{{ lobby_server_user }}"
-    group: "{{ lobby_server_user }}"
+    owner: "{{ lobby_user }}"
+    group: "{{ lobby_user }}"

--- a/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
+++ b/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
@@ -16,9 +16,9 @@ Environment=MAP_INDEXING_PERIOD_MINUTES={{ map_indexing_period_minutes }}
 Environment=MAP_INDEXING_DELAY_SECONDS={{ map_indexing_task_delay_seconds }}
 Environment=HTTP_PORT={{ lobby_http_port }}
 
-WorkingDirectory={{ lobby_server_home_folder }}
-User={{ lobby_server_user }}
-Group={{ lobby_server_user }}
+WorkingDirectory={{ lobby_home_folder }}
+User={{ lobby_user }}
+Group={{ lobby_user }}
 ExecStart=java -jar bin/{{ lobby_jar_file }}
 
 [Install]


### PR DESCRIPTION
## Change Summary & Additional Notes

- changes install location (notably we will de-dupe lobby versions by 'major.minor', meaning 2.6 versions will overwrite each other as we deploy new ones.
- simplifies ansible variable naming for lobby

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
