### PR TITLE
Infra: update build-installer script to fail on first error

### DIFF
--- a/.build/build-installer
+++ b/.build/build-installer
@@ -12,7 +12,7 @@ if [ -z "$INSTALL4J_LICENSE" ]; then
   exit 1
 fi
 
-set -x
+set -ex
 
 function main() {
   install_install4j
@@ -23,7 +23,7 @@ function main() {
 # Installs install4j, the license key is injected into install4j during this step.
 function install_install4j() {
   INSTALL4J_HOME=/tmp/install4j
-  mkdir $INSTALL4J_HOME
+  mkdir -p $INSTALL4J_HOME
 
   echo "Downloading and installing install4j to '$INSTALL4J_HOME'"
   wget --no-verbose -O install4j_unix.sh \


### PR DESCRIPTION
Add 'set -e' flag to 'build-installer' script.
Ideally we would have this flag on every script!
The flag will fail on first error. We fix up the
script to avoid unnecessary errors that could be
encountered when running locally (on a dev laptop)

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
