### PR TITLE
Infra: bring bots back to 2.5 & use syslog for logging

### DIFF
--- a/infrastructure/ansible/group_vars/bots_2_5.yml
+++ b/infrastructure/ansible/group_vars/bots_2_5.yml
@@ -1,2 +1,0 @@
-bot_lobby_uri: "https://prod2-lobby.triplea-game.org"
-bot_folder: "/home/bot"

--- a/infrastructure/ansible/group_vars/bots_2_6.yml
+++ b/infrastructure/ansible/group_vars/bots_2_6.yml
@@ -1,1 +1,0 @@
-bot_lobby_uri: "https://prod.triplea-game.org"

--- a/infrastructure/ansible/inventory/production
+++ b/infrastructure/ansible/inventory/production
@@ -4,21 +4,7 @@ forums.triplea-game.org
 [lobbyServer]
 prod.triplea-game.org reverse_proxy_server_name=prod.triplea-game.org
 
-[botHosts:children]
-bots_2_6
-bots_2_5
-
-[bots_2_5]
-# Disabled deployment to prod2-bot01, consistently unreachable during deployment
-#prod2-bot01.triplea-game.org  bot_number=1 bot_location_city_name=Dallas
-
-# Following are disabled to avoid deployments, 2.5 bots have some differences
-# that are not easy to resolve right now. It will be easier to move a full
-# to 2.6 wholesale and add cleanup tasks for 2.5 config than to get these
-# servers back under infrastructure control
-#prod2-bot08.triplea-game.org  bot_number=8 bot_location_city_name=London
-
-[bots_2_6]
+[botHosts]
 prod2-bot02.triplea-game.org  bot_number=2 bot_location_city_name=Atlanta
 prod2-bot04.triplea-game.org  bot_number=4 bot_location_city_name=Atlanta
 prod2-bot06.triplea-game.org  bot_number=6 bot_location_city_name=California

--- a/infrastructure/ansible/roles/bot/defaults/main.yml
+++ b/infrastructure/ansible/roles/bot/defaults/main.yml
@@ -1,12 +1,14 @@
 bot_user: "bot"
 bot_folder: "/opt/bot"
-bot_version: "{{ product_version | default('0.0') }}"
+bot_version: "2.5"
+
+bot_zip_file_url: "https://github.com/triplea-game/triplea/releases/download/2.5.22294/triplea-game-headless-2.5.22294.zip"
 
 # The location where we will install the bot binaries
 bot_install_home: "{{ bot_folder }}/{{ bot_version }}"
 
 # The location of the jar executable that we will run to launch the bot server.
-bot_jar: "{{ bot_install_home }}/bin/triplea-game-headless.jar"
+bot_jar: "{{ bot_install_home }}/bin/triplea-game-headless-2.5.22294.jar"
 
 # A folder where the bot server will find maps.
 bot_maps_folder: "{{ bot_folder }}/maps"

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -29,7 +29,7 @@
     - stop-all
     - download-all-maps
 
-- name: create maps folder
+- name: create folders
   file:
     state: directory
     path: "{{ item }}"
@@ -37,20 +37,25 @@
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
   with_items:
+    - "{{ bot_folder }}"
     - "{{ bot_install_home }}"
     - "{{ bot_maps_folder }}"
 
-- name: deploy game-headless-zip file
-  copy:
-    src: "triplea-game-headless.zip"
-    dest: "{{ bot_install_home }}/triplea-game-headless.zip"
+- name: Download Bot Zip File
+  register: bot_zip_file_download
+  get_url:
+    url: "{{ bot_zip_file_url }}"
+    dest: "{{ bot_install_home }}"
+    mode: "0644"
+    checksum: "md5:e83a688423c2441a5f3a89f2db0b8993"
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
 
 - name: extract zip file
+  when: bot_zip_file_download.changed
   unarchive:
     remote_src: yes
-    src: "{{ bot_install_home }}/triplea-game-headless.zip"
+    src: "{{ bot_install_home }}/triplea-game-headless-2.5.22294.zip"
     dest: "{{ bot_install_home }}/"
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
@@ -62,6 +67,30 @@
     mode: "0644"
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
+
+- name: ensure logging folder /var/log/triplea exists
+  file:
+    path: /var/log/triplea
+    state: directory
+    mode: "0755"
+    owner: syslog
+    group: adm
+
+- name: deploy rsyslog config files to send log output from syslog to files
+  register: bot_rsyslog_conf
+  template:
+    src: bot-rsyslog.conf
+    dest: /etc/rsyslog.d/bot{{ item }}.conf
+    mode: "0644"
+    owner: root
+    group: root
+  with_items: "{{ bot_numbers }}"
+
+- name: restart rsyslog to pick up any config changes
+  when: bot_rsyslog_conf.changed
+  service:
+    name: rsyslog
+    state: restarted
 
 - name: install systemd service script
   register: bot_service

--- a/infrastructure/ansible/roles/bot/templates/bot.service.j2
+++ b/infrastructure/ansible/roles/bot/templates/bot.service.j2
@@ -17,5 +17,10 @@ ExecStart=java -server \
   -Ptriplea.map.folder="{{ bot_maps_folder }}"
 Restart=always
 
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=bot%i
+
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
2.6 launch was a bust, this update brings all bots back to the 2.5 lobby.

This update also adds configs for bots to send their log output to syslog. We add some extra config for syslog to direct this log output to the file system (/var/log/triplea/), so we can now easily view log output by checking out that folder and the log files within it.
