### PR TITLE
Infra: Split Deployment github actions files

### DIFF
--- a/.github/workflows/deploy-github-release.yml
+++ b/.github/workflows/deploy-github-release.yml
@@ -1,4 +1,5 @@
-name: Master Branch Release
+# Builds installers and uploads to a new github release
+name: Deploy Installers to Github Releases
 on:
   push:
     branches:
@@ -7,17 +8,13 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build:
-    name: Master Branch Release Actions
+    name: Deploy Installers to Github Releases
     runs-on: Ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-      - name: Load SSH private key into ssh-agent
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}
       - name: Build Installers
         run: .build/build-installer
         env:
@@ -36,11 +33,4 @@ jobs:
           prerelease: true
           commit: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Ansible to Deploy
-        run: |
-          pip install ansible==2.9.13
-          cd infrastructure
-          echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
-          ./run_ansible --environment production --tags common,java,postfix,postgres,flyway
-        env:
-          ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
+

--- a/.github/workflows/deploy-servers.yml
+++ b/.github/workflows/deploy-servers.yml
@@ -1,0 +1,28 @@
+# Builds and deploys latest to servers.
+name: Deploy to Servers
+on:
+  push:
+    branches:
+      - master
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  build:
+    name: Server Deployment
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Load SSH private key into ssh-agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}
+      - name: Run Ansible to Deploy
+        run: |
+          pip install ansible==2.9.13
+          cd infrastructure
+          echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
+          ./run_ansible --environment production --tags common,java,postfix,postgres,flyway
+        env:
+          ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
+


### PR DESCRIPTION
Key split is between building installers with github
releases upload vs deployment to servers.
With the two split, we can re-run server deployments
independently (re-running the releases upload fails,
can only upload to a given release name once)

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
