### PR TITLE
Server: strip possible square brackets from 'getRemoteAddr'

### DIFF
--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/dropwizard/common/IpAddressExtractor.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/dropwizard/common/IpAddressExtractor.java
@@ -1,0 +1,23 @@
+package org.triplea.dropwizard.common;
+
+import javax.servlet.http.HttpServletRequest;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class IpAddressExtractor {
+
+  /**
+   * Extracts the IP address of the remote address making an HttpServletRequest.
+   *
+   * <p>httpServletRequest.getRemoteAddr() can return a value surrounded by square brackets. This
+   * method will return that remote addr with square brackets stripped.
+   *
+   * @return valid IP address of the remote machine making
+   */
+  public String extractIpAddress(HttpServletRequest httpServletRequest) {
+    return httpServletRequest
+        .getRemoteAddr() //
+        .replaceAll("\\[", "")
+        .replaceAll("\\]", "");
+  }
+}

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/access/authorization/BannedPlayerFilter.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/access/authorization/BannedPlayerFilter.java
@@ -19,6 +19,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.jdbi.v3.core.Jdbi;
 import org.triplea.db.dao.user.ban.BanLookupRecord;
 import org.triplea.db.dao.user.ban.UserBanDao;
+import org.triplea.dropwizard.common.IpAddressExtractor;
 import org.triplea.http.client.LobbyHttpClientConfig;
 import org.triplea.http.client.lobby.moderator.BanDurationFormatter;
 import org.triplea.spitfire.server.ResponseStatus;
@@ -49,7 +50,8 @@ public class BannedPlayerFilter implements ContainerRequestFilter {
       // check if user is banned, if so abort the request
       userBanDao
           .lookupBan(
-              request.getRemoteAddr(), request.getHeader(LobbyHttpClientConfig.SYSTEM_ID_HEADER))
+              IpAddressExtractor.extractIpAddress(request),
+              request.getHeader(LobbyHttpClientConfig.SYSTEM_ID_HEADER))
           .map(this::formatBanMessage)
           .ifPresent(
               banMessage ->

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/ErrorReportController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/ErrorReportController.java
@@ -9,6 +9,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import lombok.Builder;
 import org.jdbi.v3.core.Jdbi;
+import org.triplea.dropwizard.common.IpAddressExtractor;
 import org.triplea.http.client.LobbyHttpClientConfig;
 import org.triplea.http.client.error.report.CanUploadErrorReportResponse;
 import org.triplea.http.client.error.report.CanUploadRequest;
@@ -83,7 +84,7 @@ public class ErrorReportController extends HttpController {
 
     return errorReportIngestion.apply(
         CreateIssueParams.builder()
-            .ip(request.getRemoteAddr())
+            .ip(IpAddressExtractor.extractIpAddress(request))
             .systemId(request.getHeader(LobbyHttpClientConfig.SYSTEM_ID_HEADER))
             .errorReportRequest(errorReport)
             .build());

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/lobby/GameHostingController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/lobby/GameHostingController.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import org.jdbi.v3.core.Jdbi;
 import org.triplea.db.dao.api.key.GameHostingApiKeyDaoWrapper;
 import org.triplea.domain.data.ApiKey;
+import org.triplea.dropwizard.common.IpAddressExtractor;
 import org.triplea.http.client.lobby.game.hosting.request.GameHostingClient;
 import org.triplea.http.client.lobby.game.hosting.request.GameHostingResponse;
 import org.triplea.spitfire.server.HttpController;
@@ -36,14 +37,14 @@ public class GameHostingController extends HttpController {
   @POST
   @Path(GameHostingClient.GAME_HOSTING_REQUEST_PATH)
   public GameHostingResponse hostingRequest(@Context final HttpServletRequest request) {
+    String remoteIp = IpAddressExtractor.extractIpAddress(request);
     try {
       return GameHostingResponse.builder()
-          .apiKey(apiKeySupplier.apply(InetAddress.getByName(request.getRemoteAddr())).getValue())
-          .publicVisibleIp(request.getRemoteAddr())
+          .apiKey(apiKeySupplier.apply(InetAddress.getByName(remoteIp)).getValue())
+          .publicVisibleIp(remoteIp)
           .build();
     } catch (final UnknownHostException e) {
-      throw new IllegalArgumentException(
-          "Invalid IP address in request: " + request.getRemoteAddr(), e);
+      throw new IllegalArgumentException("Invalid IP address in request: " + remoteIp, e);
     }
   }
 }

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/ForgotPasswordController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/ForgotPasswordController.java
@@ -11,6 +11,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import org.jdbi.v3.core.Jdbi;
+import org.triplea.dropwizard.common.IpAddressExtractor;
 import org.triplea.http.client.forgot.password.ForgotPasswordClient;
 import org.triplea.http.client.forgot.password.ForgotPasswordRequest;
 import org.triplea.http.client.forgot.password.ForgotPasswordResponse;
@@ -46,7 +47,9 @@ public class ForgotPasswordController extends HttpController {
     }
 
     return ForgotPasswordResponse.builder()
-        .responseMessage(forgotPasswordModule.apply(request.getRemoteAddr(), forgotPasswordRequest))
+        .responseMessage(
+            forgotPasswordModule.apply(
+                IpAddressExtractor.extractIpAddress(request), forgotPasswordRequest))
         .build();
   }
 }

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/LoginController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/LoginController.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import org.jdbi.v3.core.Jdbi;
 import org.triplea.domain.data.LobbyConstants;
+import org.triplea.dropwizard.common.IpAddressExtractor;
 import org.triplea.http.client.LobbyHttpClientConfig;
 import org.triplea.http.client.lobby.login.LobbyLoginClient;
 import org.triplea.http.client.lobby.login.LobbyLoginResponse;
@@ -43,6 +44,6 @@ public class LoginController extends HttpController {
     return loginModule.doLogin(
         loginRequest,
         request.getHeader(LobbyHttpClientConfig.SYSTEM_ID_HEADER),
-        request.getRemoteAddr());
+        IpAddressExtractor.extractIpAddress(request));
   }
 }

--- a/spitfire-server/dropwizard-server/src/test/java/org/triplea/dropwizard/common/IpAddressExtractorTest.java
+++ b/spitfire-server/dropwizard-server/src/test/java/org/triplea/dropwizard/common/IpAddressExtractorTest.java
@@ -1,0 +1,47 @@
+package org.triplea.dropwizard.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IpAddressExtractorTest {
+
+  private static final String IPV4 = "127.0.0.1";
+  private static final String IPV6 = "3ffe:1900:4545:3:200:f8ff:fe21:67cf";
+
+  @Mock private HttpServletRequest httpServletRequest;
+
+  @Test
+  void ipv6() {
+    when(httpServletRequest.getRemoteAddr()).thenReturn(IPV6);
+    assertThat(
+        "Normal formatted IPv6 as input should return same value",
+        IpAddressExtractor.extractIpAddress(httpServletRequest),
+        is(IPV6));
+  }
+
+  @Test
+  void ipv6_WithBrackets() {
+    when(httpServletRequest.getRemoteAddr()).thenReturn("[" + IPV6 + "]");
+    assertThat(
+        "Square brackets on the IPv6 should be stripped",
+        IpAddressExtractor.extractIpAddress(httpServletRequest),
+        is(IPV6));
+  }
+
+  @Test
+  void ipv4() {
+    when(httpServletRequest.getRemoteAddr()).thenReturn(IPV4);
+    assertThat(
+        "IPv4 format is returned unaltered",
+        IpAddressExtractor.extractIpAddress(httpServletRequest),
+        is(IPV4));
+  }
+}


### PR DESCRIPTION
'getRemoteAddr' can potentially return IPv6 IP address with square
brackets around them. We need to strip these off for the IPv6 to
be a valid net address (otheriwse the DB will reject these values).

This update adds a utility that can be used to 'getRemoteAddr' and
have the square brackets be stripped.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
