### PR TITLE
Error reporting/send version label

### DIFF
--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/error/report/ErrorReportRequest.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/error/report/ErrorReportRequest.java
@@ -13,7 +13,7 @@ import org.triplea.java.StringUtils;
 /** Represents data that would be uploaded to a server. */
 @ToString
 @EqualsAndHashCode
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class ErrorReportRequest {

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/error/report/ErrorReportRequest.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/error/report/ErrorReportRequest.java
@@ -1,5 +1,7 @@
 package org.triplea.http.client.error.report;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +19,18 @@ import org.triplea.java.StringUtils;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ErrorReportRequest {
+  /**
+   * GAME_VERSION_MAJOR_MINOR regex matches first digits, and optional;u a dot followed by more
+   * digits. Examples:<br>
+   * 1.1 -> 1.1<br>
+   * 2.3.1 -> 2.3<br>
+   * 10 -> 10<br>
+   * 2.3+1 -> 3.2<br>
+   * Of note, we have a variety of matches to account for old version formats and to handle possible
+   * future variety of versions.
+   */
+  private static final Pattern GAME_VERSION_MAJOR_MINOR = Pattern.compile("^[0-9]+(\\.[0-9]+)?");
+
   @Nonnull private String title;
   @Nonnull private String body;
   @Nonnull @Getter private String gameVersion;
@@ -27,5 +41,15 @@ public class ErrorReportRequest {
 
   public String getBody() {
     return StringUtils.truncate(body, HttpClientConstants.REPORT_BODY_MAX_LENGTH);
+  }
+
+  /**
+   * Returns the 'major.minor' part of the game version, eg: "2.6+123" -> "2.6". If the gameVersion
+   * value is in an unexpected format, we return the gameVersion value as-is.
+   */
+  public String getSimpleGameVersion() {
+    Matcher m = GAME_VERSION_MAJOR_MINOR.matcher(gameVersion);
+    // return the matched part if found, otherwise just return 'gameVersion' as-is
+    return m.find() ? m.group() : gameVersion;
   }
 }

--- a/http-clients/lobby-client/src/test/java/org/triplea/http/client/error/report/ErrorReportRequestTest.java
+++ b/http-clients/lobby-client/src/test/java/org/triplea/http/client/error/report/ErrorReportRequestTest.java
@@ -1,0 +1,42 @@
+package org.triplea.http.client.error.report;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ErrorReportRequestTest {
+
+  /** Validates input/output conversions of game-version -> simplified game version. */
+  @ParameterizedTest
+  @MethodSource
+  void getSimpleGameVersion(String gameVersionInput, String expectedOutput) {
+    var errorReportRequest =
+        ErrorReportRequest.builder()
+            .gameVersion(gameVersionInput)
+            .body("body")
+            .title("title")
+            .build();
+    String result = errorReportRequest.getSimpleGameVersion();
+
+    assertThat(result, is(expectedOutput));
+  }
+
+  @SuppressWarnings("unused")
+  static Stream<Arguments> getSimpleGameVersion() {
+    return Stream.of(
+        Arguments.of("", ""),
+        Arguments.of("0", "0"),
+        Arguments.of("10+0", "10"),
+        Arguments.of("1.1", "1.1"),
+        Arguments.of("2.1.1", "2.1"),
+        Arguments.of("2.1.1.1", "2.1"),
+        Arguments.of("3.1+1", "3.1"),
+        Arguments.of("300.100+1", "300.100"),
+        Arguments.of("3.1+1+1", "3.1"),
+        Arguments.of("random", "random"));
+  }
+}

--- a/spitfire-server/error-reporting-module/src/main/java/org/triplea/modules/error/reporting/CreateIssueParams.java
+++ b/spitfire-server/error-reporting-module/src/main/java/org/triplea/modules/error/reporting/CreateIssueParams.java
@@ -6,7 +6,7 @@ import lombok.Value;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class CreateIssueParams {
   @Nonnull private final String ip;
   @Nonnull private final String systemId;

--- a/spitfire-server/error-reporting-module/src/main/java/org/triplea/modules/error/reporting/ErrorReportModule.java
+++ b/spitfire-server/error-reporting-module/src/main/java/org/triplea/modules/error/reporting/ErrorReportModule.java
@@ -34,9 +34,9 @@ public class ErrorReportModule {
     var githubCreateIssueResponse =
         githubApiClient.newIssue(
             CreateIssueRequest.builder()
-                .title(errorReportRequest.getGameVersion() + ": " + errorReportRequest.getTitle())
+                .title(errorReportRequest.getTitle())
                 .body(errorReportRequest.getBody())
-                .labels(new String[] {"Error Report"})
+                .labels(new String[] {"Error Report", errorReportRequest.getSimpleGameVersion()})
                 .build());
 
     errorReportingDao.insertHistoryRecord(

--- a/spitfire-server/error-reporting-module/src/test/java/org/triplea/modules/error/reporting/ErrorReportModuleTest.java
+++ b/spitfire-server/error-reporting-module/src/test/java/org/triplea/modules/error/reporting/ErrorReportModuleTest.java
@@ -6,13 +6,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 import org.triplea.http.client.error.report.ErrorReportResponse;
+import org.triplea.http.client.github.CreateIssueRequest;
 import org.triplea.http.client.github.CreateIssueResponse;
 import org.triplea.http.client.github.GithubApiClient;
 import org.triplea.modules.error.reporting.db.ErrorReportingDao;
@@ -54,6 +59,59 @@ class ErrorReportModuleTest {
     final ErrorReportResponse response = errorReportModule.createErrorReport(createIssueParams);
 
     assertThat(response.getGithubIssueLink(), is(GITHUB_ISSUE_URL));
+  }
+
+  /**
+   * Given an input to create an error report, we validate the parameters we send to github to
+   * create an issue.
+   */
+  @Test
+  void validateDataSentToGithub() {
+    errorReportModule.createErrorReport(createIssueParams);
+
+    verify(githubApiClient)
+        .newIssue(
+            CreateIssueRequest.builder()
+                .body("body")
+                .title("version: title")
+                .labels(new String[] {"Error Report"})
+                .build());
+  }
+
+  /**
+   * Given a variety of 'inputVersion' representing game versions, we validate the data we send to
+   * github (notably checking the labels that we send).
+   */
+  @ParameterizedTest
+  @MethodSource
+  void validateLabelsDataSentToGithub(String inputVersion, String[] expectedLabels) {
+    errorReportModule.createErrorReport(
+        createIssueParams.toBuilder()
+            .errorReportRequest(
+                createIssueParams.getErrorReportRequest().toBuilder()
+                    .gameVersion(inputVersion)
+                    .build())
+            .build());
+
+    verify(githubApiClient)
+        .newIssue(
+            CreateIssueRequest.builder()
+                .body("body")
+                .title(inputVersion + ": title")
+                .labels(expectedLabels)
+                .build());
+  }
+
+  @SuppressWarnings("unused")
+  static Stream<Arguments> validateLabelsDataSentToGithub() {
+    return Stream.of(
+        Arguments.of("version", new String[] {"Error Report"}),
+        Arguments.of("1.1", new String[] {"Error Report"}),
+        Arguments.of("2.1.1", new String[] {"Error Report"}),
+        Arguments.of("3.2.1.1", new String[] {"Error Report"}),
+        Arguments.of("4.0.1", new String[] {"Error Report"}),
+        Arguments.of("5.1+123", new String[] {"Error Report"}),
+        Arguments.of("6.0+abc", new String[] {"Error Report"}));
   }
 
   @Test

--- a/spitfire-server/error-reporting-module/src/test/java/org/triplea/modules/error/reporting/ErrorReportModuleTest.java
+++ b/spitfire-server/error-reporting-module/src/test/java/org/triplea/modules/error/reporting/ErrorReportModuleTest.java
@@ -73,8 +73,8 @@ class ErrorReportModuleTest {
         .newIssue(
             CreateIssueRequest.builder()
                 .body("body")
-                .title("version: title")
-                .labels(new String[] {"Error Report"})
+                .title("title")
+                .labels(new String[] {"Error Report", "version"})
                 .build());
   }
 
@@ -97,7 +97,7 @@ class ErrorReportModuleTest {
         .newIssue(
             CreateIssueRequest.builder()
                 .body("body")
-                .title(inputVersion + ": title")
+                .title("title")
                 .labels(expectedLabels)
                 .build());
   }
@@ -105,13 +105,13 @@ class ErrorReportModuleTest {
   @SuppressWarnings("unused")
   static Stream<Arguments> validateLabelsDataSentToGithub() {
     return Stream.of(
-        Arguments.of("version", new String[] {"Error Report"}),
-        Arguments.of("1.1", new String[] {"Error Report"}),
-        Arguments.of("2.1.1", new String[] {"Error Report"}),
-        Arguments.of("3.2.1.1", new String[] {"Error Report"}),
-        Arguments.of("4.0.1", new String[] {"Error Report"}),
-        Arguments.of("5.1+123", new String[] {"Error Report"}),
-        Arguments.of("6.0+abc", new String[] {"Error Report"}));
+        Arguments.of("version", new String[] {"Error Report", "version"}),
+        Arguments.of("1.1", new String[] {"Error Report", "1.1"}),
+        Arguments.of("2.1.1", new String[] {"Error Report", "2.1"}),
+        Arguments.of("3.2.1.1", new String[] {"Error Report", "3.2"}),
+        Arguments.of("4.0.1", new String[] {"Error Report", "4.0"}),
+        Arguments.of("5.1+123", new String[] {"Error Report", "5.1"}),
+        Arguments.of("6.0+abc", new String[] {"Error Report", "6.0"}));
   }
 
   @Test


### PR DESCRIPTION
1st commit beefs up tests to validate the labels we send when creating github issues as part of  error reporting.

2nd commit adds the current game version as a label to error reports. It is easy to filter issues by label, this will help us filter error reports by game version.

An example test issue created as an error report can be found at: https://github.com/triplea-game/test/issues/59
