### PR TITLE
Fix "host is unreachable" causing extra error message window

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -123,6 +123,12 @@ public class InGameLobbyWatcher {
       // path will be a dead-end.
       shutDown();
       watcherThreadMessaging.handleCurrentGameHostNotReachable();
+
+      //Using return here to break out as this is a dead end.
+      // Initializing keepAliveTimer and connectionChangeListener to null as they won't be needed.
+      keepAliveTimer = null;
+      connectionChangeListener = null;
+      return;
     }
 
     gameId = gamePostingResponse.getGameId();
@@ -248,7 +254,11 @@ public class InGameLobbyWatcher {
 
   void shutDown() {
     isShutdown = true;
-    gameToLobbyConnection.disconnect(gameId);
+    // if gameId is not null (game was created in lobby successfully) send remove game message to
+    //  lobby now that game is to be shut down.
+    if(gameId != null) {
+      gameToLobbyConnection.disconnect(gameId);
+    }
     serverMessenger.removeConnectionChangeListener(connectionChangeListener);
     Optional.ofNullable(keepAliveTimer).ifPresent(ScheduledTimer::cancel);
     cleanUpGameModelListener();

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -124,7 +124,7 @@ public class InGameLobbyWatcher {
       shutDown();
       watcherThreadMessaging.handleCurrentGameHostNotReachable();
 
-      //Using return here to break out as this is a dead end.
+      // Using return here to break out as this is a dead end.
       // Initializing keepAliveTimer and connectionChangeListener to null as they won't be needed.
       keepAliveTimer = null;
       connectionChangeListener = null;
@@ -256,7 +256,7 @@ public class InGameLobbyWatcher {
     isShutdown = true;
     // if gameId is not null (game was created in lobby successfully) send remove game message to
     //  lobby now that game is to be shut down.
-    if(gameId != null) {
+    if (gameId != null) {
       gameToLobbyConnection.disconnect(gameId);
     }
     serverMessenger.removeConnectionChangeListener(connectionChangeListener);

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,31 +18,45 @@ import games.strategy.engine.framework.startup.WatcherThreadMessaging;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.http.client.lobby.game.lobby.watcher.GamePostingRequest;
 import org.triplea.http.client.lobby.game.lobby.watcher.GamePostingResponse;
 import org.triplea.http.client.web.socket.client.connections.GameToLobbyConnection;
 
+@ExtendWith(MockitoExtension.class)
 final class InGameLobbyWatcherTest {
 
+  @Mock
+  private IServerMessenger mockIServerMessenger;
+
+  @Mock
+  private GameToLobbyConnection mockGameToLobbyConnection;
+
+  @Mock
+  private WatcherThreadMessaging mockWatcherThreadMessaging;
+
+  @Mock
+  private InGameLobbyWatcher mockInGameLobbyWatcher;
+
+  @Mock
+  private INode mockINode;
+
+  @Mock
+  private GamePostingResponse mockGamePostingResponse;
+
   @Test
-  public void testNewInGameLobbyWatcher_hostNotReachable() throws UnknownHostException {
+  public void testNewInGameLobbyWatcher_hostNotReachable() throws Exception {
 
     // need to set LOBBY_GAME_COMMENTS system property to avoid NPE in
     // SystemPropertyReader.gameComments()
     System.setProperty(LOBBY_GAME_COMMENTS, "testLobbyGameComments");
-
-    IServerMessenger mockIServerMessenger = mock(IServerMessenger.class);
-    GameToLobbyConnection mockGameToLobbyConnection = mock(GameToLobbyConnection.class);
-    WatcherThreadMessaging mockWatcherThreadMessaging = mock(WatcherThreadMessaging.class);
-    InGameLobbyWatcher mockInGameLobbyWatcher = mock(InGameLobbyWatcher.class);
-    INode mockINode = mock(INode.class);
-    GamePostingResponse mockGamePostingResponse = mock(GamePostingResponse.class);
 
     when(mockIServerMessenger.getLocalNode()).thenReturn(mockINode);
     when(mockGameToLobbyConnection.getPublicVisibleIp()).thenReturn(InetAddress.getLocalHost());
@@ -87,19 +100,12 @@ final class InGameLobbyWatcherTest {
   }
 
   @Test
-  public void testShutDown_gameIdNotNull() throws UnknownHostException {
+  public void testShutDown_gameIdNotNull() throws Exception {
     final String testGameId = "testGameId";
 
     // need to set LOBBY_GAME_COMMENTS system property to avoid NPE in
     // SystemPropertyReader.gameComments()
     System.setProperty(LOBBY_GAME_COMMENTS, "testLobbyGameComments");
-
-    IServerMessenger mockIServerMessenger = mock(IServerMessenger.class);
-    GameToLobbyConnection mockGameToLobbyConnection = mock(GameToLobbyConnection.class);
-    WatcherThreadMessaging mockWatcherThreadMessaging = mock(WatcherThreadMessaging.class);
-    InGameLobbyWatcher mockInGameLobbyWatcher = mock(InGameLobbyWatcher.class);
-    INode mockINode = mock(INode.class);
-    GamePostingResponse mockGamePostingResponse = mock(GamePostingResponse.class);
 
     when(mockIServerMessenger.getLocalNode()).thenReturn(mockINode);
     when(mockGameToLobbyConnection.getPublicVisibleIp()).thenReturn(InetAddress.getLocalHost());

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -33,7 +34,8 @@ final class InGameLobbyWatcherTest {
   @Test
   public void testNewInGameLobbyWatcher_hostNotReachable() throws UnknownHostException {
 
-    // need to set LOBBY_GAME_COMMENTS system property to avoid NPE in SystemPropertyReader.gameComments()
+    // need to set LOBBY_GAME_COMMENTS system property to avoid NPE in
+    // SystemPropertyReader.gameComments()
     System.setProperty(LOBBY_GAME_COMMENTS, "testLobbyGameComments");
 
     IServerMessenger mockIServerMessenger = mock(IServerMessenger.class);
@@ -45,7 +47,8 @@ final class InGameLobbyWatcherTest {
 
     when(mockIServerMessenger.getLocalNode()).thenReturn(mockINode);
     when(mockGameToLobbyConnection.getPublicVisibleIp()).thenReturn(InetAddress.getLocalHost());
-    when(mockGameToLobbyConnection.postGame(any(GamePostingRequest.class))).thenReturn(mockGamePostingResponse);
+    when(mockGameToLobbyConnection.postGame(any(GamePostingRequest.class)))
+        .thenReturn(mockGamePostingResponse);
 
     // simulate "Your computer is not reachable from the internet"
     when(mockGamePostingResponse.isConnectivityCheckSucceeded()).thenReturn(false);
@@ -63,7 +66,13 @@ final class InGameLobbyWatcherTest {
      InGameLobbyWatcher.shutDown was updated to only call GameToLobbyConnection.disconnect if the gameId is not null
      to avoid an IllegalArgumentException that will be thrown by LobbyWatcherClient.removeGame.
     */
-    Optional<InGameLobbyWatcher> createdWatcherOptional = InGameLobbyWatcher.newInGameLobbyWatcher(mockIServerMessenger, mockGameToLobbyConnection, mockWatcherThreadMessaging, mockInGameLobbyWatcher, true);
+    Optional<InGameLobbyWatcher> createdWatcherOptional =
+        InGameLobbyWatcher.newInGameLobbyWatcher(
+            mockIServerMessenger,
+            mockGameToLobbyConnection,
+            mockWatcherThreadMessaging,
+            mockInGameLobbyWatcher,
+            true);
 
     assertTrue(createdWatcherOptional.isPresent());
     assertNull(createdWatcherOptional.get().getGameId());
@@ -73,7 +82,7 @@ final class InGameLobbyWatcherTest {
     verify(mockGameToLobbyConnection).postGame(any(GamePostingRequest.class));
     verify(mockGamePostingResponse).isConnectivityCheckSucceeded();
 
-    //verify GameToLobbyConnection.disconnect is not called since gameId is null
+    // verify GameToLobbyConnection.disconnect is not called since gameId is null
     verify(mockGameToLobbyConnection, never()).disconnect(null);
   }
 
@@ -81,7 +90,8 @@ final class InGameLobbyWatcherTest {
   public void testShutDown_gameIdNotNull() throws UnknownHostException {
     final String testGameId = "testGameId";
 
-    // need to set LOBBY_GAME_COMMENTS system property to avoid NPE in SystemPropertyReader.gameComments()
+    // need to set LOBBY_GAME_COMMENTS system property to avoid NPE in
+    // SystemPropertyReader.gameComments()
     System.setProperty(LOBBY_GAME_COMMENTS, "testLobbyGameComments");
 
     IServerMessenger mockIServerMessenger = mock(IServerMessenger.class);
@@ -93,24 +103,31 @@ final class InGameLobbyWatcherTest {
 
     when(mockIServerMessenger.getLocalNode()).thenReturn(mockINode);
     when(mockGameToLobbyConnection.getPublicVisibleIp()).thenReturn(InetAddress.getLocalHost());
-    when(mockGameToLobbyConnection.postGame(any(GamePostingRequest.class))).thenReturn(mockGamePostingResponse);
+    when(mockGameToLobbyConnection.postGame(any(GamePostingRequest.class)))
+        .thenReturn(mockGamePostingResponse);
     when(mockGamePostingResponse.isConnectivityCheckSucceeded()).thenReturn(true);
     when(mockGamePostingResponse.getGameId()).thenReturn(testGameId);
 
-    //Create an InGameLobbyWatcher with a non-null gameId and call shutDown to verify
+    // Create an InGameLobbyWatcher with a non-null gameId and call shutDown to verify
     // GameToLobbyConnection.disconnect(gameId) is still called
-    Optional<InGameLobbyWatcher> createdWatcherOptional = InGameLobbyWatcher.newInGameLobbyWatcher(mockIServerMessenger, mockGameToLobbyConnection, mockWatcherThreadMessaging, mockInGameLobbyWatcher, true);
+    Optional<InGameLobbyWatcher> createdWatcherOptional =
+        InGameLobbyWatcher.newInGameLobbyWatcher(
+            mockIServerMessenger,
+            mockGameToLobbyConnection,
+            mockWatcherThreadMessaging,
+            mockInGameLobbyWatcher,
+            true);
 
     assertTrue(createdWatcherOptional.isPresent());
     Assertions.assertNotNull(createdWatcherOptional.get().getGameId());
 
     createdWatcherOptional.get().shutDown();
 
-    verify(mockIServerMessenger, times(2)).getLocalNode();
+    verify(mockIServerMessenger, atLeastOnce()).getLocalNode();
     verify(mockGameToLobbyConnection).getPublicVisibleIp();
-    verify(mockGameToLobbyConnection, times(2)).postGame(any(GamePostingRequest.class));
-    verify(mockGamePostingResponse, times(2)).isConnectivityCheckSucceeded();
-    verify(mockGamePostingResponse, times(2)).getGameId();
+    verify(mockGameToLobbyConnection, atLeastOnce()).postGame(any(GamePostingRequest.class));
+    verify(mockGamePostingResponse, atLeastOnce()).isConnectivityCheckSucceeded();
+    verify(mockGamePostingResponse, atLeastOnce()).getGameId();
     verify(mockGameToLobbyConnection).disconnect(testGameId);
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
@@ -1,15 +1,119 @@
 package games.strategy.engine.framework.startup.ui;
 
+import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_COMMENTS;
 import static games.strategy.engine.framework.startup.ui.InGameLobbyWatcher.getLobbySystemProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import games.strategy.engine.framework.startup.WatcherThreadMessaging;
+import games.strategy.net.INode;
+import games.strategy.net.IServerMessenger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.triplea.http.client.lobby.game.lobby.watcher.GamePostingRequest;
+import org.triplea.http.client.lobby.game.lobby.watcher.GamePostingResponse;
+import org.triplea.http.client.web.socket.client.connections.GameToLobbyConnection;
 
 final class InGameLobbyWatcherTest {
+
+  @Test
+  public void testNewInGameLobbyWatcher_hostNotReachable() throws UnknownHostException {
+
+    // need to set LOBBY_GAME_COMMENTS system property to avoid NPE in SystemPropertyReader.gameComments()
+    System.setProperty(LOBBY_GAME_COMMENTS, "testLobbyGameComments");
+
+    IServerMessenger mockIServerMessenger = mock(IServerMessenger.class);
+    GameToLobbyConnection mockGameToLobbyConnection = mock(GameToLobbyConnection.class);
+    WatcherThreadMessaging mockWatcherThreadMessaging = mock(WatcherThreadMessaging.class);
+    InGameLobbyWatcher mockInGameLobbyWatcher = mock(InGameLobbyWatcher.class);
+    INode mockINode = mock(INode.class);
+    GamePostingResponse mockGamePostingResponse = mock(GamePostingResponse.class);
+
+    when(mockIServerMessenger.getLocalNode()).thenReturn(mockINode);
+    when(mockGameToLobbyConnection.getPublicVisibleIp()).thenReturn(InetAddress.getLocalHost());
+    when(mockGameToLobbyConnection.postGame(any(GamePostingRequest.class))).thenReturn(mockGamePostingResponse);
+
+    // simulate "Your computer is not reachable from the internet"
+    when(mockGamePostingResponse.isConnectivityCheckSucceeded()).thenReturn(false);
+
+    /* Issue 10251: (https://github.com/triplea-game/triplea/issues/10251)
+     An extra error message is shown when a player attempts to host a game on the lobby and the call to 'reverse connect'
+     back to the game host fails. This is caused by the assignment to keepAliveTimer in the private InGameLobbyWatcher
+     Constructor which takes 6 arguments. As part of the assignment of keepAliveTimer in that Constructor, a
+     LobbyWatcherKeepAliveTask instance will try to be created via a builder with a null gameId, which will throw a NPE
+     (thrown by javax.annotation.nonnull annotation on gameId). This assignment is ultimately unneeded in this case since
+     the connection failed. To remediate this issue, when the 'reverse connect' fails, both the keepAliveTimer and
+     connectionChangeListener can be set to null (since those fields are final and must be initialized) and we can break
+     out of the constructor method via "return;". This will avoid the assignment of keepAliveTimer
+     (and the NPE causing the additional error window) later in the private constructor code. Additionally,
+     InGameLobbyWatcher.shutDown was updated to only call GameToLobbyConnection.disconnect if the gameId is not null
+     to avoid an IllegalArgumentException that will be thrown by LobbyWatcherClient.removeGame.
+    */
+    Optional<InGameLobbyWatcher> createdWatcherOptional = InGameLobbyWatcher.newInGameLobbyWatcher(mockIServerMessenger, mockGameToLobbyConnection, mockWatcherThreadMessaging, mockInGameLobbyWatcher, true);
+
+    assertTrue(createdWatcherOptional.isPresent());
+    assertNull(createdWatcherOptional.get().getGameId());
+
+    verify(mockIServerMessenger, times(2)).getLocalNode();
+    verify(mockGameToLobbyConnection).getPublicVisibleIp();
+    verify(mockGameToLobbyConnection).postGame(any(GamePostingRequest.class));
+    verify(mockGamePostingResponse).isConnectivityCheckSucceeded();
+
+    //verify GameToLobbyConnection.disconnect is not called since gameId is null
+    verify(mockGameToLobbyConnection, never()).disconnect(null);
+  }
+
+  @Test
+  public void testShutDown_gameIdNotNull() throws UnknownHostException {
+    final String testGameId = "testGameId";
+
+    // need to set LOBBY_GAME_COMMENTS system property to avoid NPE in SystemPropertyReader.gameComments()
+    System.setProperty(LOBBY_GAME_COMMENTS, "testLobbyGameComments");
+
+    IServerMessenger mockIServerMessenger = mock(IServerMessenger.class);
+    GameToLobbyConnection mockGameToLobbyConnection = mock(GameToLobbyConnection.class);
+    WatcherThreadMessaging mockWatcherThreadMessaging = mock(WatcherThreadMessaging.class);
+    InGameLobbyWatcher mockInGameLobbyWatcher = mock(InGameLobbyWatcher.class);
+    INode mockINode = mock(INode.class);
+    GamePostingResponse mockGamePostingResponse = mock(GamePostingResponse.class);
+
+    when(mockIServerMessenger.getLocalNode()).thenReturn(mockINode);
+    when(mockGameToLobbyConnection.getPublicVisibleIp()).thenReturn(InetAddress.getLocalHost());
+    when(mockGameToLobbyConnection.postGame(any(GamePostingRequest.class))).thenReturn(mockGamePostingResponse);
+    when(mockGamePostingResponse.isConnectivityCheckSucceeded()).thenReturn(true);
+    when(mockGamePostingResponse.getGameId()).thenReturn(testGameId);
+
+    //Create an InGameLobbyWatcher with a non-null gameId and call shutDown to verify
+    // GameToLobbyConnection.disconnect(gameId) is still called
+    Optional<InGameLobbyWatcher> createdWatcherOptional = InGameLobbyWatcher.newInGameLobbyWatcher(mockIServerMessenger, mockGameToLobbyConnection, mockWatcherThreadMessaging, mockInGameLobbyWatcher, true);
+
+    assertTrue(createdWatcherOptional.isPresent());
+    Assertions.assertNotNull(createdWatcherOptional.get().getGameId());
+
+    createdWatcherOptional.get().shutDown();
+
+    verify(mockIServerMessenger, times(2)).getLocalNode();
+    verify(mockGameToLobbyConnection).getPublicVisibleIp();
+    verify(mockGameToLobbyConnection, times(2)).postGame(any(GamePostingRequest.class));
+    verify(mockGamePostingResponse, times(2)).isConnectivityCheckSucceeded();
+    verify(mockGamePostingResponse, times(2)).getGameId();
+    verify(mockGameToLobbyConnection).disconnect(testGameId);
+  }
+
   @Nested
   final class GetLobbySystemPropertyTest {
     private static final String KEY = "__GetLobbySystemPropertyTest__key";

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
@@ -33,23 +33,17 @@ import org.triplea.http.client.web.socket.client.connections.GameToLobbyConnecti
 @ExtendWith(MockitoExtension.class)
 final class InGameLobbyWatcherTest {
 
-  @Mock
-  private IServerMessenger mockIServerMessenger;
+  @Mock private IServerMessenger mockIServerMessenger;
 
-  @Mock
-  private GameToLobbyConnection mockGameToLobbyConnection;
+  @Mock private GameToLobbyConnection mockGameToLobbyConnection;
 
-  @Mock
-  private WatcherThreadMessaging mockWatcherThreadMessaging;
+  @Mock private WatcherThreadMessaging mockWatcherThreadMessaging;
 
-  @Mock
-  private InGameLobbyWatcher mockInGameLobbyWatcher;
+  @Mock private InGameLobbyWatcher mockInGameLobbyWatcher;
 
-  @Mock
-  private INode mockINode;
+  @Mock private INode mockINode;
 
-  @Mock
-  private GamePostingResponse mockGamePostingResponse;
+  @Mock private GamePostingResponse mockGamePostingResponse;
 
   @Test
   public void testNewInGameLobbyWatcher_hostNotReachable() throws Exception {


### PR DESCRIPTION
## Change Summary & Additional Notes

Fixes [issue #10251](https://github.com/triplea-game/triplea/issues/10251)

When trying to host a lobby game, if host is unreachable from lobby, return out of InGameLobbyWatcher to avoid initialization of keepAliveTimer done later in the method. This will avoid a NullPointerException thrown by javax.validation.nonnull that would occur when creating a LobbyWatcherKeepAliveTask instance since gameId is null in this case. 

Also update InGameLobbyWatcher.shutDown method to only call gameToLobbyConnection.disconnect if gameId is non-null (and thus game has been successfully created already) since there is no need to call lobby to remove a game that was not successfully created in this case and also to avoid an IllegalArgumentException thrown by LobbyWatcherClient.removeGame when invoked later.

## Release Note
<!--RELEASE_NOTE-->FIX|Remove extra error message window when host is unreachable over internet when attempting to host a lobby game<!--END_RELEASE_NOTE-->
