### PR TITLE
Infra: fix version number on game-headed build artifacts

### DIFF
--- a/game-app/game-headed/build.gradle
+++ b/game-app/game-headed/build.gradle
@@ -10,6 +10,7 @@ mainClassName = 'org.triplea.game.client.HeadedGameRunner'
 
 ext {
     releasesDir = file("$buildDir/releases")
+    releaseVersion = getProductVersion() + "+" + getCommitNumber()
 }
 
 dependencies {
@@ -78,11 +79,11 @@ task downloadPlatformInstallerAssets(group: 'release', dependsOn: downloadAssets
 }
 
 task platformInstallers(
-        type: com.install4j.gradle.Install4jTask,
-        group: 'release',
-        dependsOn: [shadowJar, downloadPlatformInstallerAssets]) {
+    type: com.install4j.gradle.Install4jTask,
+    group: 'release',
+    dependsOn: [shadowJar, downloadPlatformInstallerAssets]) {
     projectFile = file('build.install4j')
-    release = version
+    release = releaseVersion
 
     doLast {
         ant.chmod(dir: releasesDir, perm: '+x', includes: '*.sh')
@@ -105,10 +106,10 @@ task portableInstaller(type: Zip, group: 'release', dependsOn: shadowJar) {
 task release(group: 'release', dependsOn: [portableInstaller, platformInstallers]) {
     doLast {
         publishArtifacts(portableInstaller.outputs.files + [
-            file("$releasesDir/TripleA_${version}_macos.dmg"),
-            file("$releasesDir/TripleA_${version}_unix.sh"),
-            file("$releasesDir/TripleA_${version}_windows-32bit.exe"),
-            file("$releasesDir/TripleA_${version}_windows-64bit.exe")
+            file("$releasesDir/TripleA_${releaseVersion}_macos.dmg"),
+            file("$releasesDir/TripleA_${releaseVersion}_unix.sh"),
+            file("$releasesDir/TripleA_${releaseVersion}_windows-32bit.exe"),
+            file("$releasesDir/TripleA_${releaseVersion}_windows-64bit.exe")
         ])
     }
 }
@@ -116,6 +117,6 @@ task release(group: 'release', dependsOn: [portableInstaller, platformInstallers
 shadowJar {
     // 'archiveVersion' sets the version number on packaged jar files
     // eg: "2.6+105234" in "lobby-server-2.6+50370c.jar"
-    archiveVersion = getProductVersion() + "+" + getCommitNumber()
+    archiveVersion = releaseVersion
     archiveClassifier.set ''
 }


### PR DESCRIPTION
Version number on build artifacts (install4j installers) had
their version number printing as 'unspecified'. This update
fixes that problem. In previous commits we remove the 'version'
variable from gradle in favor of specifying it more precisely
in just game-headed (this allowed for other projects to build
jar files that do not include a version number in them). It
was omitted to update the install4j task to account for this.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
