### PR TITLE
Lobby config: direct 2.5 users to 'prod.triplea-game.org'

### DIFF
--- a/servers.yml
+++ b/servers.yml
@@ -1,7 +1,8 @@
+# This file is read by game clients 2.2 through 2.5
 latest: 2.5.22294
 servers:
   - version: "2.0.20057"
-    lobby_uri: https://prod2-lobby.triplea-game.org
+    lobby_uri: https://prod.triplea-game.org
     message: |
       Welcome to the TripleA lobby!
       Please no politics, stay respectful, be welcoming, have fun.


### PR DESCRIPTION
Only the 2.5 game engine and below reads 'servers.yml'. This update directs those game clients to 'prod.triplea-game.org'. We have NGINX running on that URL which will in turn redirect the game client to an appropriate lobby server (NGINX going forward will control which game client versions connect to which lobby).

## Change Summary & Additional Notes

Merging this would have immediate effect for any 2.5 users logging into the lobby.
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
