### PR TITLE
Make AI faster by speeding up some combat code.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
@@ -26,9 +26,6 @@ public final class TerritoryEffectHelper {
 
   public static int getTerritoryCombatBonus(
       final UnitType type, final Collection<TerritoryEffect> effects, final boolean defending) {
-    if (type == null || effects == null || effects.isEmpty()) {
-      return 0;
-    }
     int combatBonus = 0;
     for (final TerritoryEffect effect : effects) {
       combatBonus += TerritoryEffectAttachment.get(effect).getCombatEffect(type, defending);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
@@ -33,6 +33,8 @@ class AvailableSupports {
 
   final Map<UnitSupportAttachment.BonusType, List<UnitSupportAttachment>> supportRules;
 
+  // Wrapped over IntegerMap<Unit> that keeps track of the total, instead of recomputing it
+  // repeatedly which can be very slow with lots of support units.
   static class SupportDetails {
     IntegerMap<Unit> supportUnits;
     int totalSupport;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
@@ -33,7 +33,7 @@ class AvailableSupports {
 
   final Map<UnitSupportAttachment.BonusType, List<UnitSupportAttachment>> supportRules;
 
-  // Wrapped over IntegerMap<Unit> that keeps track of the total, instead of recomputing it
+  // Wrapper over IntegerMap<Unit> that keeps track of the total, instead of recomputing it
   // repeatedly which can be very slow with lots of support units.
   static class SupportDetails {
     IntegerMap<Unit> supportUnits;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
@@ -5,7 +5,6 @@ import games.strategy.triplea.attachments.UnitSupportAttachment;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
@@ -33,7 +32,23 @@ class AvailableSupports {
           .build();
 
   final Map<UnitSupportAttachment.BonusType, List<UnitSupportAttachment>> supportRules;
-  final Map<UnitSupportAttachment, IntegerMap<Unit>> supportUnits;
+
+  static class SupportDetails {
+    IntegerMap<Unit> supportUnits;
+    int totalSupport;
+
+    public SupportDetails(IntegerMap<Unit> supportUnits) {
+      this.supportUnits = supportUnits;
+      this.totalSupport = supportUnits.totalValues();
+    }
+
+    public SupportDetails(SupportDetails other) {
+      this.supportUnits = new IntegerMap<>(other.supportUnits);
+      this.totalSupport = other.totalSupport;
+    }
+  }
+
+  final Map<UnitSupportAttachment, SupportDetails> supportUnits;
 
   /**
    * Keeps track of the units that have provided support in {@link
@@ -59,9 +74,12 @@ class AvailableSupports {
   }
 
   static AvailableSupports getSupport(final SupportCalculator supportCalculator) {
+    Map<UnitSupportAttachment, SupportDetails> transformedSupportUnits =
+        supportCalculator.getSupportUnits().entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> new SupportDetails(e.getValue())));
     return builder()
         .supportRules(supportCalculator.getSupportRules())
-        .supportUnits(supportCalculator.getSupportUnits())
+        .supportUnits(transformedSupportUnits)
         .build();
   }
 
@@ -84,18 +102,14 @@ class AvailableSupports {
       }
     }
 
-    final Map<UnitSupportAttachment, IntegerMap<Unit>> supportUnits = new HashMap<>();
+    final Map<UnitSupportAttachment, SupportDetails> supportUnits = new HashMap<>();
     for (final UnitSupportAttachment usa : this.supportUnits.keySet()) {
       if (ruleFilter.test(usa)) {
-        supportUnits.put(usa, new IntegerMap<>(this.supportUnits.get(usa)));
+        supportUnits.put(usa, new SupportDetails(this.supportUnits.get(usa)));
       }
     }
 
     return builder().supportRules(supportRules).supportUnits(supportUnits).build();
-  }
-
-  int getSupportLeft(final UnitSupportAttachment support) {
-    return supportUnits.getOrDefault(support, new IntegerMap<>()).totalValues();
   }
 
   /**
@@ -134,11 +148,12 @@ class AvailableSupports {
   }
 
   private int getSupportAvailable(final UnitSupportAttachment support) {
-    return Math.max(
-        0,
-        Math.min(
-            support.getBonusType().getCount(),
-            supportUnits.getOrDefault(support, new IntegerMap<>()).totalValues()));
+    return Math.max(0, Math.min(support.getBonusType().getCount(), getSupportLeft(support)));
+  }
+
+  int getSupportLeft(final UnitSupportAttachment support) {
+    SupportDetails details = supportUnits.get(support);
+    return details != null ? details.totalSupport : 0;
   }
 
   /**
@@ -148,11 +163,13 @@ class AvailableSupports {
    * unit can give.
    */
   private Unit getNextAvailableSupporter(final UnitSupportAttachment support) {
-    final Set<Unit> supporters = supportUnits.get(support).keySet();
-    final Unit u = CollectionUtils.getAny(supporters);
-    supportUnits.get(support).add(u, -1);
-    if (supportUnits.get(support).getInt(u) <= 0) {
-      supportUnits.get(support).removeKey(u);
+    final SupportDetails details = supportUnits.get(support);
+    final IntegerMap<Unit> intMap = details.supportUnits;
+    final Unit u = CollectionUtils.getAny(intMap.keySet());
+    intMap.add(u, -1);
+    details.totalSupport -= 1;
+    if (intMap.getInt(u) <= 0) {
+      intMap.removeKey(u);
     }
     return u;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
@@ -111,7 +111,7 @@ public class BombardmentCombatValue implements CombatValue {
   static class BombardmentStrength implements StrengthCalculator {
 
     int gameDiceSides;
-    Collection<TerritoryEffect> territoryEffects;
+    @Nonnull Collection<TerritoryEffect> territoryEffects;
     AvailableSupports supportFromFriends;
     AvailableSupports supportFromEnemies;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
@@ -4,6 +4,8 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.function.Function;
 
 public interface CombatValue {
 
@@ -24,11 +26,12 @@ public interface CombatValue {
   default Comparator<Unit> unitComparator() {
     // unit support is stateful which would mess up the sort calculations so remove unit supports
     final StrengthCalculator strengthCalculator = this.buildWithNoUnitSupports().getStrength();
+    final var cache = new HashMap<Unit, Integer>();
+    final Function<Unit, Integer> getStrength = u -> strengthCalculator.getStrength(u).getValue();
     return Comparator.<Unit, Boolean>comparing(
-            unit -> strengthCalculator.getStrength(unit).getValue() == 0)
+            unit -> cache.computeIfAbsent(unit, getStrength) == 0)
         .thenComparingDouble(
-            unit ->
-                -strengthCalculator.getStrength(unit).getValue() / (float) this.getDiceSides(unit));
+            unit -> -cache.computeIfAbsent(unit, getStrength) / (float) getDiceSides(unit));
   }
 
   int getDiceSides(Unit unit);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
@@ -137,7 +137,7 @@ class MainDefenseCombatValue implements CombatValue {
 
     GameSequence gameSequence;
     int gameDiceSides;
-    Collection<TerritoryEffect> territoryEffects;
+    @Nonnull Collection<TerritoryEffect> territoryEffects;
     AvailableSupports supportFromFriends;
     AvailableSupports supportFromEnemies;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
@@ -134,7 +134,7 @@ class MainOffenseCombatValue implements CombatValue {
   static class MainOffenseStrength implements StrengthCalculator {
 
     int gameDiceSides;
-    Collection<TerritoryEffect> territoryEffects;
+    @Nonnull Collection<TerritoryEffect> territoryEffects;
     AvailableSupports supportFromFriends;
     AvailableSupports supportFromEnemies;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
@@ -16,7 +16,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Value;
-import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 /** Calculates how much support units can give */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -122,8 +122,8 @@ public class UnitSeparator {
               canRetreat);
       // we test to see if we have the key using equals, then since
       // key maps to key, we retrieve it to add the unit to the correct category
-      if (categories.containsKey(entry)) {
-        final UnitCategory stored = categories.get(entry);
+      final UnitCategory stored = categories.get(entry);
+      if (stored != null) {
         stored.addUnit(current);
       } else {
         categories.put(entry, entry);


### PR DESCRIPTION
## Change Summary & Additional Notes
This PR speeds up several areas in the code that were showing in performance profiles.

With this change, we achieve the following speed ups on a given AI's turn on "Another World" map:

1. Main game thread CPU time goes from 90s to 70s
2. Each of 15 (on my machine) AI combat simulation threads go from 73s CPU time to 52s CPU time

This is with this save game: [speed_test.zip](https://github.com/triplea-game/triplea/files/9137146/speed_test.zip)
Before starting it, set player "Malliton" to Hard AI.

The above profiling results were measured with VisualVM, attaching to the game for the entire duration of the AI turn.
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
