### PR TITLE
expanded public static Image getImage(final Path path) errorMessage

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/io/ImageLoader.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/ImageLoader.java
@@ -18,7 +18,8 @@ public class ImageLoader {
    * @param path Location of the file to be read as an image.
    */
   public static Image getImage(final Path path) {
-    checkArgument(Files.exists(path), "File must exist at path: " + path.toAbsolutePath());
+    checkArgument(Files.exists(path), "File must exist at path: " + path.toAbsolutePath()
+        + "You should build with the checked in launcher, or and run 'downloadAssets'.");
     checkArgument(!Files.isDirectory(path), "Must be a file: " + path.toAbsolutePath());
     try {
       return ImageIO.read(path.toFile());

--- a/lib/java-extras/src/main/java/org/triplea/io/ImageLoader.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/ImageLoader.java
@@ -18,8 +18,11 @@ public class ImageLoader {
    * @param path Location of the file to be read as an image.
    */
   public static Image getImage(final Path path) {
-    checkArgument(Files.exists(path), "File must exist at path: " + path.toAbsolutePath()
-        + "You should build with the checked in launcher, or and run 'downloadAssets'.");
+    checkArgument(
+        Files.exists(path),
+        "File must exist at path: "
+            + path.toAbsolutePath()
+            + "You should build with the checked in launcher, or and run 'downloadAssets'.");
     checkArgument(!Files.isDirectory(path), "Must be a file: " + path.toAbsolutePath());
     try {
       return ImageIO.read(path.toFile());


### PR DESCRIPTION
Expanded Image getImage(final Path path) errorMessage with:
"You should build with the checked in launcher, or and run 'downloadAssets'." 
to avoid unnecessary issues like #10106   because Typically, the logo image is bundled with the game, and if game bundling is a problem, this is not necessarily the first error you would see in that case (hence it is likely a dev issue).
