### PR TITLE
Infra: do not restart lobby on deployment

### DIFF
--- a/infrastructure/ansible/roles/lobby_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/tasks/main.yml
@@ -78,18 +78,19 @@
     owner: "{{ lobby_user }}"
     group: "{{ lobby_user }}"
 
-- name: install systemd service script
+- name: install systemd service file
   register: service_script
   template:
     src: lobby_server.service.j2
     dest: /lib/systemd/system/{{ lobby_name }}.service
     mode: "644"
 
-- name: restart service if new artifact was deployed
-  when: (lobby_restart_on_new_deployment) and ((deploy_artifact.changed) or (service_script.changed))
+# Ideally we would restart the lobby if we update it to run the new version.
+# We do not want to disconnect users, so we do not restart the lobby.
+- name: ensure lobby is started
   systemd:
     name: "{{ lobby_name }}"
-    state: restarted
+    state: started
     enabled: yes
     daemon_reload: true
 


### PR DESCRIPTION
Just ensure we start the lobby up. A restart right now would
disconnect users, something we do not want.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
