### PR TITLE
Infra: add check for install-4-license variable or abort

### DIFF
--- a/.build/build-installer
+++ b/.build/build-installer
@@ -8,6 +8,11 @@
 set -x
 scriptDir=$(dirname "$0")
 
+if [ -z "$INSTALL4J_LICENSE" ]; then
+  echo "Environment variable 'INSTALL4J_LICENSE' must be set"
+  exit 1
+fi
+
 function main() {
   install_install4j
   build_installers


### PR DESCRIPTION
Abort early if 'install-4-license' variable is not. This value is
required later in the build when install4j builds artifacts.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
