### PR TITLE
Infra: Increase ansible SSH timeout and retries

### DIFF
--- a/infrastructure/ansible.cfg
+++ b/infrastructure/ansible.cfg
@@ -11,13 +11,15 @@ remote_user = root
 stdout_callback = yaml
 # Use the stdout_callback when running ad-hoc commands.
 bin_ansible_callbacks = True
+# timeout updates the value of ansible_ssh_timeout, default is 10
+timeout = 30
 
 [ssh_connection]
 pipelining = True
 control_path = /tmp/ansible-ssh-%%h-%%p-%%r
 ControlMaster = auto
 ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
-retries = 5
+retries = 10
 
 [persistent_connection]
 connect_timeout = 30


### PR DESCRIPTION
We are seeing builds fail due to 'host unreachable' (even though the host
is perfectly reachable). This is seemingly a problem with not trying enough
times or not waiting long enough. This update increases the number of
SSH attempts that we will make and increases how long we wait.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
