### PR TITLE
Websocket Relay: add various websocket alternatives for network communication

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -2,6 +2,7 @@ package games.strategy.engine.chat;
 
 import games.strategy.engine.chat.ChatMessagePanel.ChatSoundProfile;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import javax.swing.DefaultListCellRenderer;
@@ -47,8 +48,12 @@ public class ChatPanel extends JPanel implements ChatModel {
    * the UI might freeze for a long time.
    */
   public static ChatPanel newChatPanel(
-      final Messengers messengers, final String chatName, final ChatSoundProfile chatSoundProfile) {
-    final Chat chat = new Chat(new MessengersChatTransmitter(chatName, messengers));
+      final Messengers messengers,
+      final String chatName,
+      final ChatSoundProfile chatSoundProfile,
+      final ClientNetworkBridge clientNetworkBridge) {
+    final Chat chat =
+        new Chat(new MessengersChatTransmitter(chatName, messengers, clientNetworkBridge));
     final ClipPlayer clipPlayer = new ClipPlayer();
     return Interruptibles.awaitResult(
             () ->

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
@@ -2,8 +2,13 @@ package games.strategy.engine.chat;
 
 import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.engine.message.RemoteActionCode;
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
 import org.triplea.domain.data.ChatParticipant;
 import org.triplea.domain.data.UserName;
+import org.triplea.http.client.web.socket.MessageEnvelope;
+import org.triplea.http.client.web.socket.messages.MessageType;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 
 /** Chat messages occur on this channel. */
 public interface IChatChannel extends IChannelSubscriber {
@@ -11,21 +16,118 @@ public interface IChatChannel extends IChannelSubscriber {
   @RemoteActionCode(0)
   void chatOccurred(String message);
 
+  @AllArgsConstructor
+  class ChatMessage implements WebSocketMessage {
+    public static final MessageType<ChatMessage> TYPE = MessageType.of(ChatMessage.class);
+
+    @Nonnull private final String message;
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void invokeCallback(IChatChannel iChatChannel) {
+      iChatChannel.chatOccurred(message);
+    }
+  }
+
   @RemoteActionCode(2)
   void slapOccurred(UserName userName);
+
+  @AllArgsConstructor
+  class SlapMessage implements WebSocketMessage {
+    public static final MessageType<SlapMessage> TYPE = MessageType.of(SlapMessage.class);
+
+    @Nonnull private final UserName userName;
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void invokeCallback(IChatChannel iChatChannel) {
+      iChatChannel.slapOccurred(userName);
+    }
+  }
 
   @RemoteActionCode(3)
   void speakerAdded(ChatParticipant chatParticipant);
 
+  @AllArgsConstructor
+  class SpeakAddedMessage implements WebSocketMessage {
+    public static final MessageType<SpeakAddedMessage> TYPE =
+        MessageType.of(SpeakAddedMessage.class);
+
+    @Nonnull private final ChatParticipant chatParticipant;
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void invokeCallback(IChatChannel iChatChannel) {
+      iChatChannel.speakerAdded(chatParticipant);
+    }
+  }
+
   @RemoteActionCode(4)
   void speakerRemoved(UserName userName);
 
+  @AllArgsConstructor
+  class SpeakerRemovedMessage implements WebSocketMessage {
+    public static final MessageType<SpeakerRemovedMessage> TYPE =
+        MessageType.of(SpeakerRemovedMessage.class);
+
+    @Nonnull private final String userName;
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void invokeCallback(IChatChannel iChatChannel) {
+      iChatChannel.speakerRemoved(UserName.of(userName));
+    }
+  }
+
   // purely here to keep connections open and stop NATs and crap from thinking that our connection
-  // is closed when it is
-  // not.
+  // is closed when it is not.
   @RemoteActionCode(1)
   void ping();
 
+  @AllArgsConstructor
+  class PingMessage implements WebSocketMessage {
+    public static final MessageType<PingMessage> TYPE = MessageType.of(PingMessage.class);
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void invokeCallback(IChatChannel iChatChannel) {
+      iChatChannel.ping();
+    }
+  }
+
   @RemoteActionCode(5)
   void statusChanged(UserName userName, String status);
+
+  @AllArgsConstructor
+  class StatusChangedMessage implements WebSocketMessage {
+    public static final MessageType<StatusChangedMessage> TYPE =
+        MessageType.of(StatusChangedMessage.class);
+
+    private final UserName userName;
+    private final String status;
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void invokeCallback(IChatChannel iChatChannel) {
+      iChatChannel.statusChanged(userName, status);
+    }
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/IChatController.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/IChatController.java
@@ -28,10 +28,10 @@ public interface IChatController extends IRemote {
 
   @AllArgsConstructor
   class SetChatStatusMessage implements WebSocketMessage {
-    public static final MessageType<SetChatStatusMessage> TYPE = MessageType.of(SetChatStatusMessage.class);
+    public static final MessageType<SetChatStatusMessage> TYPE =
+        MessageType.of(SetChatStatusMessage.class);
 
-    @Nonnull
-    private final String status;
+    @Nonnull private final String status;
 
     @Override
     public MessageEnvelope toEnvelope() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/IChatController.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/IChatController.java
@@ -3,7 +3,12 @@ package games.strategy.engine.chat;
 import games.strategy.engine.message.IRemote;
 import games.strategy.engine.message.RemoteActionCode;
 import java.util.Collection;
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
 import org.triplea.domain.data.ChatParticipant;
+import org.triplea.http.client.web.socket.MessageEnvelope;
+import org.triplea.http.client.web.socket.messages.MessageType;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 
 /**
  * A central controller of who is in the chat.
@@ -15,15 +20,30 @@ public interface IChatController extends IRemote {
   @RemoteActionCode(0)
   Collection<ChatParticipant> joinChat();
 
-  /** Leave the chat, and ask that everyone stops bothering me. */
   @RemoteActionCode(1)
   void leaveChat();
 
   @RemoteActionCode(2)
   void setStatus(String newStatus);
 
+  @AllArgsConstructor
+  class SetChatStatusMessage implements WebSocketMessage {
+    public static final MessageType<SetChatStatusMessage> TYPE = MessageType.of(SetChatStatusMessage.class);
+
+    @Nonnull
+    private final String status;
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void invokeCallback(IChatController iChatController) {
+      iChatController.setStatus(status);
+    }
+  }
+
   /** A tag associated with a chat participant indicating the participant's role. */
-  // TODO: rename to Role upon next lobby-incompatible release
   enum Tag {
     MODERATOR,
     NONE

--- a/game-app/game-core/src/main/java/games/strategy/engine/delegate/IDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/delegate/IDelegate.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.delegate;
 
 import games.strategy.engine.message.IRemote;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import java.io.Serializable;
 
 /**
@@ -15,6 +16,8 @@ import java.io.Serializable;
 public interface IDelegate {
   /** Uses name as the internal unique name and displayName for display to users. */
   void initialize(String name, String displayName);
+
+  void setDelegateBridgeAndPlayer(IDelegateBridge delegateBridge, ClientNetworkBridge clientNetworkBridge);
 
   /**
    * Called before the delegate will run and before "start" is called.

--- a/game-app/game-core/src/main/java/games/strategy/engine/delegate/IDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/delegate/IDelegate.java
@@ -17,7 +17,8 @@ public interface IDelegate {
   /** Uses name as the internal unique name and displayName for display to users. */
   void initialize(String name, String displayName);
 
-  void setDelegateBridgeAndPlayer(IDelegateBridge delegateBridge, ClientNetworkBridge clientNetworkBridge);
+  void setDelegateBridgeAndPlayer(
+      IDelegateBridge delegateBridge, ClientNetworkBridge clientNetworkBridge);
 
   /**
    * Called before the delegate will run and before "start" is called.

--- a/game-app/game-core/src/main/java/games/strategy/engine/display/IDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/display/IDisplay.java
@@ -44,7 +44,8 @@ public interface IDisplay extends IChannelSubscriber {
   @Builder
   @AllArgsConstructor
   class BroadcastMessageMessage implements WebSocketMessage {
-    public static final MessageType<BroadcastMessageMessage> TYPE = MessageType.of(BroadcastMessageMessage.class);
+    public static final MessageType<BroadcastMessageMessage> TYPE =
+        MessageType.of(BroadcastMessageMessage.class);
 
     @Nonnull private final String message;
     @Nonnull private final String title;
@@ -58,7 +59,6 @@ public interface IDisplay extends IChannelSubscriber {
       iDisplay.reportMessageToAll(message, title, true, false, true);
     }
   }
-
 
   /**
    * Sends a message to all TripleAFrame's that are playing AND are controlling one or more of the
@@ -248,7 +248,8 @@ public interface IDisplay extends IChannelSubscriber {
     private final double diceRollExpectedHits;
     private final String playerName;
 
-    public NotifyDiceMessage(final DiceRoll diceRoll, final String stepName, final String playerName) {
+    public NotifyDiceMessage(
+        final DiceRoll diceRoll, final String stepName, final String playerName) {
       this.stepName = stepName;
       diceRollExpectedHits = diceRoll.getExpectedHits();
       diceRollHits = diceRoll.getHits();

--- a/game-app/game-core/src/main/java/games/strategy/engine/display/IDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/display/IDisplay.java
@@ -1,8 +1,10 @@
 package games.strategy.engine.display;
 
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.PlayerList;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitsList;
 import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.engine.message.RemoteActionCode;
 import games.strategy.triplea.delegate.DiceRoll;
@@ -12,6 +14,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+import org.triplea.http.client.web.socket.MessageEnvelope;
+import org.triplea.http.client.web.socket.messages.MessageType;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 import org.triplea.java.RemoveOnNextMajorRelease;
 
 /**
@@ -29,6 +40,25 @@ public interface IDisplay extends IChannelSubscriber {
       boolean doNotIncludeHost,
       boolean doNotIncludeClients,
       boolean doNotIncludeObservers);
+
+  @Builder
+  @AllArgsConstructor
+  class BroadcastMessageMessage implements WebSocketMessage {
+    public static final MessageType<BroadcastMessageMessage> TYPE = MessageType.of(BroadcastMessageMessage.class);
+
+    @Nonnull private final String message;
+    @Nonnull private final String title;
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void invokeCallback(IDisplay iDisplay) {
+      iDisplay.reportMessageToAll(message, title, true, false, true);
+    }
+  }
+
 
   /**
    * Sends a message to all TripleAFrame's that are playing AND are controlling one or more of the
@@ -118,20 +148,189 @@ public interface IDisplay extends IChannelSubscriber {
   @RemoteActionCode(1)
   void bombingResults(UUID battleId, List<Die> dice, int cost);
 
+  class BombingResultsMessage implements WebSocketMessage {
+    public static final MessageType<IDisplay.BombingResultsMessage> TYPE =
+        MessageType.of(IDisplay.BombingResultsMessage.class);
+
+    private final String battleId;
+    private final List<DieRollData> diceData;
+    private final Integer cost;
+
+    public BombingResultsMessage(final UUID battleId, final List<Die> dice, final int cost) {
+      this.battleId = battleId.toString();
+      this.diceData = dice.stream().map(DieRollData::new).collect(Collectors.toList());
+      this.cost = cost;
+    }
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void accept(final IDisplay display) {
+      display.bombingResults(UUID.fromString(battleId), DieRollData.toDieList(diceData), cost);
+    }
+  }
+
   /** Notify that the given player has retreated some or all of his units. */
   @RemoteActionCode(9)
   void notifyRetreat(String shortMessage, String message, String step, GamePlayer retreatingPlayer);
 
+  @Builder
+  class NotifyRetreatMessage implements WebSocketMessage {
+    public static final MessageType<NotifyRetreatMessage> TYPE =
+        MessageType.of(NotifyRetreatMessage.class);
+
+    @Nonnull private final String shortMessage;
+    @Nonnull private final String message;
+    @Nonnull private final String step;
+    @Nonnull private final String retreatingPlayerName;
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void accept(final IDisplay display, final PlayerList playerlist) {
+      display.notifyRetreat(
+          shortMessage, message, step, playerlist.getPlayerId(retreatingPlayerName));
+    }
+  }
+
   @RemoteActionCode(8)
   void notifyRetreat(UUID battleId, Collection<Unit> retreating);
+
+  class NotifyUnitsRetreatingMessage implements WebSocketMessage {
+    public static final MessageType<NotifyUnitsRetreatingMessage> TYPE =
+        MessageType.of(NotifyUnitsRetreatingMessage.class);
+
+    @Nonnull private final String battleId;
+    @Nonnull private final Collection<String> retreatingUnitIds;
+
+    public NotifyUnitsRetreatingMessage(
+        final UUID battleId, final Collection<Unit> retreatingUnits) {
+      this.battleId = battleId.toString();
+      this.retreatingUnitIds =
+          retreatingUnits.stream()
+              .map(Unit::getId)
+              .map(UUID::toString)
+              .collect(Collectors.toList());
+    }
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void accept(final IDisplay display, final UnitsList unitsList) {
+      display.notifyRetreat(
+          UUID.fromString(battleId),
+          retreatingUnitIds.stream()
+              .map(UUID::fromString)
+              .map(unitsList::get)
+              .collect(Collectors.toList()));
+    }
+  }
 
   /** Show dice for the given battle and step. */
   @RemoteActionCode(7)
   void notifyDice(DiceRoll dice, String stepName);
 
+  @Builder
+  @AllArgsConstructor
+  class NotifyDiceMessage implements WebSocketMessage {
+    public static final MessageType<NotifyDiceMessage> TYPE =
+        MessageType.of(NotifyDiceMessage.class);
+
+    private final String stepName;
+    private final List<DieRollData> diceRollData;
+    private final int diceRollHits;
+    private final double diceRollExpectedHits;
+    private final String playerName;
+
+    public NotifyDiceMessage(final DiceRoll diceRoll, final String stepName, final String playerName) {
+      this.stepName = stepName;
+      diceRollExpectedHits = diceRoll.getExpectedHits();
+      diceRollHits = diceRoll.getHits();
+      diceRollData =
+          diceRoll.getRolls().stream().map(DieRollData::new).collect(Collectors.toList());
+      this.playerName = playerName;
+    }
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    public void accept(final IDisplay display) {
+      final List<Die> rolls = DieRollData.toDieList(diceRollData);
+      DiceRoll diceRoll = new DiceRoll(rolls, diceRollHits, diceRollExpectedHits, playerName);
+      display.notifyDice(diceRoll, stepName);
+    }
+  }
+
   @RemoteActionCode(5)
   void gotoBattleStep(UUID battleId, String step);
 
+  @AllArgsConstructor
+  class GoToBattleStepMessage implements WebSocketMessage, Consumer<IDisplay> {
+    public static final MessageType<GoToBattleStepMessage> TYPE =
+        MessageType.of(GoToBattleStepMessage.class);
+
+    private final String battleStepUuid;
+    private final String battleStepName;
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    @Override
+    public void accept(final IDisplay display) {
+      display.gotoBattleStep(UUID.fromString(battleStepUuid), battleStepName);
+    }
+  }
+
   @RemoteActionCode(13)
   void shutDown();
+
+  class DisplayShutdownMessage implements WebSocketMessage, Consumer<IDisplay> {
+    public static final MessageType<DisplayShutdownMessage> TYPE =
+        MessageType.of(DisplayShutdownMessage.class);
+
+    @Override
+    public MessageEnvelope toEnvelope() {
+      return MessageEnvelope.packageMessage(TYPE, this);
+    }
+
+    @Override
+    public void accept(final IDisplay display) {
+      display.shutDown();
+    }
+  }
+
+  @Value
+  class DieRollData {
+    String type;
+    int rolledAt;
+    int value;
+
+    public DieRollData(final Die die) {
+      this.type = die.getType().toString();
+      this.rolledAt = die.getRolledAt();
+      this.value = die.getValue();
+    }
+
+    static List<Die> toDieList(final List<DieRollData> diceRollData) {
+      return diceRollData.stream()
+          .map(
+              dieRollData ->
+                  Die.builder()
+                      .rolledAt(dieRollData.rolledAt)
+                      .value(dieRollData.value)
+                      .type(Die.DieType.valueOf(dieRollData.type))
+                      .build())
+          .collect(Collectors.toList());
+    }
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -40,12 +40,7 @@ public abstract class AbstractGame implements IGame {
   final Map<GamePlayer, Player> gamePlayers = new HashMap<>();
   final PlayerManager playerManager;
 
-  // TODO: Project#20 - clientNetworkBridge will be used for Websocket network bridge.
-  //   Usages will basically be to add listeners to map message types to methods calls.
-  //   The mapped method calls will replace the existing RMI-style based network code.
-  @SuppressWarnings({"FieldCanBeLocal", "unused"})
   private final ClientNetworkBridge clientNetworkBridge;
-
   @Nullable private IDisplay display;
   @Nullable private ISound sound;
 
@@ -134,6 +129,21 @@ public abstract class AbstractGame implements IGame {
     }
     if (display != null) {
       messengers.registerChannelSubscriber(display, getDisplayChannel());
+
+      clientNetworkBridge.addListener(
+          IDisplay.BombingResultsMessage.TYPE, message -> message.accept(display));
+      clientNetworkBridge.addListener(
+          IDisplay.NotifyRetreatMessage.TYPE,
+          message -> message.accept(display, gameData.getPlayerList()));
+      clientNetworkBridge.addListener(
+          IDisplay.NotifyUnitsRetreatingMessage.TYPE,
+          message -> message.accept(display, gameData.getUnits()));
+      clientNetworkBridge.addListener(
+          IDisplay.NotifyDiceMessage.TYPE, message -> message.accept(display));
+      clientNetworkBridge.addListener(
+          IDisplay.DisplayShutdownMessage.TYPE, message -> message.accept(display));
+      clientNetworkBridge.addListener(
+          IDisplay.GoToBattleStepMessage.TYPE, message -> message.accept(display));
     }
     this.display = display;
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -534,7 +534,7 @@ public class ServerGame extends AbstractGame {
               delegateRandomSource);
       delegateExecutionManager.enterDelegateExecution();
       try {
-        delegate.setDelegateBridgeAndPlayer(bridge);
+        delegate.setDelegateBridgeAndPlayer(bridge, clientNetworkBridge);
         delegate.start();
       } finally {
         delegateExecutionManager.leaveDelegateExecution();
@@ -571,7 +571,7 @@ public class ServerGame extends AbstractGame {
     delegateExecutionManager.enterDelegateExecution();
     try {
       final IDelegate delegate = getCurrentStep().getDelegate();
-      delegate.setDelegateBridgeAndPlayer(bridge);
+      delegate.setDelegateBridgeAndPlayer(bridge, clientNetworkBridge);
       delegate.start();
     } finally {
       delegateExecutionManager.leaveDelegateExecution();

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LaunchAction.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LaunchAction.java
@@ -13,6 +13,7 @@ import games.strategy.engine.framework.startup.ui.PlayerTypes;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.engine.player.Player;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
@@ -40,7 +41,8 @@ public interface LaunchAction {
 
   AutoSaveFileUtils getAutoSaveFileUtils();
 
-  ChatModel createChatModel(String chatName, Messengers messengers);
+  ChatModel createChatModel(
+      String chatName, Messengers messengers, ClientNetworkBridge clientNetworkBridge);
 
   /**
    * Controls if the AI should be avoided when preparing a game. Headless systems may choose to

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -267,7 +267,7 @@ public class ClientModel implements IMessengerErrorListener {
     this.messengers = new Messengers(messenger);
     messengers.registerChannelSubscriber(channelListener, IClientChannel.CHANNEL_NAME);
 
-    chatPanel = ChatPanel.newChatPanel(messengers, ServerModel.CHAT_NAME, ChatSoundProfile.GAME);
+    chatPanel = ChatPanel.newChatPanel(messengers, ServerModel.CHAT_NAME, ChatSoundProfile.GAME, clientNetworkBridge);
     if (getIsServerHeadlessTest()) {
       gameSelectorModel.setClientModelForHostBots(this);
       chatPanel

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -267,7 +267,9 @@ public class ClientModel implements IMessengerErrorListener {
     this.messengers = new Messengers(messenger);
     messengers.registerChannelSubscriber(channelListener, IClientChannel.CHANNEL_NAME);
 
-    chatPanel = ChatPanel.newChatPanel(messengers, ServerModel.CHAT_NAME, ChatSoundProfile.GAME, clientNetworkBridge);
+    chatPanel =
+        ChatPanel.newChatPanel(
+            messengers, ServerModel.CHAT_NAME, ChatSoundProfile.GAME, clientNetworkBridge);
     if (getIsServerHeadlessTest()) {
       gameSelectorModel.setClientModelForHostBots(this);
       chatPanel

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -29,6 +29,7 @@ import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
 import games.strategy.net.ServerMessenger;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import java.io.IOException;
 import java.net.BindException;
 import java.net.URI;
@@ -259,7 +260,9 @@ public class ServerModel extends Observable implements IConnectionChangeListener
 
       chatController = new ChatController(CHAT_NAME, messengers, node -> false);
 
-      chatModel = launchAction.createChatModel(CHAT_NAME, messengers);
+      // TODO: Project#4 Change no-op network sender to a real network bridge
+      chatModel =
+          launchAction.createChatModel(CHAT_NAME, messengers, ClientNetworkBridge.NO_OP_SENDER);
 
       if (gameToLobbyConnection != null && lobbyWatcherThread != null) {
         chatModel

--- a/game-app/game-core/src/main/java/games/strategy/net/websocket/ClientNetworkBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/websocket/ClientNetworkBridge.java
@@ -25,10 +25,15 @@ public interface ClientNetworkBridge {
         @Override
         public <T extends WebSocketMessage> void addListener(
             final MessageType<T> messageType, final Consumer<T> messageConsumer) {}
+
+        @Override
+        public void disconnect() {}
       };
 
   void sendMessage(WebSocketMessage webSocketMessage);
 
   <T extends WebSocketMessage> void addListener(
       MessageType<T> messageType, Consumer<T> messageConsumer);
+
+  void disconnect();
 }

--- a/game-app/game-core/src/main/java/games/strategy/net/websocket/WebsocketNetworkBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/websocket/WebsocketNetworkBridge.java
@@ -26,6 +26,11 @@ public class WebsocketNetworkBridge implements ClientNetworkBridge {
   }
 
   @Override
+  public void disconnect() {
+    genericWebSocketClient.close();
+  }
+
+  @Override
   public void sendMessage(final WebSocketMessage webSocketMessage) {
     if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
       genericWebSocketClient.sendMessage(webSocketMessage);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
@@ -4,8 +4,10 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import java.io.Serializable;
+import javax.annotation.Nullable;
 
 /**
  * Base class designed to make writing custom delegates simpler. Code common to all delegates is
@@ -16,11 +18,20 @@ public abstract class AbstractDelegate implements IDelegate {
   protected String displayName;
   protected GamePlayer player;
   protected IDelegateBridge bridge;
+  @Nullable protected ClientNetworkBridge clientNetworkBridge;
 
   @Override
   public void initialize(final String name, final String displayName) {
     this.name = name;
     this.displayName = displayName;
+  }
+
+  @Override
+  public void setDelegateBridgeAndPlayer(
+      final IDelegateBridge delegateBridge, final ClientNetworkBridge clientNetworkBridge) {
+    bridge = delegateBridge;
+    player = delegateBridge.getGamePlayer();
+    this.clientNetworkBridge = clientNetworkBridge;
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
@@ -2,10 +2,12 @@ package games.strategy.triplea.delegate;
 
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /** A single roll of a die. */
+@Builder
 @AllArgsConstructor
 @EqualsAndHashCode
 @Getter

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -30,6 +30,7 @@ import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.dice.RollDiceFactory;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.formatter.MyFormatter;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -505,7 +506,12 @@ public class AirBattle extends AbstractBattle {
     final GamePlayer retreatingPlayer = defender ? this.defender : attacker;
     final String text = retreatingPlayer.getName() + " retreat?";
     final String step = defender ? DEFENDERS_WITHDRAW : ATTACKERS_WITHDRAW;
-    bridge.getDisplayChannelBroadcaster().gotoBattleStep(battleId, step);
+
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      bridge.sendMessage(new IDisplay.GoToBattleStepMessage(battleId.toString(), step));
+    } else {
+      bridge.getDisplayChannelBroadcaster().gotoBattleStep(battleId, step);
+    }
     final Territory retreatTo =
         getRemote(retreatingPlayer, bridge)
             .retreatQuery(battleId, false, battleSite, availableTerritories, text);
@@ -527,9 +533,19 @@ public class AirBattle extends AbstractBattle {
       final String messageShort = retreatingPlayer.getName() + " retreats";
       final String messageLong =
           retreatingPlayer.getName() + " retreats all units to " + retreatTo.getName();
-      bridge
-          .getDisplayChannelBroadcaster()
-          .notifyRetreat(messageShort, messageLong, step, retreatingPlayer);
+      if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+        bridge.sendMessage(
+            IDisplay.NotifyRetreatMessage.builder()
+                .shortMessage(messageShort)
+                .message(messageLong)
+                .step(step)
+                .retreatingPlayerName(retreatingPlayer.getName())
+                .build());
+      } else {
+        bridge
+            .getDisplayChannelBroadcaster()
+            .notifyRetreat(messageShort, messageLong, step, retreatingPlayer);
+      }
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -11,6 +11,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.display.IDisplay;
 import games.strategy.engine.history.change.HistoryChangeFactory;
 import games.strategy.engine.player.Player;
 import games.strategy.engine.random.IRandomStats.DiceType;
@@ -35,6 +36,7 @@ import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.dice.RollDiceFactory;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.formatter.MyFormatter;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -926,7 +928,12 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           }
           final int totalDamage = current.getUnitDamage() + currentUnitCost;
           // display the results
-          bridge.getDisplayChannelBroadcaster().bombingResults(battleId, dice, currentUnitCost);
+          if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+            bridge.sendMessage(new IDisplay.BombingResultsMessage(battleId, dice, currentUnitCost));
+          } else {
+            bridge.getDisplayChannelBroadcaster().bombingResults(battleId, dice, currentUnitCost);
+          }
+
           if (currentUnitCost > 0) {
             bridge
                 .getSoundChannelBroadcaster()
@@ -968,7 +975,11 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         // Record PUs lost
         gameData.getMoveDelegate().pusLost(battleSite, cost);
         cost *= Properties.getPuMultiplier(gameData.getProperties());
-        bridge.getDisplayChannelBroadcaster().bombingResults(battleId, dice, cost);
+        if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+          bridge.sendMessage(new IDisplay.BombingResultsMessage(battleId, dice, cost));
+        } else {
+          bridge.getDisplayChannelBroadcaster().bombingResults(battleId, dice, cost);
+        }
         if (cost > 0) {
           bridge
               .getSoundChannelBroadcaster()

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectCasualties.java
@@ -6,11 +6,13 @@ import static games.strategy.triplea.delegate.battle.BattleStepStrings.SELECT_PR
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.UNITS;
 
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.display.IDisplay;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
+import games.strategy.triplea.settings.ClientSetting;
 import java.util.List;
 import java.util.function.BiFunction;
 import lombok.Getter;
@@ -54,13 +56,21 @@ public class SelectCasualties implements BattleStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-
-    bridge
-        .getDisplayChannelBroadcaster()
-        .notifyDice(
-            fireRoundState.getDice(),
-            MarkCasualties.getPossibleOldNameForNotifyingBattleDisplay(
-                battleState, firingGroup, side, getName()));
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      bridge.sendMessage(
+          new IDisplay.NotifyDiceMessage(
+              fireRoundState.getDice(),
+              MarkCasualties.getPossibleOldNameForNotifyingBattleDisplay(
+                  battleState, firingGroup, side, getName()),
+              fireRoundState.getDice().getPlayerName()));
+    } else {
+      bridge
+          .getDisplayChannelBroadcaster()
+          .notifyDice(
+              fireRoundState.getDice(),
+              MarkCasualties.getPossibleOldNameForNotifyingBattleDisplay(
+                  battleState, firingGroup, side, getName()));
+    }
 
     final CasualtyDetails details = selectCasualties.apply(bridge, this);
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/EvaderRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/EvaderRetreat.java
@@ -8,10 +8,12 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.display.IDisplay;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.formatter.MyFormatter;
+import games.strategy.triplea.settings.ClientSetting;
 import java.util.ArrayList;
 import java.util.Collection;
 import javax.annotation.Nonnull;
@@ -39,10 +41,16 @@ public class EvaderRetreat {
     final GamePlayer retreatingPlayer = parameters.battleState.getPlayer(parameters.side);
     final String text = retreatingPlayer.getName() + " retreat subs?";
 
-    parameters
-        .bridge
-        .getDisplayChannelBroadcaster()
-        .gotoBattleStep(parameters.battleState.getBattleId(), step);
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      parameters.bridge.sendMessage(
+          new IDisplay.GoToBattleStepMessage(
+              parameters.battleState.getBattleId().toString(), step));
+    } else {
+      parameters
+          .bridge
+          .getDisplayChannelBroadcaster()
+          .gotoBattleStep(parameters.battleState.getBattleId(), step);
+    }
 
     final boolean isAttemptingSubmerge =
         possibleRetreatSites.size() == 1
@@ -84,10 +92,20 @@ public class EvaderRetreat {
       longMessage = retreatingPlayer.getName() + " retreats subs to " + retreatTo.getName();
     }
 
-    parameters
-        .bridge
-        .getDisplayChannelBroadcaster()
-        .notifyRetreat(shortMessage, longMessage, step, retreatingPlayer);
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      parameters.bridge.sendMessage(
+          IDisplay.NotifyRetreatMessage.builder()
+              .shortMessage(shortMessage)
+              .message(longMessage)
+              .step(step)
+              .retreatingPlayerName(retreatingPlayer.getName())
+              .build());
+    } else {
+      parameters
+          .bridge
+          .getDisplayChannelBroadcaster()
+          .notifyRetreat(shortMessage, longMessage, step, retreatingPlayer);
+    }
   }
 
   public static void submergeEvaders(final Parameters parameters) {
@@ -122,7 +140,12 @@ public class EvaderRetreat {
     if (battleState.filterUnits(ALIVE, side).isEmpty()) {
       battleActions.endBattle(side.getOpposite().getWhoWon(), bridge);
     } else {
-      bridge.getDisplayChannelBroadcaster().notifyRetreat(battleState.getBattleId(), retreating);
+      if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+        bridge.sendMessage(
+            new IDisplay.NotifyUnitsRetreatingMessage(battleState.getBattleId(), retreating));
+      } else {
+        bridge.getDisplayChannelBroadcaster().notifyRetreat(battleState.getBattleId(), retreating);
+      }
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.display.IDisplay;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.Matches;
@@ -18,6 +19,7 @@ import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.battle.steps.RetreatChecks;
+import games.strategy.triplea.settings.ClientSetting;
 import java.util.Collection;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -109,7 +111,12 @@ public class OffensiveGeneralRetreat implements BattleStep {
       final Collection<Territory> possibleRetreatSites =
           retreater.getPossibleRetreatSites(retreatUnits);
 
-      bridge.getDisplayChannelBroadcaster().gotoBattleStep(battleState.getBattleId(), getName());
+      if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+        bridge.sendMessage(
+            new IDisplay.GoToBattleStepMessage(battleState.getBattleId().toString(), getName()));
+      } else {
+        bridge.getDisplayChannelBroadcaster().gotoBattleStep(battleState.getBattleId(), getName());
+      }
       final Territory retreatTo =
           battleActions.queryRetreatTerritory(
               battleState,
@@ -166,18 +173,37 @@ public class OffensiveGeneralRetreat implements BattleStep {
     if (battleState.filterUnits(ALIVE, OFFENSE).isEmpty()) {
       battleActions.endBattle(IBattle.WhoWon.DEFENDER, bridge);
     } else {
-      bridge.getDisplayChannelBroadcaster().notifyRetreat(battleState.getBattleId(), retreatUnits);
+      if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+        bridge.sendMessage(
+            new IDisplay.NotifyUnitsRetreatingMessage(battleState.getBattleId(), retreatUnits));
+      } else {
+        bridge
+            .getDisplayChannelBroadcaster()
+            .notifyRetreat(battleState.getBattleId(), retreatUnits);
+      }
     }
 
-    bridge
-        .getDisplayChannelBroadcaster()
-        .notifyRetreat(
-            battleState.getPlayer(OFFENSE).getName()
-                + getShortBroadcastSuffix(retreater.getRetreatType()),
-            battleState.getPlayer(OFFENSE).getName()
-                + getLongBroadcastSuffix(retreater.getRetreatType(), retreatTo),
-            getName(),
-            battleState.getPlayer(OFFENSE));
+    final String shortMessage =
+        battleState.getPlayer(OFFENSE).getName()
+            + getShortBroadcastSuffix(retreater.getRetreatType());
+
+    final String longMessage =
+        battleState.getPlayer(OFFENSE).getName()
+            + getLongBroadcastSuffix(retreater.getRetreatType(), retreatTo);
+
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      bridge.sendMessage(
+          IDisplay.NotifyRetreatMessage.builder()
+              .shortMessage(shortMessage)
+              .message(longMessage)
+              .step(getName())
+              .retreatingPlayerName(battleState.getPlayer(OFFENSE).getName())
+              .build());
+    } else {
+      bridge
+          .getDisplayChannelBroadcaster()
+          .notifyRetreat(shortMessage, longMessage, getName(), battleState.getPlayer(OFFENSE));
+    }
   }
 
   private String getShortBroadcastSuffix(final MustFightBattle.RetreatType retreatType) {

--- a/game-app/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -13,6 +13,7 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
 import games.strategy.net.TestServerMessenger;
 import games.strategy.net.websocket.ClientNetworkBridge;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,7 +27,7 @@ import org.triplea.domain.data.SystemId;
 import org.triplea.domain.data.UserName;
 import org.triplea.java.ThreadRunner;
 
-final class ChatIntegrationTest {
+final class ChatIntegrationTest extends AbstractClientSettingTestCase {
   private static final String CHAT_NAME = TestServerMessenger.CHAT_CHANNEL_NAME;
   private static final int MESSAGE_COUNT = 50;
   private static final int NODE_COUNT = 3;

--- a/game-app/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -12,6 +12,7 @@ import games.strategy.net.IMessenger;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
 import games.strategy.net.TestServerMessenger;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -132,7 +133,8 @@ final class ChatIntegrationTest {
   }
 
   private static Chat newChat(final Messengers messengers) {
-    return new Chat(new MessengersChatTransmitter(CHAT_NAME, messengers));
+    return new Chat(
+        new MessengersChatTransmitter(CHAT_NAME, messengers, ClientNetworkBridge.NO_OP_SENDER));
   }
 
   private static void waitFor(final Runnable assertion) throws InterruptedException {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
@@ -10,6 +10,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.xml.TestMapGameData;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -19,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
  * <p>Pre-loads the {@link TestMapGameData#DELEGATE_TEST} save game and provides fields for the
  * most-commonly-accessed players, territories, and unit types.
  */
-public abstract class AbstractDelegateTestCase {
+public abstract class AbstractDelegateTestCase extends AbstractClientSettingTestCase {
   protected GameData gameData = TestMapGameData.DELEGATE_TEST.getGameData();
   protected GamePlayer british = GameDataTestUtil.british(gameData);
   protected GamePlayer japanese = GameDataTestUtil.japanese(gameData);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -18,13 +18,14 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.remote.IBattleDelegate;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import org.junit.jupiter.api.Test;
 
-class AirThatCantLandUtilTest {
+class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
   private GameData gameData = TestMapGameData.REVISED.getGameData();
   private GamePlayer americansPlayer = GameDataTestUtil.americans(gameData);
   private UnitType fighterType = GameDataTestUtil.fighter(gameData);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -26,12 +26,13 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.StrategicBombingRaidBattle;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
-class LhtrTest {
+class LhtrTest extends AbstractClientSettingTestCase {
   private final GameData gameData = TestMapGameData.LHTR.getGameData();
 
   private static void thenRemotePlayerShouldNeverBeAskedToConfirmMove(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -76,6 +76,7 @@ import games.strategy.triplea.delegate.data.CasualtyList;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import games.strategy.triplea.delegate.data.TechResults;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
@@ -87,7 +88,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 import org.triplea.java.collections.CollectionUtils;
 
-class RevisedTest {
+class RevisedTest extends AbstractClientSettingTestCase {
   private final GameData gameData = TestMapGameData.REVISED.getGameData();
 
   private static void givenRemotePlayerWillSelectDefaultCasualties(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -89,6 +89,7 @@ import games.strategy.triplea.delegate.dice.RollDiceFactory;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -104,7 +105,7 @@ import org.mockito.stubbing.Answer;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
-class WW2V3Year41Test {
+class WW2V3Year41Test extends AbstractClientSettingTestCase {
   private final GameData gameData = TestMapGameData.WW2V3_1941.getGameData();
 
   private Territory getTerritory(final String territoryName) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
@@ -34,13 +34,14 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
-class MustFightBattleTest {
+class MustFightBattleTest extends AbstractClientSettingTestCase {
   @Test
   void testFightWithIsSuicideOnHit() {
     final GameData twwGameData = TestMapGameData.TWW.getGameData();

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
@@ -32,6 +32,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -44,7 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.sound.ISound;
 
 @ExtendWith(MockitoExtension.class)
-class DefensiveSubsRetreatTest {
+class DefensiveSubsRetreatTest extends AbstractClientSettingTestCase {
 
   @Mock ExecutionStack executionStack;
   @Mock IDelegateBridge delegateBridge;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreatTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreatTest.java
@@ -32,6 +32,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -44,7 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.sound.ISound;
 
 @ExtendWith(MockitoExtension.class)
-class OffensiveGeneralRetreatTest {
+class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
   @Mock ExecutionStack executionStack;
   @Mock IDelegateBridge delegateBridge;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
@@ -34,6 +34,7 @@ import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.MockGameData;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -46,7 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.sound.ISound;
 
 @ExtendWith(MockitoExtension.class)
-public class OffensiveSubsRetreatTest {
+public class OffensiveSubsRetreatTest extends AbstractClientSettingTestCase {
 
   @Mock ExecutionStack executionStack;
   @Mock IDelegateBridge delegateBridge;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
@@ -27,6 +27,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class SubmergeSubsVsOnlyAirStepTest {
+class SubmergeSubsVsOnlyAirStepTest extends AbstractClientSettingTestCase {
 
   @Mock ExecutionStack executionStack;
   @Mock IDelegateBridge delegateBridge;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
@@ -18,13 +18,14 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class BattleCalculatorTest {
+class BattleCalculatorTest extends AbstractClientSettingTestCase {
   @Test
   void testUnbalancedFight() {
     final GameData gameData = TestMapGameData.REVISED.getGameData();

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedLaunchAction.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedLaunchAction.java
@@ -16,6 +16,7 @@ import games.strategy.engine.framework.startup.ui.ServerOptions;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.engine.player.Player;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.TripleAPlayer;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.TripleAFrame;
@@ -121,8 +122,10 @@ public class HeadedLaunchAction implements LaunchAction {
   }
 
   @Override
-  public ChatModel createChatModel(String chatName, Messengers messengers) {
-    return ChatPanel.newChatPanel(messengers, chatName, ChatMessagePanel.ChatSoundProfile.GAME);
+  public ChatModel createChatModel(
+      String chatName, Messengers messengers, ClientNetworkBridge clientNetworkBridge) {
+    return ChatPanel.newChatPanel(
+        messengers, chatName, ChatMessagePanel.ChatSoundProfile.GAME, clientNetworkBridge);
   }
 
   @Override

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -22,6 +22,7 @@ import games.strategy.engine.framework.startup.ui.PlayerTypes;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.engine.player.Player;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import java.nio.file.Files;
@@ -125,7 +126,9 @@ public class HeadlessLaunchAction implements LaunchAction {
 
   @Override
   public ChatModel createChatModel(String chatName, Messengers messengers) {
-    Chat chat = new Chat(new MessengersChatTransmitter(chatName, messengers));
+    Chat chat =
+        new Chat(
+            new MessengersChatTransmitter(chatName, messengers, ClientNetworkBridge.NO_OP_SENDER));
     registerChatAppender(chat);
     return new HeadlessChat(chat);
   }

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -125,10 +125,9 @@ public class HeadlessLaunchAction implements LaunchAction {
   }
 
   @Override
-  public ChatModel createChatModel(String chatName, Messengers messengers) {
-    Chat chat =
-        new Chat(
-            new MessengersChatTransmitter(chatName, messengers, ClientNetworkBridge.NO_OP_SENDER));
+  public ChatModel createChatModel(
+      String chatName, Messengers messengers, ClientNetworkBridge clientNetworkBridge) {
+    Chat chat = new Chat(new MessengersChatTransmitter(chatName, messengers, clientNetworkBridge));
     registerChatAppender(chat);
     return new HeadlessChat(chat);
   }


### PR DESCRIPTION
Behind a feature flag, add a variety of network connections that send data over websocket rather than the  previous java-sockets mechanism.

Further work is needed to finish more conversions.

## Change Summary & Additional Notes

Of note, the pattern is:
1. For each 'remote action method', we create a message envelope class that contains all of the same data as the method parameters. Given a message envelope, we can then always invoke the existing network method.
2. Wire a network bridge to places that do network connection
3. Instead of invoking the network method, we create the equivalent message envelope and send that
4. In places that receive network messages, we add a listener to the network bridge that will listen for network messages. When we get the right network envelope, our listener uses that envelope to extract data and call the existing network method


Example:
```
@RemoteAction
void foo(String a);
```
We create envelope:

```
class FooMessage extends WebsocketMessage {
   String a;
   ....
}
```

We replace existing invocations:

```
String value = ...;
if(ClientSettings.useWebsockets) {
  networkBridge.sendMessage(new FooMessage(value));
} else {
  remoteMessenger.foo(value);
}
```

Last, we add a listener to handle the receiving side (previously Java customized RMI-like mechanism invokes the method for us)

```
  networkBridge.addLIstener(fooMessage -> foo(fooMessage.a));


@RemoteAction
void foo(String a) {

}
```

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
