### PR TITLE
Fix in SwingComponents#promptUser - always run on EDT

### DIFF
--- a/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -108,7 +108,7 @@ public final class SwingComponents {
    */
   public static void promptUser(
       final String title, final String message, final Runnable confirmedAction) {
-    if(!SwingUtilities.isEventDispatchThread()) {
+    if (!SwingUtilities.isEventDispatchThread()) {
       SwingUtilities.invokeLater(() -> promptUser(title, message, confirmedAction));
       return;
     }

--- a/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -108,6 +108,11 @@ public final class SwingComponents {
    */
   public static void promptUser(
       final String title, final String message, final Runnable confirmedAction) {
+    if(!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(() -> promptUser(title, message, confirmedAction));
+      return;
+    }
+
     boolean showMessage = false;
     synchronized (visiblePrompts) {
       if (!visiblePrompts.contains(message)) {


### PR DESCRIPTION
This update ensures we will run the 'prompt user' code on the swing EDT, thereby avoiding swing threading errors where it complains when UI components are created off of the EDT.
