### PR TITLE
Game-Client: run game-notes migration when loading game notes

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -78,13 +78,13 @@ public final class GameParser {
   private static final String RESOURCE_IS_DISPLAY_FOR_NONE = "NONE";
 
   @Nonnull private final GameData data;
-  private final String xmlUri;
+  private final Path xmlUri;
   private final XmlGameElementMapper xmlGameElementMapper;
   private GameDataVariables variables;
   private final Version engineVersion;
 
   private GameParser(
-      final String xmlUri,
+      final Path xmlUri,
       final XmlGameElementMapper xmlGameElementMapper,
       final Version engineVersion) {
     data = new GameData();
@@ -130,7 +130,7 @@ public final class GameParser {
         xmlFile.toUri(),
         inputStream -> {
           try {
-            return new GameParser(xmlFile.toString(), xmlGameElementMapper, engineVersion)
+            return new GameParser(xmlFile, xmlGameElementMapper, engineVersion)
                 .parse(xmlFile, inputStream);
           } catch (final EngineVersionException e) {
             log.warn("Game engine not compatible with: " + xmlFile, e);

--- a/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -43,7 +43,6 @@ import org.triplea.http.client.LobbyHttpClientConfig;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.ThreadRunner;
 import org.triplea.map.description.file.MapDescriptionYamlGeneratorRunner;
-import org.triplea.map.game.notes.GameNotesMigrator;
 import org.triplea.swing.SwingAction;
 import org.triplea.util.ExitStatus;
 
@@ -126,13 +125,6 @@ public final class HeadedGameRunner {
                 BackgroundTaskRunner.runInBackground("Generating map descriptor files", unzipTask))
         .build()
         .generateYamlFiles();
-
-    GameNotesMigrator.builder()
-        .downloadedMapsFolder(ClientFileSystemHelper.getUserMapsFolder())
-        .progressIndicator(
-            unzipTask -> BackgroundTaskRunner.runInBackground("Migrating game notes..", unzipTask))
-        .build()
-        .extractGameNotes();
 
     log.info("Launching game, version: {} ", ProductVersionReader.getCurrentVersion());
     start();

--- a/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotes.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotes.java
@@ -27,6 +27,9 @@ public class GameNotes {
     final String notesFileName = createExpectedNotesFileName(xmlGameFile);
     final Path notesFile = xmlGameFile.resolveSibling(notesFileName);
 
+    if (!Files.exists(notesFile)) {
+      GameNotesMigrator.extractGameNotes(xmlGameFile);
+    }
     return Files.exists(notesFile) ? FileUtils.readContents(notesFile).orElse("") : "";
   }
 

--- a/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotesMigrator.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotesMigrator.java
@@ -1,13 +1,7 @@
 package org.triplea.map.game.notes;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.generic.xml.reader.XmlMapper;
@@ -24,54 +18,18 @@ import org.triplea.map.data.elements.PropertyList;
 @Builder
 @Slf4j
 public class GameNotesMigrator {
-
-  /** Callback to be invoked if we start generating YAML files. */
-  private final Consumer<Runnable> progressIndicator;
-
-  /** Path to where downloaded maps can be found. */
-  private final Path downloadedMapsFolder;
-
-  public void extractGameNotes() {
-    final Collection<Path> xmlFilesMissingGameNotesFile =
-        findAllGameXmlFiles(downloadedMapsFolder).stream()
-            .filter(Predicate.not(GameNotes::gameNotesFileExistsForGameXmlFile))
-            .collect(Collectors.toSet());
-
-    // For each game XML missing a game-notes file, generate the game-notes file.
-    // If we have a number of game notes files to create, run in a progress dialog.
-
-    final Runnable migrationJob =
-        () ->
-            xmlFilesMissingGameNotesFile.forEach(
-                xmlGameFile -> {
-                  final String gameNotes = readGameNotesFromXml(xmlGameFile);
-                  final String fileNameToWrite = GameNotes.createExpectedNotesFileName(xmlGameFile);
-                  final Path fileToWrite = xmlGameFile.resolveSibling(fileNameToWrite);
-                  log.info("Writing game notes file: " + fileToWrite.toAbsolutePath());
-                  FileUtils.writeToFile(fileToWrite, gameNotes);
-                });
-
-    if (xmlFilesMissingGameNotesFile.size() > 3) {
-      progressIndicator.accept(migrationJob);
-    } else {
-      migrationJob.run();
+  public static void extractGameNotes(Path xmlGameFile) {
+    if (GameNotes.gameNotesFileExistsForGameXmlFile(xmlGameFile)) {
+      return;
     }
+    final String gameNotes = readGameNotesFromXml(xmlGameFile);
+    final String fileNameToWrite = GameNotes.createExpectedNotesFileName(xmlGameFile);
+    final Path fileToWrite = xmlGameFile.resolveSibling(fileNameToWrite);
+    log.info("Writing game notes file: " + fileToWrite.toAbsolutePath());
+    FileUtils.writeToFile(fileToWrite, gameNotes);
   }
 
-  private Collection<Path> findAllGameXmlFiles(final Path rootPath) {
-    final Collection<Path> xmlFiles = new ArrayList<>();
-
-    for (final Path child : FileUtils.listFiles(rootPath)) {
-      if (Files.isDirectory(child) && child.getFileName().toString().equalsIgnoreCase("games")) {
-        xmlFiles.addAll(FileUtils.findXmlFiles(child, 1));
-      } else if (Files.isDirectory(child)) {
-        xmlFiles.addAll(findAllGameXmlFiles(child));
-      }
-    }
-    return xmlFiles;
-  }
-
-  private String readGameNotesFromXml(final Path xmlGameFile) {
+  private static String readGameNotesFromXml(final Path xmlGameFile) {
     final Game game =
         FileUtils.openInputStream(
             xmlGameFile,
@@ -104,7 +62,7 @@ public class GameNotesMigrator {
         .orElse("");
   }
 
-  private Optional<PropertyList.Property> getGameNotesProperty(final Game game) {
+  private static Optional<PropertyList.Property> getGameNotesProperty(final Game game) {
     return game.getPropertyList().getProperties().stream()
         .filter(property -> property.getName() != null)
         .filter(property -> property.getName().equalsIgnoreCase("notes"))


### PR DESCRIPTION
Performance improvement. Moves "xml" to "html" game-note
migration from program launch to instead be done (on-demand)
when we read game-notes.

This avoids a possible performance hit when launching the game.
'PerfTimer' has the game notes migration process as needing
about 30ms (so we are adding a pretty minimal one-time time
cost to reading game notes)

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
