### PR TITLE
Fix code to handle newer savegame json response

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
@@ -111,19 +111,6 @@ public class NodeBbForumPoster {
     }
   }
 
-  private String appendOptionalSaveGameLink(
-      final String text,
-      final CloseableHttpClient client,
-      final String token,
-      @Nullable final SaveGameParameter saveGame)
-      throws IOException {
-    if (saveGame == null) {
-      return text;
-    }
-    final String saveGameUrl = uploadSaveGame(client, token, saveGame);
-    return text + "\n[Savegame](" + saveGameUrl + ")";
-  }
-
   private void post(
       final CloseableHttpClient client,
       final String token,
@@ -150,6 +137,19 @@ public class NodeBbForumPoster {
             String.format("Forum responded with code %s%s", code, message));
       }
     }
+  }
+
+  private String appendOptionalSaveGameLink(
+      final String text,
+      final CloseableHttpClient client,
+      final String token,
+      @Nullable final SaveGameParameter saveGame)
+      throws IOException {
+    if (saveGame == null) {
+      return text;
+    }
+    final String saveGameUrl = uploadSaveGame(client, token, saveGame);
+    return text + "\n[Savegame](" + saveGameUrl + ")";
   }
 
   private String uploadSaveGame(

--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
@@ -178,7 +178,7 @@ public class NodeBbForumPoster {
           .get("images") // get images element of the response
           .get(0) // get first element of the images list (we expect only one)
           .get("url");
-    } catch(NullPointerException e) {
+    } catch (NullPointerException e) {
       throw new UnableToParseResponseException(json, e);
     } catch (YamlReader.InvalidYamlFormatException ignored) {
       // This is expected for older forum versions that return a list as top level item
@@ -196,12 +196,14 @@ public class NodeBbForumPoster {
     private static final long serialVersionUID = -4435748866723675027L;
 
     UnableToParseResponseException(String json, Exception cause) {
-      super("Unexpected forum response when uploading save game.\n"
-          + "Please report this to TripleA.\n"
-          + "Unable to properly attach save-game to forum post.\n"
-          + "You will need to manually attach a save-game to the latest forum post.\n"
-          + "Forums response was: "
-          + json, cause);
+      super(
+          "Unexpected forum response when uploading save game.\n"
+              + "Please report this to TripleA.\n"
+              + "Unable to properly attach save-game to forum post.\n"
+              + "You will need to manually attach a save-game to the latest forum post.\n"
+              + "Forums response was: "
+              + json,
+          cause);
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
@@ -111,11 +111,16 @@ public class NodeBbForumPoster {
     }
   }
 
-  private static String appendOptionalSaveGameLink(
-      final String text, @Nullable final String saveGameUrl) {
-    if (saveGameUrl == null) {
+  private String appendOptionalSaveGameLink(
+      final String text,
+      final CloseableHttpClient client,
+      final String token,
+      @Nullable final SaveGameParameter saveGame)
+      throws IOException {
+    if (saveGame == null) {
       return text;
     }
+    final String saveGameUrl = uploadSaveGame(client, token, saveGame);
     return text + "\n[Savegame](" + saveGameUrl + ")";
   }
 
@@ -131,9 +136,7 @@ public class NodeBbForumPoster {
         new UrlEncodedFormEntity(
             List.of(
                 new BasicNameValuePair(
-                    "content",
-                    appendOptionalSaveGameLink(
-                        text, saveGame != null ? uploadSaveGame(client, token, saveGame) : null))),
+                    "content", appendOptionalSaveGameLink(text, client, token, saveGame))),
             StandardCharsets.UTF_8));
     HttpProxy.addProxy(post);
     try (CloseableHttpResponse response = client.execute(post)) {

--- a/game-app/game-core/src/test/java/games/strategy/engine/posted/game/pbf/NodeBbForumPosterTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/posted/game/pbf/NodeBbForumPosterTest.java
@@ -1,0 +1,29 @@
+package games.strategy.engine.posted.game.pbf;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+import org.triplea.test.common.TestDataFileReader;
+
+class NodeBbForumPosterTest {
+
+  /** sample response from https://forums.triplea-game.org/ */
+  @Test
+  void uploadResponseParsing_tripleaForums() {
+    String sampleResponse =
+        TestDataFileReader.readContents("forums/upload_response_triplea_forums.json");
+    String saveGameUrl = NodeBbForumPoster.parseSaveGameUrlFromJsonResponse(sampleResponse);
+    assertThat(saveGameUrl, is("/assets/uploads/files/1665366598238-triplea_3321_1car.tsvg"));
+  }
+
+  /** sample response from https://www.axisandallies.org/ */
+  @Test
+  void uploadResponseParsing_axisAndAlliesOrg() {
+    String sampleResponse =
+        TestDataFileReader.readContents("forums/upload_response_axis_and_allies_org.json");
+    String saveGameUrl = NodeBbForumPoster.parseSaveGameUrlFromJsonResponse(sampleResponse);
+    assertThat(
+        saveGameUrl, is("/forums/assets/uploads/files/1665368873282-triplea_20781_1car.tsvg"));
+  }
+}

--- a/game-app/game-core/src/test/resources/forums/upload_response_axis_and_allies_org.json
+++ b/game-app/game-core/src/test/resources/forums/upload_response_axis_and_allies_org.json
@@ -1,0 +1,15 @@
+{
+  "response" : {
+    "images" : [
+      {
+        "name" : "triplea_20781_1Car.tsvg",
+        "path" : "/var/srv/nodebb/public/uploads/files/1665368873282-triplea_20781_1car.tsvg",
+        "url" : "/forums/assets/uploads/files/1665368873282-triplea_20781_1car.tsvg"
+      }
+    ]
+  },
+  "status" : {
+    "code" : "ok",
+    "message" : "OK"
+  }
+}

--- a/game-app/game-core/src/test/resources/forums/upload_response_triplea_forums.json
+++ b/game-app/game-core/src/test/resources/forums/upload_response_triplea_forums.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name" : "triplea_3321_1Car.tsvg",
+    "path" : "/opt/nodebb/public/uploads/files/1665366598238-triplea_3321_1car.tsvg",
+    "url" : "/assets/uploads/files/1665366598238-triplea_3321_1car.tsvg"
+  }
+]


### PR DESCRIPTION
## Change Summary & Additional Notes

Fixes #11056

This changes the code to accept the newer JSON format instead of silently printing null when it arrives.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Links to uploaded savegames are no longer 'null' on newer versions of NodeBB<!--END_RELEASE_NOTE-->
