### PR TITLE
Build config: remove experimental config (resolve gradle error)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,6 @@ allprojects {
             trimTrailingWhitespace()
         }
     }
-    test {
-        useJUnitPlatform()
-    }
-    dependencies {
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-    }
 }
 
 subprojects {


### PR DESCRIPTION
Remove an experimental config in build.gradle that should not have been checked in a few commits ago. The config causes a minor gradle error (project still compiled, but with a non-blocking error)
