### PR TITLE
(docs-only) Fix IDE setup link in dev README

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -12,7 +12,7 @@
 
 - Fork: <https://github.com/triplea-game/triplea>
 - Using your favorite git-client, clone the newly forked repository 
-- Setup IDE: [/docs/development/how-to/ide-setup](../how-to/ide-setup>)
+- Setup IDE: [/docs/development/how-to/ide-setup](how-to/ide-setup)
 - Use a feature-branch workflow, see: [typical git workflow](reference/typical-git-workflow.md))
 - Submit pull request, see: [pull requests process](../project/pull-requests.md).
 


### PR DESCRIPTION
## Change Summary & Additional Notes
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->
Docs-only change. Fixed a broken link in the development environment setup README.

I forked the repo and confirmed that the link works in the version in my repo.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->
[This doesn't merit a mention in the release notes. The game itself won't be affected.]

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
