### PR TITLE
Infra: fix ansible type-casting warning (add quotes)

### DIFF
--- a/infrastructure/ansible/roles/nginx/install/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/install/tasks/main.yml
@@ -18,8 +18,8 @@
     port: "{{ item }}"
     proto: tcp
   with_items:
-    - 443
-    - 80
+    - "443"
+    - "80"
 
 - name: ensure nginx is started
   systemd:


### PR DESCRIPTION
Ansible is printing a warning that numeric values are being converted to strings. This update quotes those values so that they start as strings and are not converted (and resolves the warning about this implicit conversion)

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
