### PR TITLE
Infra: add task to deploy Lobby (2.5) nginx config

### DIFF
--- a/infrastructure/ansible/roles/lobby_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/tasks/main.yml
@@ -32,6 +32,14 @@
     group: root
     mode: "0644"
 
+- name: Nginx config - deploy 2.5 lobby nginx config
+  template:
+    src: 2-5_lobby.conf
+    dest: /etc/nginx/sites-enabled/lobby-2-5.conf
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Nginx config - generate self signed cert
   when: nginx_generate_self_signed_cert
   include_role:

--- a/infrastructure/ansible/roles/lobby_server/templates/2-5_lobby.conf
+++ b/infrastructure/ansible/roles/lobby_server/templates/2-5_lobby.conf
@@ -1,0 +1,57 @@
+# warning: be sure that we can run certbot role and then re-run the nginx
+# role without this file changing. If this file is changed (white-space included)
+# then nginx will be restarting, disconnecting all active connections.
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name prod2-lobby.triplea-game.org;
+    ssl_certificate /etc/letsencrypt/live/prod2-lobby.triplea-game.org/fullchain.pem; # managed by Certbot; 
+    ssl_certificate_key /etc/letsencrypt/live/prod2-lobby.triplea-game.org/privkey.pem; # managed by Certbot;
+
+    ssl on;
+    ssl_protocols  TLSv1.2 TLSv1.3;
+    ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
+    ssl_prefer_server_ciphers on;
+    access_log            /var/log/nginx/java_server.access.log;
+
+    ssl_dhparam /etc/nginx/dhparam.pem;
+    ssl_ecdh_curve secp384r1;
+    ssl_session_timeout  10m;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_tickets off;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+
+    location / {
+
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+
+      # Fix the “It appears that your reverse proxy set up is broken" error.
+      proxy_pass          http://localhost:8080;
+      proxy_read_timeout  90;
+
+      proxy_redirect      https://localhost:443 https://localhost:8080;
+    }
+
+    location /game-connection/ws {
+      proxy_pass http://localhost:8080;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+
+    location /player-connection/ws {
+      proxy_pass http://localhost:8080;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+}


### PR DESCRIPTION
Production is already updated with this configuration, where
nginx has two configuration files:
 - lobby.conf (listens on 'prod.triplea-game.org')
 - lobby-2.5.conf (listons on 'prod2.triplea-game.org')

The lobby.conf file is the very latest & only works with 2.6 clients.
This update adds in the '2.5' configuration into source control.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
