### PR TITLE
Infra: fix 2.6 lobby nginx config

### DIFF
--- a/infrastructure/ansible/inventory/production
+++ b/infrastructure/ansible/inventory/production
@@ -2,7 +2,7 @@
 forums.triplea-game.org
 
 [lobbyServer]
-prod.triplea-game.org
+prod.triplea-game.org reverse_proxy_server_name=prod.triplea-game.org
 
 [botHosts]
 # Disabled deployment to prod2-bot01, consistently unreachable during deployment

--- a/infrastructure/ansible/roles/lobby_server/templates/etc_nginx_sites_enabled_lobby.conf
+++ b/infrastructure/ansible/roles/lobby_server/templates/etc_nginx_sites_enabled_lobby.conf
@@ -1,4 +1,4 @@
-map $http_Triplea-Version $lobby_port {
+map $http_Triplea_Version $lobby_port {
 {% for version,port in lobby_ports.items()|sort(attribute='1') %}
    {{ version }}  "{{ port }}";
 {% endfor %}
@@ -8,8 +8,8 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_name {{ reverse_proxy_server_name }};
-    ssl_certificate {{ lobby_public_cert_file }};
-    ssl_certificate_key {{ lobby_private_key_file }};
+    ssl_certificate /etc/letsencrypt/live/prod.triplea-game.org-0001/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/prod.triplea-game.org-0001/privkey.pem; # managed by Certbot
 
     ssl_protocols  TLSv1.2 TLSv1.3;
     ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
@@ -29,7 +29,7 @@ server {
     add_header X-XSS-Protection "1; mode=block";
 
     location / {
-      proxy_pass              http://localhost:$lobby_port;
+      proxy_pass              http://127.0.0.1:$lobby_port;
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -38,7 +38,7 @@ server {
     }
 
     location /game-connection/ws {
-      proxy_pass              http://localhost:$lobby_port;
+      proxy_pass              http://127.0.0.1:$lobby_port;
       proxy_http_version      1.1;
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
@@ -50,7 +50,7 @@ server {
     }
 
     location /player-connection/ws {
-      proxy_pass              http://localhost:$lobby_port;
+      proxy_pass              http://127.0.0.1:$lobby_port;
       proxy_http_version      1.1;
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
@@ -60,5 +60,6 @@ server {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
+
 }
 


### PR DESCRIPTION
(1) Fix mapping statement to match header name

Nginx automatically converts dashes in headers
to underscores. In nginx config, we need to
specify header names with underscores.

(2) Update SSL cert paths as managed by certbot

(3) Use IP address instead of localhost

Nginx uses a resolver when there is a variable in 'proxy_pass'
to resolve the proxy_pass hostname.
See: https://stackoverflow.com/questions/17685674/nginx-proxy-pass-with-remote-addr
So, when we have a variable in 'proxy_pass', we are required
to specify a 'resolver' directive. We do not need a resolver
at all and instead can use the IP address of localhost directly.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
