### PR TITLE
AI-test: run in parallel and use @RepeatedTest Annotation

### DIFF
--- a/game-app/smoke-testing/src/test/resources/junit-platform.properties 
+++ b/game-app/smoke-testing/src/test/resources/junit-platform.properties 
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.parallel.mode.classes.default = concurrent


### PR DESCRIPTION
Adds Junit config to run tests in parallel. Reduces test runtime from 37s to 30s

Update test to remove a for loop with junit annotation to repeat the test.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
