### PR TITLE
Infra/commit number in version

### DIFF
--- a/.build/get-build-version
+++ b/.build/get-build-version
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Prints the current build version, this is the product version plus current git SHA
-# Example output: 2.6+e448c5f73b
+# Prints the current build version, this is the product version plus current commit number
+# Example output: 2.6+23400
 
 set -eu
 
@@ -9,8 +9,8 @@ scriptDir=$(dirname "$0")
 
 echo -n "$($scriptDir/get-product-version)+"
 
-# finish printing with  git SHA
+# finish printing with commit number
 (
   cd $scriptDir || exit 1
-  git rev-parse --short HEAD
+  git rev-list --count HEAD
 )

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
       - name: Load SSH private key into ssh-agent
         uses: webfactory/ssh-agent@v0.5.4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,12 @@ subprojects {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
 
+    // The value of 'version' is used by 'shadowJar' to set 'archiveName'
+    // and adds version number to packaged jar files.
+    // ie:  [module-name]-[build-version].jar,
+    // eg:  lobby-server-2.6+50370c.jar
+    version = getProductVersion() + "+" + getCommitNumber()
+
     ext {
         apacheHttpComponentsVersion = '4.5.13'
         awaitilityVersion = '4.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -59,12 +59,6 @@ subprojects {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
 
-    // The value of 'version' is used by 'shadowJar' to set 'archiveName'
-    // and adds version number to packaged jar files.
-    // ie:  [module-name]-[build-version].jar,
-    // eg:  lobby-server-2.6+50370c.jar
-    version = getProductVersion() + "+" + getCommitNumber()
-
     ext {
         apacheHttpComponentsVersion = '4.5.13'
         awaitilityVersion = '4.2.0'

--- a/game-app/game-headed/build.gradle
+++ b/game-app/game-headed/build.gradle
@@ -116,6 +116,6 @@ task release(group: 'release', dependsOn: [portableInstaller, platformInstallers
 shadowJar {
     // 'archiveVersion' sets the version number on packaged jar files
     // eg: "2.6+105234" in "lobby-server-2.6+50370c.jar"
-    archiveVersion = getProductVersion() + "+" + getGitHash()
+    archiveVersion = getProductVersion() + "+" + getCommitNumber()
     archiveClassifier.set ''
 }

--- a/gradle/scripts/version.gradle
+++ b/gradle/scripts/version.gradle
@@ -2,10 +2,10 @@ ext.getProductVersion = {
     return project(':game-app').file("../.build/product-version.txt").text.trim();
 }
 
-ext.getGitHash = { ->
+ext.getCommitNumber = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        commandLine 'git', 'rev-list', '--count', 'HEAD'
         standardOutput = stdout
     }
     return stdout.toString().trim()


### PR DESCRIPTION
## Change Summary & Additional Notes

- Redo's the update to use 'number-of-commits' as the build number.
- Includes a potential fix for 'checkout' action where update the fetch size to '0' from a default value of '1'. This should cause us to get all commits and then count them all properly. Previously we had the problem the number of commits was '1' and so the count was always '1' (because we only fetched the latest commit)
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
