### PR TITLE
Lobby: wire a 'lobby-message' to front-end

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -105,6 +105,7 @@ public class LobbyLogin {
                 .apiKey(ApiKey.of(loginResponse.getApiKey()))
                 .moderator(loginResponse.isModerator())
                 .passwordChangeRequired(loginResponse.isPasswordChangeRequired())
+                .loginMessage(loginResponse.getLobbyMessage())
                 .build());
       } else {
         showMessage("Login Failed", loginResponse.getFailReason());
@@ -156,6 +157,7 @@ public class LobbyLogin {
                         .username(UserName.of(createAccountPanel.getUsername()))
                         .apiKey(ApiKey.of(lobbyLoginResponse.getApiKey()))
                         .passwordChangeRequired(lobbyLoginResponse.isPasswordChangeRequired())
+                        .loginMessage(lobbyLoginResponse.getLobbyMessage())
                         .build());
       case CANCEL:
         return Optional.empty();

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginResponse.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginResponse.java
@@ -25,6 +25,11 @@ public class LobbyLoginResponse {
    * password.
    */
   private final boolean passwordChangeRequired;
+  /**
+   * When users log in to lobby successfully, we optionally can optionally send them a banner
+   * message that is printed on the lobby screen.
+   */
+  private final String lobbyMessage;
 
   public boolean isSuccess() {
     return apiKey != null;

--- a/spitfire-server/database/src/main/resources/db/migration/lobby_db/V2.02.00__lobby_message.sql
+++ b/spitfire-server/database/src/main/resources/db/migration/lobby_db/V2.02.00__lobby_message.sql
@@ -1,0 +1,9 @@
+create table lobby_message
+(
+    message varchar(256) not null
+);
+comment on table lobby_message is 'Stores the message that we display to users on login';
+
+insert into lobby_message(message)
+values ('Welcome to the TripleA lobby!\n' ||
+        'Please no politics, stay respectful, be welcoming, have fun.');

--- a/spitfire-server/lobby-module/src/main/java/org/triplea/modules/user/account/login/LobbyLoginMessageDao.java
+++ b/spitfire-server/lobby-module/src/main/java/org/triplea/modules/user/account/login/LobbyLoginMessageDao.java
@@ -1,0 +1,26 @@
+package org.triplea.modules.user.account.login;
+
+import java.util.function.Supplier;
+import lombok.AllArgsConstructor;
+import org.jdbi.v3.core.Jdbi;
+
+/** Fetches from database the lobby login message */
+@AllArgsConstructor
+public class LobbyLoginMessageDao implements Supplier<String> {
+
+  private final Jdbi jdbi;
+
+  static LobbyLoginMessageDao build(final Jdbi jdbi) {
+    return new LobbyLoginMessageDao(jdbi);
+  }
+
+  @Override
+  public String get() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery("select message from lobby_message") //
+                .mapTo(String.class)
+                .one());
+  }
+}

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/modules/user/account/login/LobbyLoginMessageDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/modules/user/account/login/LobbyLoginMessageDaoTest.java
@@ -1,0 +1,24 @@
+package org.triplea.modules.user.account.login;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+import com.github.database.rider.junit5.DBUnitExtension;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.db.LobbyModuleDatabaseTestSupport;
+
+@RequiredArgsConstructor
+@ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
+class LobbyLoginMessageDaoTest {
+
+  private final LobbyLoginMessageDao lobbyLoginMessageDao;
+
+  @Test
+  void selectLobbyMessage() {
+    assertThat(lobbyLoginMessageDao.get(), is(notNullValue()));
+  }
+}

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/modules/user/account/login/LoginModuleTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/modules/user/account/login/LoginModuleTest.java
@@ -47,6 +47,8 @@ class LoginModuleTest {
 
   private static final ApiKey API_KEY = ApiKey.of("api-key");
 
+  private static final String LOBBY_MESSAGE = "Example lobby message";
+
   @Mock private Predicate<LoginRequest> registeredLogin;
   @Mock private Predicate<LoginRequest> tempPasswordLogin;
   @Mock private Function<UserName, Optional<String>> anonymousLogin;
@@ -68,6 +70,7 @@ class LoginModuleTest {
             .accessLogUpdater(accessLogUpdater)
             .userJdbiDao(userJdbiDao)
             .nameValidation(nameValidation)
+            .lobbyLoginMessageDao(() -> LOBBY_MESSAGE)
             .build();
   }
 
@@ -100,6 +103,7 @@ class LoginModuleTest {
   private static void assertSuccessLogin(final LobbyLoginResponse result) {
     assertThat(result.getFailReason(), nullValue());
     assertThat(result.getApiKey(), is(API_KEY.getValue()));
+    assertThat(result.getLobbyMessage(), is(LOBBY_MESSAGE));
   }
 
   @Nested

--- a/spitfire-server/lobby-module/src/test/resources/datasets/login_message/login_message.yml
+++ b/spitfire-server/lobby-module/src/test/resources/datasets/login_message/login_message.yml
@@ -1,3 +1,0 @@
-lobby_message:
-  - message: "This is an example!\nWith a two lines!"
-

--- a/spitfire-server/lobby-module/src/test/resources/datasets/login_message/login_message.yml
+++ b/spitfire-server/lobby-module/src/test/resources/datasets/login_message/login_message.yml
@@ -1,0 +1,3 @@
+lobby_message:
+  - message: "This is an example!\nWith a two lines!"
+


### PR DESCRIPTION
To replicate 2.5 functionality, this is a partial iteration on the backend to send a custom message to users when they login. Previously this message was stored in the lobby servers YML file (now it will live in database instead)

## Change Summary & Additional Notes

In the future will want to add a cache to the message lookup.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
