### PR TITLE
Infra: Bot config - add missing rsyslog config file

### DIFF
--- a/infrastructure/ansible/roles/bot/templates/bot-rsyslog.conf
+++ b/infrastructure/ansible/roles/bot/templates/bot-rsyslog.conf
@@ -1,0 +1,3 @@
+if $programname == 'bot{{ item }}' then /var/log/triplea/bot{{ item }}.log
+& stop
+


### PR DESCRIPTION
Should have been included in previous commit.
