### PR TITLE
Infra: enable full deployments on merge

### DIFF
--- a/.github/workflows/deploy-servers.yml
+++ b/.github/workflows/deploy-servers.yml
@@ -22,8 +22,7 @@ jobs:
           pip install ansible==2.9.13
           cd infrastructure
           echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
-          ./run_ansible --environment production --tags common,java,postfix,postgres,flyway
-          ./run_ansible --environment production --limit prod2-bot02.triplea-game.org
+          ./run_ansible --environment production
         env:
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 

--- a/infrastructure/ansible/inventory/production
+++ b/infrastructure/ansible/inventory/production
@@ -11,11 +11,16 @@ bots_2_5
 [bots_2_5]
 # Disabled deployment to prod2-bot01, consistently unreachable during deployment
 #prod2-bot01.triplea-game.org  bot_number=1 bot_location_city_name=Dallas
-prod2-bot04.triplea-game.org  bot_number=4 bot_location_city_name=Atlanta
-prod2-bot06.triplea-game.org  bot_number=6 bot_location_city_name=California
-prod2-bot07.triplea-game.org  bot_number=7 bot_location_city_name=Jersey
-prod2-bot08.triplea-game.org  bot_number=8 bot_location_city_name=London
-prod2-bot09.triplea-game.org  bot_number=9 bot_location_city_name=Frankfurt
+
+# Following are disabled to avoid deployments, 2.5 bots have some differences
+# that are not easy to resolve right now. It will be easier to move a full
+# to 2.6 wholesale and add cleanup tasks for 2.5 config than to get these
+# servers back under infrastructure control
+#prod2-bot04.triplea-game.org  bot_number=4 bot_location_city_name=Atlanta
+#prod2-bot06.triplea-game.org  bot_number=6 bot_location_city_name=California
+#prod2-bot07.triplea-game.org  bot_number=7 bot_location_city_name=Jersey
+#prod2-bot08.triplea-game.org  bot_number=8 bot_location_city_name=London
+#prod2-bot09.triplea-game.org  bot_number=9 bot_location_city_name=Frankfurt
 
 [bots_2_6]
 prod2-bot02.triplea-game.org  bot_number=2 bot_location_city_name=Atlanta

--- a/infrastructure/ansible/roles/nginx/install/templates/etc_nginx_sites_enabled_default.j2
+++ b/infrastructure/ansible/roles/nginx/install/templates/etc_nginx_sites_enabled_default.j2
@@ -1,5 +1,7 @@
 server {
     listen 80;
     listen [::]:80;
-    return 301 https://$host$request_uri;
+#    return 301 https://$host$request_uri;
+
+    root /usr/share/nginx/html;
 }


### PR DESCRIPTION
Largely this update validates the deployed config is what matches what is checked in, meaning we are not making drastic and unintended changes when doing future automated deployments based on config changes.

- Updates lobby config that is checked in to match what is currently on the server. After this update, deployments are no-ops because config matches (keep in mind we do not yet automatically restart lobby for any changes to take effect).
- Disabled deployments to 2.5 bots, they have differences that are hard to resolve right now. The remaining 2.6 bots have a config that matches what is checked in.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
