### PR TITLE
Infra: Add lobby 2.6 config & move Atlanta02 bot server to 2.6

### DIFF
--- a/.github/workflows/deploy-servers.yml
+++ b/.github/workflows/deploy-servers.yml
@@ -23,6 +23,7 @@ jobs:
           cd infrastructure
           echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
           ./run_ansible --environment production --tags common,java,postfix,postgres,flyway
+          ./run_ansible --environment production --limit prod2-bot02.triplea-game.org
         env:
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 

--- a/infrastructure/ansible/group_vars/bots_2_5.yml
+++ b/infrastructure/ansible/group_vars/bots_2_5.yml
@@ -1,0 +1,2 @@
+bot_lobby_uri: "https://prod2-lobby.triplea-game.org"
+bot_folder: "/home/bot"

--- a/infrastructure/ansible/group_vars/bots_2_6.yml
+++ b/infrastructure/ansible/group_vars/bots_2_6.yml
@@ -1,0 +1,1 @@
+bot_lobby_uri: "https://prod.triplea-game.org"

--- a/infrastructure/ansible/inventory/production
+++ b/infrastructure/ansible/inventory/production
@@ -4,15 +4,21 @@ forums.triplea-game.org
 [lobbyServer]
 prod.triplea-game.org reverse_proxy_server_name=prod.triplea-game.org
 
-[botHosts]
+[botHosts:children]
+bots_2_6
+bots_2_5
+
+[bots_2_5]
 # Disabled deployment to prod2-bot01, consistently unreachable during deployment
 #prod2-bot01.triplea-game.org  bot_number=1 bot_location_city_name=Dallas
-prod2-bot02.triplea-game.org  bot_number=2 bot_location_city_name=Atlanta
 prod2-bot04.triplea-game.org  bot_number=4 bot_location_city_name=Atlanta
 prod2-bot06.triplea-game.org  bot_number=6 bot_location_city_name=California
 prod2-bot07.triplea-game.org  bot_number=7 bot_location_city_name=Jersey
 prod2-bot08.triplea-game.org  bot_number=8 bot_location_city_name=London
 prod2-bot09.triplea-game.org  bot_number=9 bot_location_city_name=Frankfurt
+
+[bots_2_6]
+prod2-bot02.triplea-game.org  bot_number=2 bot_location_city_name=Atlanta
 
 [prod:children]
 lobbyServer

--- a/infrastructure/ansible/roles/bot/defaults/main.yml
+++ b/infrastructure/ansible/roles/bot/defaults/main.yml
@@ -1,5 +1,5 @@
 bot_user: "bot"
-bot_folder: "/home/{{ bot_user }}"
+bot_folder: "/opt/bot"
 bot_version: "{{ product_version | default('0.0') }}"
 
 # The location where we will install the bot binaries

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: create service user to run the app
   user:
     name: "{{ bot_user }}"
-    create_home: yes
+    create_home: no
     system: yes
 
 - name: deploy scripts to admin home

--- a/infrastructure/run_ansible
+++ b/infrastructure/run_ansible
@@ -30,6 +30,9 @@ function usage() {
   echo "      This option can cause false positive failures if one action depends on a previous"
   echo "  --verbose, -v"
   echo "      Shows ansible verbose output, gives more detail about what has changed."
+  echo "  --limit, -l"
+  echo "      Limits which servers we deploy to, only these servers will be updated."
+  echo "      Specify server hostnames, and/or hostgroup names"
   exit 1
 }
 
@@ -44,6 +47,7 @@ DRY_RUN_ARG=""
 ENVIRONMENT=""
 TAGS_ARG=""
 VERBOSE_ARG=""
+LIMIT_ARG=""
 
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -74,6 +78,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     --verbose|-v)
       VERBOSE_ARG="-v"
+      shift
+      ;;
+    --limit|-l)
+      LIMIT_ARG="--limit $2"
+      shift
       shift
       ;;
     *)
@@ -111,6 +120,6 @@ set -x
 ANSIBLE_CONFIG="$scriptDir/ansible.cfg" ansible-playbook \
   --extra-vars "build_version=$BUILD_VERSION" \
   --extra-vars "product_version=$PRODUCT_VERSION" \
-   --inventory "$scriptDir/ansible/inventory/$ENVIRONMENT" $DRY_RUN_ARG \
+   --inventory "$scriptDir/ansible/inventory/$ENVIRONMENT" $DRY_RUN_ARG $LIMIT_ARG \
    $VAULT_PASSWORD_FILE_ARG $TAGS_ARG $DIFF_ARG $VERBOSE_ARG "$scriptDir/ansible/site.yml"
 set +x


### PR DESCRIPTION
- Changes Atlanta bot from 2.5 lobby to 2.6 lobby
- We will now always update atlanta bot fully with source code updates
- Add a '--limit' config option when running ansible so we can selectively update just the atlanta bot
- Update bot install folder to '/opt'. It is more canonical rather than installing into a home folder. We keep '2.5' lobby bots with their existing home folders for now.
