### PR TITLE
Configure nginx to send 2.5 clients to 2.6 lobby

### DIFF
--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -8,8 +8,8 @@ lobby_name: "lobby_{{ lobby_product_version }}"
 lobby_home_folder: "/opt/lobby/{{ lobby_product_version }}"
 
 lobby_ports:
-  "default": "8080"
-  "2.5": "8080"
+  "default": "9026"
+  "2.5": "9026"
   "2.6": "9026"
 
 lobby_http_port: "{{ lobby_ports[lobby_product_version] }}"


### PR DESCRIPTION
This update would have NGINX (which is listening on 'prod.triplea-game.org') send 2.5 game clients to the 2.6 lobby (2.5 is the current 'main' release).

The 2.6 lobby and 2.5 game clients are compatible with each other, so this is a safe configuration update to make.

Though, 2.5 clients are currently configured to use a 'prod2' URL and they would see no difference. But, we can configure the 2.5 clients to start using the 'prod.triplea-game' server by modifying the lobby_games.yml file, which would then cause 2.5 clients to be redirect to the 2.6 lobby. Until then, this change has no impact.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
