### PR TITLE
Build checks: remove check of SQL entity names

### DIFF
--- a/.build/code-convention-checks/check-custom-style
+++ b/.build/code-convention-checks/check-custom-style
@@ -29,8 +29,7 @@ function main() {
   favorJava9CollectionsApi
   #referToCollectionsByInterfaceType
   removeUnusedLogAnnotations
-  #preferSlf4jOverJavaLogging  
-  databaseNamesAreLowerSnakeCase
+  #preferSlf4jOverJavaLogging
   noTabsInSql
   useEmptyOverSizeEqualsZero
   useStaticImportsInTest
@@ -113,25 +112,12 @@ function preferSlf4jOverJavaLogging() {
   displayResult "$found"
 }
 
-function databaseNamesAreLowerSnakeCase() {
-  title "Database entities should not be camelCased, lower_snake_case instead."
-  example "Ex: instead of 'tableName' use 'table_name'"
-  local found=0
-  
-  while read -r file; do
-    grep --color=auto -HEn "[a-z][A-Z]" "$file" && status=1 && found=1
-  done <<< "$(cat "$sqlFiles")"
-  
-  displayResult "$found"
-}
-  
 function noTabsInSql() {
   title "Use spaces in SQL and not tabs"
   local found=0
   while read -r file; do
     grep --color=auto -Pn "\t" "$file" && status=1 && found=1
   done <<< "$(cat "$sqlFiles")"
-  
   displayResult "$found"
 }
 


### PR DESCRIPTION
Removing because possibly triggers on false-positives. The check for SQL naming validated that we had nothing camelCased in any of the '*.sql' files. While generally true, this can fail when being scanned against data in 'insert' statements.

Rather than building in a way to override this to create exceptions, for now the check is being removed.

## Notes

Diff is a tiny bit cleaner with whitespace ignored. 