### PR TITLE
Infra: Replace '+' in version back to a '.', eg: "2.6+1000" -> "2.6.1000"

### DIFF
--- a/.build/get-build-version
+++ b/.build/get-build-version
@@ -1,15 +1,17 @@
 #!/bin/bash
 
 # Prints the current build version, this is the product version plus current commit number
-# Example output: 2.6+23400
+# Example output: 2.6.23400
 
 set -eu
 
 scriptDir=$(dirname "$0")
 
-echo -n "$($scriptDir/get-product-version)+"
+## Prints the 'major.minor' and a trailing period, eg: '2.6.'
+echo -n "$($scriptDir/get-product-version)."
 
-# finish printing with commit number
+# Print the 'build' number, this is the commit number.
+# This will complete the 'major.minor.build' output, eg: '2.6.1001'
 (
   cd $scriptDir || exit 1
   git rev-list --count HEAD

--- a/.build/get-product-version
+++ b/.build/get-product-version
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Prints the current product version number. That value is found in the file: 'product_version.txt'.
+# Reads and then prints the current product version ('major.minor') from file.
 # Example output: 2.6
 
 scriptDir=$(dirname "$0")


### PR DESCRIPTION
An update changing the build process and how version number is displayed. From 'major.minor+build' to 'major.minor.build'

The plus sign for build number is arguably better, though there are some compelling reasons for us to use a 'dot' instead of a plus sign:
- Slightly more conventional with a lot of tooling, github releases expects there to be dots in a version number
- More compatible with running & existing software and legacy saves. We simply have a lot of older things that only work when there are only dots in the version number. Changing from a dot to a plus breaks those components. The benefit of this compatibility is worth a lot.

