### PR TITLE
Infra: Clean up use of generate-self-cert toggle

### DIFF
--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -42,3 +42,8 @@ lobby_public_cert_file: "{{ lobby_public_cert_folder }}/cert.crt"
 lobby_private_key_file: "{{ lobby_public_cert_folder }}//cert.key"
 
 lobby_dhparam_file: "/etc/nginx/dhparam.pem"
+
+# Whether we should generate self signed SSL certs, suitable
+# for a dev environment where we are not using letsencrypt to
+# obtain certs.
+nginx_generate_self_signed_cert: false

--- a/infrastructure/ansible/roles/nginx/generate_self_signed_cert/defaults/main.yml
+++ b/infrastructure/ansible/roles/nginx/generate_self_signed_cert/defaults/main.yml
@@ -1,4 +1,3 @@
-nginx_generate_self_signed_cert: true
 ssl_cert_folder: ""
 ssl_cert_key: ""
 ssl_cert: ""

--- a/infrastructure/ansible/roles/nginx/generate_self_signed_cert/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/generate_self_signed_cert/tasks/main.yml
@@ -14,7 +14,6 @@
     mode: "0770"
 
 - name: create SSL keys if needed
-  when: nginx_generate_self_signed_cert
   command: |
     openssl req -x509 -nodes -days 365 \
        -newkey rsa:4096 -keyout {{ ssl_cert_key }} -out {{ ssl_cert }} \


### PR DESCRIPTION
We already toggle whether we generate self signed certs
when we include the role. This update cleans up an
extraneous 'when' clause and places the default
value for the toggle with the role that uses it.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
