### PR TITLE
Infra: always run 'ufw' commands (fix for --dry-run)

### DIFF
--- a/infrastructure/ansible/roles/system/firewall/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/firewall/tasks/main.yml
@@ -1,35 +1,24 @@
-- name: Gather ufw status
-  shell: ufw status verbose
-  register: ufw_status
-  changed_when: false
-
 - name: UFW allow SSH
-  when: ufw_status.stdout is not regex("\(OpenSSH\)\s*ALLOW")
   ufw:
     rule: allow
     name: OpenSSH
 
 - name: UFW deny incoming by default
-  when: ufw_status.stdout is not regex("deny \(incoming\)")
   ufw:
     default: deny
     direction: incoming
 
 - name: UFW allow outgoing by default
-  when: ufw_status.stdout is not regex("allow \(outgoing\)")
   ufw:
     default: allow
     direction: outgoing
 
 - name: turn on ssh rate limiting
-  when: ufw_status.stdout is not regex("22/tcp\s*LIMIT IN")
   ufw:
     rule: limit
     port: ssh
     proto: tcp
 
 - name: Turn on firewall
-  when: "ufw_status.stdout is not regex('Status: active')"
   ufw:
     state: enabled
-


### PR DESCRIPTION
## Change Summary & Additional Notes

When running ansible deployment with '--dry-run', "register" variables are not defined. This causes the UFW tasks to fail when run in --dry-run mode due to undefined variable error.

To resolve this, we remove the conditional run logic which removes the usage of the register variable. The conditional logic was there to avoid contention and sporadic failures when running the ufw command. If we see failures again on UFW commands, we can re-evaluate then.

