### PR TITLE
Infra: disable dropwizard admin connectors (avoid port conflict)

### DIFF
--- a/spitfire-server/dropwizard-server/configuration.yml
+++ b/spitfire-server/dropwizard-server/configuration.yml
@@ -88,3 +88,4 @@ server:
       # for all other environments that do have a NGINX server, the value should be
       # set to true.
       useForwardedHeaders: ${USE_FORWARDED_HEADERS:-false}
+  adminConnectors: []


### PR DESCRIPTION
Admin connectors are not used, yet we open port 8081 for it and
this prevents us from running multiple lobbies on the same machine.
To resolve this, we can disable the admin connectors and not require
the port.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
