### PR TITLE
Disable maps-integration test (flaky, hitting rate limits)

### DIFF
--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.StringContains.containsString;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.github.MapRepoListing;
 
@@ -13,6 +14,7 @@ import org.triplea.http.client.github.MapRepoListing;
  * build an indexer and then run indexing on the test map. The test map will be in a known state and
  * we'll then verify the returned indexing results are as expected.
  */
+@Disabled
 public class MapIndexingIntegrationTest {
 
   @Test


### PR DESCRIPTION
Test is failing about as often as it passes. We need to investigate this test and improve its reliability. Stack trace is below, we are being rate-limited by github which fails this test. To fix this we need to find a way to send fewer requests to the github-api while doing integration testing.

```
MapIndexingIntegrationTest > runIndexingOnTestMap() STANDARD_OUT
    2023-01-14 20:38:55,262 [Test worker] o.t.m.i.tasks.CommitDateFetcher ERROR: Could not index map: https://github.com/triplea-maps/test-map, unable to fetch last commit date. Either the last commitdate was missing from the webservice call payload from github, or most likelythe webservice call to github failed.
    feign.FeignException$Forbidden: [403 rate limit exceeded] during [GET] to [https://api.github.com/repos/triplea-maps/test-map/branches/master] [GithubApiFeignClient#getBranchInfo(String,String,String)]: [{"message":"API rate limit exceeded for 13.83.3.160. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
    ]
    	at feign.FeignException.clientErrorStatus(FeignException.java:226)
    	at feign.FeignException.errorStatus(FeignException.java:203)
    	at feign.FeignException.errorStatus(FeignException.java:194)
    	at feign.FeignException.errorStatus(FeignException.java:171)
    	at feign.ResponseHandler.decodeError(ResponseHandler.java:136)
    	at feign.ResponseHandler.handleResponse(ResponseHandler.java:70)
```
