### PR TITLE
Infra: remove unused ansible.cfg settings

### DIFF
--- a/infrastructure/ansible.cfg
+++ b/infrastructure/ansible.cfg
@@ -6,7 +6,6 @@ host_key_checking = False
 forks = 10
 serial = 100%
 gathering = explicit
-poll_interval = 1
 remote_user = root
 stdout_callback = yaml
 # Use the stdout_callback when running ad-hoc commands.
@@ -20,9 +19,6 @@ control_path = /tmp/ansible-ssh-%%h-%%p-%%r
 ControlMaster = auto
 ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 retries = 10
-
-[persistent_connection]
-connect_timeout = 30
 
 [privilege_escalation]
 become = true


### PR DESCRIPTION
'poll_interval' is only used for async tasks, we do not use any
and so have no need to override this value.

'persistent_connection' setting does not look to be a real
configuration settings block and seemingly has no effect.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
