### PR TITLE
Smoke-testing: remove download of full maps, use just test XMLs

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -706,7 +706,7 @@ public class ServerGame extends AbstractGame {
   public void stopGameSequence(final String status, final String title) {
     delegateExecutionStopped =
         launchAction.promptGameStop(
-            status, title, getResourceLoader().getAssetPaths().stream().findAny().orElseThrow());
+            status, title, getResourceLoader().getAssetPaths().stream().findAny().orElse(null));
   }
 
   public boolean isGameSequenceRunning() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LaunchAction.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LaunchAction.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.triplea.game.chat.ChatModel;
 
 /**
@@ -64,7 +65,7 @@ public interface LaunchAction {
    *
    * @return true if the game should stop execution, false otherwise.
    */
-  boolean promptGameStop(String status, String title, Path mapLocation);
+  boolean promptGameStop(String status, String title, @Nullable Path mapLocation);
 
   PlayerTypes.Type getDefaultLocalPlayerType();
 }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedLaunchAction.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedLaunchAction.java
@@ -29,6 +29,7 @@ import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
@@ -193,9 +194,10 @@ public class HeadedLaunchAction implements LaunchAction {
   }
 
   @Override
-  public boolean promptGameStop(String status, String title, Path mapLocation) {
+  public boolean promptGameStop(String status, String title, @Nullable Path mapLocation) {
     // now tell the HOST, and see if they want to continue the game.
-    String displayMessage = LocalizeHtml.localizeImgLinksInHtml(status, mapLocation);
+    String displayMessage =
+        mapLocation == null ? status : LocalizeHtml.localizeImgLinksInHtml(status, mapLocation);
     if (displayMessage.endsWith("</body>")) {
       displayMessage =
           displayMessage.substring(0, displayMessage.length() - "</body>".length())

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -62,6 +62,8 @@ public final class HeadlessGameRunner {
         .build()
         .unzipMapFiles();
 
+    log.info(
+        "Using map folder: " + ClientSetting.mapFolderOverride.getValueOrThrow().toAbsolutePath());
     try {
       HeadlessGameServer.runHeadlessGameServer();
     } catch (final Exception e) {

--- a/game-app/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/game-app/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -7,15 +7,12 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 
 import games.strategy.engine.framework.ServerGame;
-import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.triplea.delegate.EndRoundDelegate;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * End-to-end test that starts all-AI games on a selected set of maps and verifies they conclude
@@ -29,13 +26,9 @@ public class AiGameTest {
     GameTestUtils.setUp();
   }
 
-  @ParameterizedTest
-  @CsvSource({
-    "map_making_tutorial,map/games/Test1.xml",
-  })
-  void testAiGame(String mapName, String mapXmlPath) throws Exception {
-    GameSelectorModel gameSelector = GameTestUtils.loadGameFromURI(mapName, mapXmlPath);
-    ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
+  @Test
+  void testAiGame() {
+    ServerGame game = GameTestUtils.setUpGameWithAis("Test1.xml");
     game.setStopGameOnDelegateExecutionStop(true);
     while (!game.isGameOver()) {
       if (game.getData().getSequence().getRound() > 100) {
@@ -55,9 +48,7 @@ public class AiGameTest {
   @RepeatedTest(10)
   // Run the first round of all-AI game several times. Ensure no errors and no winner so early.
   void testFirstRoundTenTimes() throws Exception {
-    GameSelectorModel gameSelector =
-        GameTestUtils.loadGameFromURI("map_making_tutorial", "map/games/Test1.xml");
-    ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
+    ServerGame game = GameTestUtils.setUpGameWithAis("Test1.xml");
     game.setStopGameOnDelegateExecutionStop(true);
     while (!game.isGameOver() && game.getData().getSequence().getRound() < 2) {
       game.runNextStep();
@@ -73,8 +64,8 @@ public class AiGameTest {
   }
 
   @Test
-  void testAiGameWithConsumedUnits() throws Exception {
-    ServerGame game = loadImperialism1974();
+  void testAiGameWithConsumedUnits() {
+    ServerGame game = GameTestUtils.setUpGameWithAis("imperialism_1974_board_game.xml");
     game.getData().preGameDisablePlayers(p -> !p.getName().equals("Blue"));
     game.setUpGameForRunningSteps();
 
@@ -94,8 +85,8 @@ public class AiGameTest {
   }
 
   @Test
-  void testAiGameMovingConsumedUnitsToFactories() throws Exception {
-    ServerGame game = loadImperialism1974();
+  void testAiGameMovingConsumedUnitsToFactories() {
+    ServerGame game = GameTestUtils.setUpGameWithAis("imperialism_1974_board_game.xml");
     GameData gameData = game.getData();
     gameData.preGameDisablePlayers(p -> !p.getName().equals("Blue"));
     game.setUpGameForRunningSteps();
@@ -125,13 +116,6 @@ public class AiGameTest {
     // Verify that the Culiacan wealth was moved to Oaxaca (that has a port).
     assertThat(GameTestUtils.countUnitsOfType(oaxaca, blue, "wealth"), is(1));
     assertThat(GameTestUtils.countUnitsOfType(culiacan, blue, "wealth"), is(0));
-  }
-
-  private ServerGame loadImperialism1974() throws Exception {
-    GameSelectorModel gameSelector =
-        GameTestUtils.loadGameFromURI(
-            "imperialism_1974_board_game", "map/games/imperialism_1974_board_game.xml");
-    return GameTestUtils.setUpGameWithAis(gameSelector);
   }
 
   private String getResourceSummary(GameData gameData) {

--- a/game-app/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/game-app/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -7,13 +7,12 @@ import static org.hamcrest.io.FileMatchers.aFileWithSize;
 
 import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.ServerGame;
-import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Checks that no error is encountered when saving a game on several different maps. This test
@@ -29,17 +28,18 @@ class GameSaveTest {
     GameTestUtils.setUp();
   }
 
+  /** Validates that we can properly create a save game file without any errors. */
   @ParameterizedTest
-  @CsvSource({
-    "map_making_tutorial,map/games/Test1.xml",
-    "minimap,map/games/minimap.xml",
-    "world_war_ii_revised,map/games/ww2v2.xml",
-    "pacific_challenge,map/games/Pacific_Theater_Solo_Challenge.xml",
-    "imperialism_1974_board_game,map/games/imperialism_1974_board_game.xml",
-  })
-  void testSaveGame(String mapName, String mapXmlPath) throws Exception {
-    GameSelectorModel gameSelector = GameTestUtils.loadGameFromURI(mapName, mapXmlPath);
-    ServerGame game = GameTestUtils.setUpGameWithAis(gameSelector);
+  @ValueSource(
+      strings = {
+        "Test1.xml",
+        "minimap.xml",
+        "ww2v2.xml",
+        "Pacific_Theater_Solo_Challenge.xml",
+        "imperialism_1974_board_game.xml"
+      })
+  void testSaveGame(String mapXmlPath) throws Exception {
+    ServerGame game = GameTestUtils.setUpGameWithAis(mapXmlPath);
     Path saveFile = Files.createTempFile("save", GameDataFileUtils.getExtension());
     game.saveGame(saveFile);
     assertThat(saveFile.toFile(), is(not(aFileWithSize(0))));

--- a/game-app/smoke-testing/src/test/resources/map-xmls/imperialism_1974_board_game.xml
+++ b/game-app/smoke-testing/src/test/resources/map-xmls/imperialism_1974_board_game.xml
@@ -1,0 +1,2166 @@
+<?xml version="1.0"?>
+<!DOCTYPE game SYSTEM "game.dtd">
+<game>
+	<info name="Imperialism 1974 Board Game" version="0.5"/>
+	<triplea minimumVersion="2.5"/>
+	<loader javaClass="games.strategy.triplea.TripleA"/>
+	<variableList>
+		<variable name="nums_1_to_6">
+			<element name="1"/>
+			<element name="2"/>
+			<element name="3"/>
+			<element name="4"/>
+			<element name="5"/>
+			<element name="6"/>
+		</variable>
+		<variable name="nums_1_to_25">
+			<element name="1"/>
+			<element name="2"/>
+			<element name="3"/>
+			<element name="4"/>
+			<element name="5"/>
+			<element name="6"/>
+			<element name="7"/>
+			<element name="8"/>
+			<element name="9"/>
+			<element name="10"/>
+			<element name="11"/>
+			<element name="12"/>
+			<element name="13"/>
+			<element name="14"/>
+			<element name="15"/>
+			<element name="16"/>
+			<element name="17"/>
+			<element name="18"/>
+			<element name="19"/>
+			<element name="20"/>
+			<element name="21"/>
+			<element name="22"/>
+			<element name="23"/>
+			<element name="24"/>
+			<element name="25"/>
+		</variable>
+		<variable name="players">
+			<element name="Blue"/>
+			<element name="Red"/>
+			<element name="Green"/>
+			<element name="Yellow"/>
+			<element name="Orange"/>
+			<element name="Cyan"/>
+			<element name="Purple"/>
+			<element name="Brown"/>
+		</variable>
+		<variable name="players_and_neutral">
+			<element name="Blue"/>
+			<element name="Red"/>
+			<element name="Green"/>
+			<element name="Yellow"/>
+			<element name="Orange"/>
+			<element name="Cyan"/>
+			<element name="Purple"/>
+			<element name="Brown"/>
+			<element name="Neutrals"/>
+		</variable>
+		<variable name="mountains">
+			<element name="Pskov"/>
+			<element name="Bari"/>
+		</variable>
+		<variable name="old_world_land_territories">
+			<element name="Anyang"/>
+			<element name="Babruysk"/>
+			<element name="Bac Lieu"/>
+			<element name="Chefoe"/>
+			<element name="Harbin"/>
+			<element name="Imphal"/>
+			<element name="Ivanovo"/>
+			<element name="Kazan"/>
+			<element name="Kirov"/>
+			<element name="Kowloon"/>
+			<element name="Lubo"/>
+			<element name="Pskov"/>
+			<element name="Tomsk"/>
+		</variable>
+		<variable name="new_world_land_territories">
+			<element name="Aduwa"/>
+			<element name="Aki-Aki"/>
+			<element name="Ambo"/>
+			<element name="Andres"/>
+			<element name="Bari"/>
+			<element name="Billings"/>
+			<element name="Cartagena"/>
+			<element name="Cork"/>
+			<element name="Culiacan"/>
+			<element name="Dominica"/>
+			<element name="Galway"/>
+			<element name="Gondar"/>
+			<element name="Helena"/>
+			<element name="Juwara"/>
+			<element name="Leon"/>
+			<element name="Lodwar"/>
+			<element name="Malden"/>
+			<element name="Mersin"/>
+			<element name="Nicosia"/>
+			<element name="Oaxaca"/>
+			<element name="Palma"/>
+			<element name="Palmyra"/>
+			<element name="Reno"/>
+			<element name="St Lucia"/>
+			<element name="Tebuk"/>
+			<element name="Waco"/>
+			<element name="Yorkton"/>
+		</variable>
+		<variable name="land_territories">
+			<element name="Aduwa"/>
+			<element name="Aki-Aki"/>
+			<element name="Ambo"/>
+			<element name="Andres"/>
+			<element name="Anyang"/>
+			<element name="Babruysk"/>
+			<element name="Bac Lieu"/>
+			<element name="Bari"/>
+			<element name="Billings"/>
+			<element name="Cartagena"/>
+			<element name="Chefoe"/>
+			<element name="Cork"/>
+			<element name="Culiacan"/>
+			<element name="Dominica"/>
+			<element name="Galway"/>
+			<element name="Gondar"/>
+			<element name="Harbin"/>
+			<element name="Helena"/>
+			<element name="Imphal"/>
+			<element name="Ivanovo"/>
+			<element name="Juwara"/>
+			<element name="Kazan"/>
+			<element name="Kirov"/>
+			<element name="Kowloon"/>
+			<element name="Leon"/>
+			<element name="Lodwar"/>
+			<element name="Lubo"/>
+			<element name="Malden"/>
+			<element name="Mersin"/>
+			<element name="Nicosia"/>
+			<element name="Oaxaca"/>
+			<element name="Palma"/>
+			<element name="Palmyra"/>
+			<element name="Pskov"/>
+			<element name="Reno"/>
+			<element name="St Lucia"/>
+			<element name="Tebuk"/>
+			<element name="Tomsk"/>
+			<element name="Waco"/>
+			<element name="Yorkton"/>
+		</variable>
+		<variable name="water_territories">
+			<element name="Eastern Sea"/>
+			<element name="Ice Sea"/>
+			<element name="Juwara Sea"/>
+			<element name="North Sea"/>
+			<element name="Sea of Doom"/>
+			<element name="Sea of Leon"/>
+			<element name="Sea of Lodwar"/>
+			<element name="Sea of No Return"/>
+			<element name="Sea of Peace"/>
+			<element name="Sea of Tebuk"/>
+			<element name="South Central Sea"/>
+			<element name="Southern Ocean"/>
+			<element name="The Blue Sea"/>
+			<element name="The Passage"/>
+			<element name="Western Ocean"/>
+			<element name="Aduwa E Coast"/>
+			<element name="Aduwa N Coast"/>
+			<element name="Aki-Aki E Coast"/>
+			<element name="Aki-Aki W Coast"/>
+			<element name="Ambo S Coast"/>
+			<element name="Ambo W Coast"/>
+			<element name="Andres Coast"/>
+			<element name="Babruysk E Coast"/>
+			<element name="Babruysk N Coast"/>
+			<element name="Billings N Coast"/>
+			<element name="Billings S Coast"/>
+			<element name="Billings W Coast"/>
+			<element name="Cartagena Coast"/>
+			<element name="Chefoe N Coast"/>
+			<element name="Chefoe W Coast"/>
+			<element name="Cork N Coast"/>
+			<element name="Cork S Coast"/>
+			<element name="Culiacan N Coast"/>
+			<element name="Culiacan W Coast"/>
+			<element name="Dominica S Coast"/>
+			<element name="Dominica W Coast"/>
+			<element name="Galway N Coast"/>
+			<element name="Galway NW Coast"/>
+			<element name="Galway S Coast"/>
+			<element name="Galway SW Coast"/>
+			<element name="Gondar N Coast"/>
+			<element name="Gondar W Coast"/>
+			<element name="Harbin Coast"/>
+			<element name="Helena E Coast"/>
+			<element name="Helena N Coast"/>
+			<element name="Helena S Coast"/>
+			<element name="Imphal Coast"/>
+			<element name="Ivanovo Coast"/>
+			<element name="Juwara Coast"/>
+			<element name="Kazan Coast"/>
+			<element name="Kirov E Coast"/>
+			<element name="Kirov S Coast"/>
+			<element name="Kowloon S Coast"/>
+			<element name="Kowloon W Coast"/>
+			<element name="Lodwar E Coast"/>
+			<element name="Lodwar N Coast"/>
+			<element name="Lodwar W Coast"/>
+			<element name="Lubo Coast"/>
+			<element name="Malden Coast"/>
+			<element name="Mersin E Coast"/>
+			<element name="Mersin N Coast"/>
+			<element name="Nicosia N Coast"/>
+			<element name="Nicosia NW Coast"/>
+			<element name="Nicosia W Coast"/>
+			<element name="North Central Ocean"/>
+			<element name="Oaxaca Coast"/>
+			<element name="Palma S Coast"/>
+			<element name="Palma W Coast"/>
+			<element name="Palmyra E Coast"/>
+			<element name="Palmyra N Coast"/>
+			<element name="Palmyra W Coast"/>
+			<element name="Reno Coast"/>
+			<element name="St Lucia E Coast"/>
+			<element name="St Lucia S Coast"/>
+			<element name="Tebuk E Coast"/>
+			<element name="Tebuk S Coast"/>
+			<element name="Waco S Coast"/>
+			<element name="Waco SE Coast"/>
+			<element name="Yorkton Coast"/>
+		</variable>
+	</variableList>
+	<map>
+		<!-- Territory Definitions -->
+		<territory name="Aduwa"/>
+		<territory name="Aki-Aki"/>
+		<territory name="Ambo"/>
+		<territory name="Andres"/>
+		<territory name="Anyang"/>
+		<territory name="Babruysk"/>
+		<territory name="Bac Lieu"/>
+		<territory name="Bari"/>
+		<territory name="Billings"/>
+		<territory name="Cartagena"/>
+		<territory name="Chefoe"/>
+		<territory name="Cork"/>
+		<territory name="Culiacan"/>
+		<territory name="Dominica"/>
+		<territory name="Galway"/>
+		<territory name="Gondar"/>
+		<territory name="Harbin"/>
+		<territory name="Helena"/>
+		<territory name="Imphal"/>
+		<territory name="Ivanovo"/>
+		<territory name="Juwara"/>
+		<territory name="Kazan"/>
+		<territory name="Kirov"/>
+		<territory name="Kowloon"/>
+		<territory name="Leon"/>
+		<territory name="Lodwar"/>
+		<territory name="Lubo"/>
+		<territory name="Malden"/>
+		<territory name="Mersin"/>
+		<territory name="Nicosia"/>
+		<territory name="Oaxaca"/>
+		<territory name="Palma"/>
+		<territory name="Palmyra"/>
+		<territory name="Pskov"/>
+		<territory name="Reno"/>
+		<territory name="St Lucia"/>
+		<territory name="Tebuk"/>
+		<territory name="Tomsk"/>
+		<territory name="Waco"/>
+		<territory name="Yorkton"/>
+		<territory name="Eastern Sea" water="true"/>
+		<territory name="Ice Sea" water="true"/>
+		<territory name="Juwara Sea" water="true"/>
+		<territory name="North Sea" water="true"/>
+		<territory name="Sea of Doom" water="true"/>
+		<territory name="Sea of Leon" water="true"/>
+		<territory name="Sea of Lodwar" water="true"/>
+		<territory name="Sea of No Return" water="true"/>
+		<territory name="Sea of Peace" water="true"/>
+		<territory name="Sea of Tebuk" water="true"/>
+		<territory name="South Central Sea" water="true"/>
+		<territory name="Southern Ocean" water="true"/>
+		<territory name="The Blue Sea" water="true"/>
+		<territory name="The Passage" water="true"/>
+		<territory name="Western Ocean" water="true"/>
+		<territory name="Aduwa E Coast" water="true"/>
+		<territory name="Aduwa N Coast" water="true"/>
+		<territory name="Aki-Aki E Coast" water="true"/>
+		<territory name="Aki-Aki W Coast" water="true"/>
+		<territory name="Ambo S Coast" water="true"/>
+		<territory name="Ambo W Coast" water="true"/>
+		<territory name="Andres Coast" water="true"/>
+		<territory name="Babruysk E Coast" water="true"/>
+		<territory name="Babruysk N Coast" water="true"/>
+		<territory name="Billings N Coast" water="true"/>
+		<territory name="Billings S Coast" water="true"/>
+		<territory name="Billings W Coast" water="true"/>
+		<territory name="Cartagena Coast" water="true"/>
+		<territory name="Chefoe N Coast" water="true"/>
+		<territory name="Chefoe W Coast" water="true"/>
+		<territory name="Cork N Coast" water="true"/>
+		<territory name="Cork S Coast" water="true"/>
+		<territory name="Culiacan N Coast" water="true"/>
+		<territory name="Culiacan W Coast" water="true"/>
+		<territory name="Dominica S Coast" water="true"/>
+		<territory name="Dominica W Coast" water="true"/>
+		<territory name="Galway N Coast" water="true"/>
+		<territory name="Galway NW Coast" water="true"/>
+		<territory name="Galway S Coast" water="true"/>
+		<territory name="Galway SW Coast" water="true"/>
+		<territory name="Gondar N Coast" water="true"/>
+		<territory name="Gondar W Coast" water="true"/>
+		<territory name="Harbin Coast" water="true"/>
+		<territory name="Helena E Coast" water="true"/>
+		<territory name="Helena N Coast" water="true"/>
+		<territory name="Helena S Coast" water="true"/>
+		<territory name="Imphal Coast" water="true"/>
+		<territory name="Ivanovo Coast" water="true"/>
+		<territory name="Juwara Coast" water="true"/>
+		<territory name="Kazan Coast" water="true"/>
+		<territory name="Kirov E Coast" water="true"/>
+		<territory name="Kirov S Coast" water="true"/>
+		<territory name="Kowloon S Coast" water="true"/>
+		<territory name="Kowloon W Coast" water="true"/>
+		<territory name="Lodwar E Coast" water="true"/>
+		<territory name="Lodwar N Coast" water="true"/>
+		<territory name="Lodwar W Coast" water="true"/>
+		<territory name="Lubo Coast" water="true"/>
+		<territory name="Malden Coast" water="true"/>
+		<territory name="Mersin E Coast" water="true"/>
+		<territory name="Mersin N Coast" water="true"/>
+		<territory name="Nicosia N Coast" water="true"/>
+		<territory name="Nicosia NW Coast" water="true"/>
+		<territory name="Nicosia W Coast" water="true"/>
+		<territory name="North Central Ocean" water="true"/>
+		<territory name="Oaxaca Coast" water="true"/>
+		<territory name="Palma S Coast" water="true"/>
+		<territory name="Palma W Coast" water="true"/>
+		<territory name="Palmyra E Coast" water="true"/>
+		<territory name="Palmyra N Coast" water="true"/>
+		<territory name="Palmyra W Coast" water="true"/>
+		<territory name="Reno Coast" water="true"/>
+		<territory name="St Lucia E Coast" water="true"/>
+		<territory name="St Lucia S Coast" water="true"/>
+		<territory name="Tebuk E Coast" water="true"/>
+		<territory name="Tebuk S Coast" water="true"/>
+		<territory name="Waco S Coast" water="true"/>
+		<territory name="Waco SE Coast" water="true"/>
+		<territory name="Yorkton Coast" water="true"/>
+		<!-- Wealth Roll territory is where the wealth die is shown. -->
+		<territory name="Wealth Roll" water="true"/>
+		<!-- Threat territory, adjacent to all land territories to make AIs not abandon their territories. -->
+		<territory name="Threat"/>
+		<connection t1="Threat" t2="Aduwa"/>
+		<connection t1="Threat" t2="Aki-Aki"/>
+		<connection t1="Threat" t2="Ambo"/>
+		<connection t1="Threat" t2="Andres"/>
+		<connection t1="Threat" t2="Anyang"/>
+		<connection t1="Threat" t2="Babruysk"/>
+		<connection t1="Threat" t2="Bac Lieu"/>
+		<connection t1="Threat" t2="Bari"/>
+		<connection t1="Threat" t2="Billings"/>
+		<connection t1="Threat" t2="Cartagena"/>
+		<connection t1="Threat" t2="Chefoe"/>
+		<connection t1="Threat" t2="Cork"/>
+		<connection t1="Threat" t2="Culiacan"/>
+		<connection t1="Threat" t2="Dominica"/>
+		<connection t1="Threat" t2="Galway"/>
+		<connection t1="Threat" t2="Gondar"/>
+		<connection t1="Threat" t2="Harbin"/>
+		<connection t1="Threat" t2="Helena"/>
+		<connection t1="Threat" t2="Imphal"/>
+		<connection t1="Threat" t2="Ivanovo"/>
+		<connection t1="Threat" t2="Juwara"/>
+		<connection t1="Threat" t2="Kazan"/>
+		<connection t1="Threat" t2="Kirov"/>
+		<connection t1="Threat" t2="Kowloon"/>
+		<connection t1="Threat" t2="Leon"/>
+		<connection t1="Threat" t2="Lodwar"/>
+		<connection t1="Threat" t2="Lubo"/>
+		<connection t1="Threat" t2="Malden"/>
+		<connection t1="Threat" t2="Mersin"/>
+		<connection t1="Threat" t2="Nicosia"/>
+		<connection t1="Threat" t2="Oaxaca"/>
+		<connection t1="Threat" t2="Palma"/>
+		<connection t1="Threat" t2="Palmyra"/>
+		<connection t1="Threat" t2="Pskov"/>
+		<connection t1="Threat" t2="Reno"/>
+		<connection t1="Threat" t2="St Lucia"/>
+		<connection t1="Threat" t2="Tebuk"/>
+		<connection t1="Threat" t2="Tomsk"/>
+		<connection t1="Threat" t2="Waco"/>
+		<connection t1="Threat" t2="Yorkton"/>
+		<!-- Territory Connections -->
+		<connection t1="Aduwa" t2="Aduwa E Coast"/>
+		<connection t1="Aduwa" t2="Aduwa N Coast"/>
+		<connection t1="Aduwa" t2="Ambo"/>
+		<connection t1="Aduwa" t2="Gondar"/>
+		<connection t1="Aduwa E Coast" t2="Aduwa N Coast"/>
+		<connection t1="Aduwa E Coast" t2="Ambo S Coast"/>
+		<connection t1="Aduwa E Coast" t2="South Central Sea"/>
+		<connection t1="Aduwa N Coast" t2="Gondar N Coast"/>
+		<connection t1="Aduwa N Coast" t2="The Blue Sea"/>
+		<connection t1="Aki-Aki" t2="Aki-Aki E Coast"/>
+		<connection t1="Aki-Aki" t2="Aki-Aki W Coast"/>
+		<connection t1="Aki-Aki" t2="Malden"/>
+		<connection t1="Aki-Aki" t2="Palmyra"/>
+		<connection t1="Aki-Aki E Coast" t2="Aki-Aki W Coast"/>
+		<connection t1="Aki-Aki E Coast" t2="North Central Ocean"/>
+		<connection t1="Aki-Aki E Coast" t2="Palmyra E Coast"/>
+		<connection t1="Aki-Aki W Coast" t2="Malden Coast"/>
+		<connection t1="Aki-Aki W Coast" t2="The Blue Sea"/>
+		<connection t1="Ambo" t2="Ambo S Coast"/>
+		<connection t1="Ambo" t2="Ambo W Coast"/>
+		<connection t1="Ambo" t2="Gondar"/>
+		<connection t1="Ambo S Coast" t2="Ambo W Coast"/>
+		<connection t1="Ambo S Coast" t2="South Central Sea"/>
+		<connection t1="Ambo W Coast" t2="Gondar W Coast"/>
+		<connection t1="Ambo W Coast" t2="Sea of Lodwar"/>
+		<connection t1="Ambo W Coast" t2="South Central Sea"/>
+		<connection t1="Andres" t2="Andres Coast"/>
+		<connection t1="Andres" t2="Dominica"/>
+		<connection t1="Andres" t2="Leon"/>
+		<connection t1="Andres" t2="Oaxaca"/>
+		<connection t1="Andres" t2="St Lucia"/>
+		<connection t1="Andres Coast" t2="Oaxaca Coast"/>
+		<connection t1="Andres Coast" t2="Sea of Leon"/>
+		<connection t1="Andres Coast" t2="St Lucia E Coast"/>
+		<connection t1="Anyang" t2="Bac Lieu"/>
+		<connection t1="Anyang" t2="Harbin"/>
+		<connection t1="Anyang" t2="Lubo"/>
+		<connection t1="Babruysk" t2="Babruysk E Coast"/>
+		<connection t1="Babruysk" t2="Babruysk N Coast"/>
+		<connection t1="Babruysk" t2="Harbin"/>
+		<connection t1="Babruysk" t2="Ivanovo"/>
+		<connection t1="Babruysk" t2="Kazan"/>
+		<connection t1="Babruysk" t2="Kirov"/>
+		<connection t1="Babruysk" t2="Pskov"/>
+		<connection t1="Babruysk E Coast" t2="Babruysk N Coast"/>
+		<connection t1="Babruysk E Coast" t2="Kirov E Coast"/>
+		<connection t1="Babruysk E Coast" t2="Sea of Peace"/>
+		<connection t1="Babruysk N Coast" t2="Harbin Coast"/>
+		<connection t1="Babruysk N Coast" t2="North Sea"/>
+		<connection t1="Bac Lieu" t2="Harbin"/>
+		<connection t1="Bac Lieu" t2="Imphal"/>
+		<connection t1="Bac Lieu" t2="Kazan"/>
+		<connection t1="Bac Lieu" t2="Kowloon"/>
+		<connection t1="Bari" t2="Cartagena"/>
+		<connection t1="Bari" t2="Mersin"/>
+		<connection t1="Bari" t2="Nicosia"/>
+		<connection t1="Billings" t2="Billings N Coast"/>
+		<connection t1="Billings" t2="Billings S Coast"/>
+		<connection t1="Billings" t2="Billings W Coast"/>
+		<connection t1="Billings" t2="Reno"/>
+		<connection t1="Billings" t2="Yorkton"/>
+		<connection t1="Billings N Coast" t2="Billings W Coast"/>
+		<connection t1="Billings N Coast" t2="Reno Coast"/>
+		<connection t1="Billings N Coast" t2="South Central Sea"/>
+		<connection t1="Billings S Coast" t2="Billings W Coast"/>
+		<connection t1="Billings S Coast" t2="Southern Ocean"/>
+		<connection t1="Billings S Coast" t2="Yorkton Coast"/>
+		<connection t1="Billings W Coast" t2="Sea of Tebuk"/>
+		<connection t1="Cartagena" t2="Cartagena Coast"/>
+		<connection t1="Cartagena" t2="Mersin"/>
+		<connection t1="Cartagena" t2="Nicosia"/>
+		<connection t1="Cartagena" t2="Palma"/>
+		<connection t1="Cartagena Coast" t2="Eastern Sea"/>
+		<connection t1="Cartagena Coast" t2="Mersin E Coast"/>
+		<connection t1="Cartagena Coast" t2="Palma S Coast"/>
+		<connection t1="Chefoe" t2="Chefoe N Coast"/>
+		<connection t1="Chefoe" t2="Chefoe W Coast"/>
+		<connection t1="Chefoe" t2="Kowloon"/>
+		<connection t1="Chefoe" t2="Lubo"/>
+		<connection t1="Chefoe N Coast" t2="Chefoe W Coast"/>
+		<connection t1="Chefoe N Coast" t2="Lubo Coast"/>
+		<connection t1="Chefoe N Coast" t2="North Sea"/>
+		<connection t1="Chefoe W Coast" t2="Kowloon W Coast"/>
+		<connection t1="Chefoe W Coast" t2="Western Ocean"/>
+		<connection t1="Cork" t2="Cork N Coast"/>
+		<connection t1="Cork" t2="Cork S Coast"/>
+		<connection t1="Cork" t2="Galway"/>
+		<connection t1="Cork N Coast" t2="Cork S Coast"/>
+		<connection t1="Cork N Coast" t2="Eastern Sea"/>
+		<connection t1="Cork N Coast" t2="Galway N Coast"/>
+		<connection t1="Cork S Coast" t2="Galway S Coast"/>
+		<connection t1="Cork S Coast" t2="Ice Sea"/>
+		<connection t1="Culiacan" t2="Culiacan N Coast"/>
+		<connection t1="Culiacan" t2="Culiacan W Coast"/>
+		<connection t1="Culiacan" t2="Dominica"/>
+		<connection t1="Culiacan" t2="Oaxaca"/>
+		<connection t1="Culiacan N Coast" t2="Culiacan W Coast"/>
+		<connection t1="Culiacan N Coast" t2="Oaxaca Coast"/>
+		<connection t1="Culiacan N Coast" t2="Sea of Leon"/>
+		<connection t1="Culiacan W Coast" t2="Sea of Peace"/>
+		<connection t1="Culiacan W Coast" t2="Dominica W Coast"/>
+		<connection t1="Dominica" t2="Dominica S Coast"/>
+		<connection t1="Dominica" t2="Dominica W Coast"/>
+		<connection t1="Dominica" t2="Leon"/>
+		<connection t1="Dominica" t2="Oaxaca"/>
+		<connection t1="Dominica" t2="St Lucia"/>
+		<connection t1="Dominica S Coast" t2="Dominica W Coast"/>
+		<connection t1="Dominica S Coast" t2="Sea of Doom"/>
+		<connection t1="Dominica S Coast" t2="St Lucia S Coast"/>
+		<connection t1="Dominica W Coast" t2="Sea of Peace"/>
+		<connection t1="Eastern Sea" t2="Galway N Coast"/>
+		<connection t1="Eastern Sea" t2="Ice Sea"/>
+		<connection t1="Eastern Sea" t2="Mersin E Coast"/>
+		<connection t1="Eastern Sea" t2="Palma S Coast"/>
+		<connection t1="Eastern Sea" t2="Sea of Doom"/>
+		<connection t1="Eastern Sea" t2="The Passage"/>
+		<connection t1="Galway" t2="Galway N Coast"/>
+		<connection t1="Galway" t2="Galway NW Coast"/>
+		<connection t1="Galway" t2="Galway S Coast"/>
+		<connection t1="Galway" t2="Galway SW Coast"/>
+		<connection t1="Galway N Coast" t2="Galway NW Coast"/>
+		<connection t1="Galway NW Coast" t2="Eastern Sea"/>
+		<connection t1="Galway NW Coast" t2="Galway SW Coast"/>
+		<connection t1="Galway NW Coast" t2="The Passage"/>
+		<connection t1="Galway S Coast" t2="Galway SW Coast"/>
+		<connection t1="Galway S Coast" t2="Ice Sea"/>
+		<connection t1="Galway SW Coast" t2="Sea of No Return"/>
+		<connection t1="Gondar" t2="Gondar N Coast"/>
+		<connection t1="Gondar" t2="Gondar W Coast"/>
+		<connection t1="Gondar N Coast" t2="Gondar W Coast"/>
+		<connection t1="Gondar N Coast" t2="The Blue Sea"/>
+		<connection t1="Gondar W Coast" t2="Sea of Lodwar"/>
+		<connection t1="Harbin" t2="Harbin Coast"/>
+		<connection t1="Harbin" t2="Kazan"/>
+		<connection t1="Harbin" t2="Lubo"/>
+		<connection t1="Harbin" t2="Tomsk"/>
+		<connection t1="Harbin Coast" t2="Lubo Coast"/>
+		<connection t1="Harbin Coast" t2="North Sea"/>
+		<connection t1="Helena" t2="Helena E Coast"/>
+		<connection t1="Helena" t2="Helena N Coast"/>
+		<connection t1="Helena" t2="Helena S Coast"/>
+		<connection t1="Helena" t2="Reno"/>
+		<connection t1="Helena" t2="Waco"/>
+		<connection t1="Helena E Coast" t2="Helena N Coast"/>
+		<connection t1="Helena E Coast" t2="Helena S Coast"/>
+		<connection t1="Helena E Coast" t2="The Passage"/>
+		<connection t1="Helena N Coast" t2="Reno Coast"/>
+		<connection t1="Helena N Coast" t2="South Central Sea"/>
+		<connection t1="Helena S Coast" t2="Sea of No Return"/>
+		<connection t1="Helena S Coast" t2="The Passage"/>
+		<connection t1="Helena S Coast" t2="Waco SE Coast"/>
+		<connection t1="Ice Sea" t2="Sea of No Return"/>
+		<connection t1="Imphal" t2="Imphal Coast"/>
+		<connection t1="Imphal" t2="Kazan"/>
+		<connection t1="Imphal" t2="Kowloon"/>
+		<connection t1="Imphal Coast" t2="Kazan Coast"/>
+		<connection t1="Imphal Coast" t2="Kowloon S Coast"/>
+		<connection t1="Imphal Coast" t2="The Blue Sea"/>
+		<connection t1="Ivanovo" t2="Ivanovo Coast"/>
+		<connection t1="Ivanovo" t2="Kazan"/>
+		<connection t1="Ivanovo" t2="Kirov"/>
+		<connection t1="Ivanovo Coast" t2="Kazan Coast"/>
+		<connection t1="Ivanovo Coast" t2="Kirov S Coast"/>
+		<connection t1="Ivanovo Coast" t2="The Blue Sea"/>
+		<connection t1="Juwara" t2="Juwara Coast"/>
+		<connection t1="Juwara" t2="Lodwar"/>
+		<connection t1="Juwara" t2="Tebuk"/>
+		<connection t1="Juwara Coast" t2="Juwara Sea"/>
+		<connection t1="Juwara Coast" t2="Lodwar W Coast"/>
+		<connection t1="Juwara Coast" t2="Tebuk S Coast"/>
+		<connection t1="Juwara Sea" t2="Lodwar W Coast"/>
+		<connection t1="Juwara Sea" t2="Sea of Lodwar"/>
+		<connection t1="Juwara Sea" t2="Sea of Tebuk"/>
+		<connection t1="Juwara Sea" t2="Southern Ocean"/>
+		<connection t1="Juwara Sea" t2="Tebuk S Coast"/>
+		<connection t1="Kazan" t2="Kazan Coast"/>
+		<connection t1="Kazan" t2="Tomsk"/>
+		<connection t1="Kazan Coast" t2="The Blue Sea"/>
+		<connection t1="Kirov" t2="Kirov E Coast"/>
+		<connection t1="Kirov" t2="Kirov S Coast"/>
+		<connection t1="Kirov E Coast" t2="Kirov S Coast"/>
+		<connection t1="Kirov E Coast" t2="Sea of Peace"/>
+		<connection t1="Kirov S Coast" t2="The Blue Sea"/>
+		<connection t1="Kowloon" t2="Kowloon S Coast"/>
+		<connection t1="Kowloon" t2="Kowloon W Coast"/>
+		<connection t1="Kowloon S Coast" t2="Kowloon W Coast"/>
+		<connection t1="Kowloon S Coast" t2="The Blue Sea"/>
+		<connection t1="Kowloon W Coast" t2="Western Ocean"/>
+		<connection t1="Leon" t2="St Lucia"/>
+		<connection t1="Lodwar" t2="Lodwar E Coast"/>
+		<connection t1="Lodwar" t2="Lodwar N Coast"/>
+		<connection t1="Lodwar" t2="Lodwar W Coast"/>
+		<connection t1="Lodwar" t2="Tebuk"/>
+		<connection t1="Lodwar E Coast" t2="Lodwar N Coast"/>
+		<connection t1="Lodwar E Coast" t2="Sea of Tebuk"/>
+		<connection t1="Lodwar E Coast" t2="Tebuk E Coast"/>
+		<connection t1="Lodwar N Coast" t2="Lodwar W Coast"/>
+		<connection t1="Lodwar N Coast" t2="Sea of Lodwar"/>
+		<connection t1="Lubo" t2="Lubo Coast"/>
+		<connection t1="Lubo Coast" t2="North Sea"/>
+		<connection t1="Malden" t2="Malden Coast"/>
+		<connection t1="Malden" t2="Palmyra"/>
+		<connection t1="Malden Coast" t2="Palmyra W Coast"/>
+		<connection t1="Malden Coast" t2="The Blue Sea"/>
+		<connection t1="Mersin" t2="Mersin E Coast"/>
+		<connection t1="Mersin" t2="Mersin N Coast"/>
+		<connection t1="Mersin" t2="Nicosia"/>
+		<connection t1="Mersin E Coast" t2="Mersin N Coast"/>
+		<connection t1="Mersin N Coast" t2="Nicosia N Coast"/>
+		<connection t1="Mersin N Coast" t2="Sea of Doom"/>
+		<connection t1="Nicosia" t2="Nicosia N Coast"/>
+		<connection t1="Nicosia" t2="Nicosia NW Coast"/>
+		<connection t1="Nicosia" t2="Nicosia W Coast"/>
+		<connection t1="Nicosia" t2="Palma"/>
+		<connection t1="Nicosia N Coast" t2="Nicosia NW Coast"/>
+		<connection t1="Nicosia N Coast" t2="Sea of Doom"/>
+		<connection t1="Nicosia NW Coast" t2="Nicosia W Coast"/>
+		<connection t1="Nicosia NW Coast" t2="North Central Ocean"/>
+		<connection t1="Nicosia NW Coast" t2="Sea of Doom"/>
+		<connection t1="Nicosia W Coast" t2="Palma W Coast"/>
+		<connection t1="Nicosia W Coast" t2="The Passage"/>
+		<connection t1="North Central Ocean" t2="Palmyra E Coast"/>
+		<connection t1="North Central Ocean" t2="Sea of Doom"/>
+		<connection t1="North Central Ocean" t2="Sea of Peace"/>
+		<connection t1="North Central Ocean" t2="South Central Sea"/>
+		<connection t1="North Central Ocean" t2="The Blue Sea"/>
+		<connection t1="North Central Ocean" t2="The Passage"/>
+		<connection t1="North Sea" t2="Sea of Leon"/>
+		<connection t1="North Sea" t2="Sea of Peace"/>
+		<connection t1="North Sea" t2="Western Ocean"/>
+		<connection t1="Oaxaca" t2="Oaxaca Coast"/>
+		<connection t1="Oaxaca Coast" t2="Sea of Leon"/>
+		<connection t1="Palma" t2="Palma S Coast"/>
+		<connection t1="Palma" t2="Palma W Coast"/>
+		<connection t1="Palma S Coast" t2="Palma W Coast"/>
+		<connection t1="Palma W Coast" t2="The Passage"/>
+		<connection t1="Palmyra" t2="Palmyra E Coast"/>
+		<connection t1="Palmyra" t2="Palmyra N Coast"/>
+		<connection t1="Palmyra" t2="Palmyra W Coast"/>
+		<connection t1="Palmyra E Coast" t2="Palmyra N Coast"/>
+		<connection t1="Palmyra N Coast" t2="Palmyra W Coast"/>
+		<connection t1="Palmyra N Coast" t2="Sea of Peace"/>
+		<connection t1="Palmyra W Coast" t2="The Blue Sea"/>
+		<connection t1="Reno" t2="Reno Coast"/>
+		<connection t1="Reno" t2="Waco"/>
+		<connection t1="Reno" t2="Yorkton"/>
+		<connection t1="Reno Coast" t2="South Central Sea"/>
+		<connection t1="Sea of Doom" t2="Sea of Leon"/>
+		<connection t1="Sea of Doom" t2="Sea of Peace"/>
+		<connection t1="Sea of Doom" t2="St Lucia S Coast"/>
+		<connection t1="Sea of Leon" t2="Sea of Peace"/>
+		<connection t1="Sea of Leon" t2="St Lucia E Coast"/>
+		<connection t1="Sea of Lodwar" t2="Sea of Tebuk"/>
+		<connection t1="Sea of Lodwar" t2="South Central Sea"/>
+		<connection t1="Sea of Lodwar" t2="The Blue Sea"/>
+		<connection t1="Sea of Lodwar" t2="Western Ocean"/>
+		<connection t1="Sea of No Return" t2="Southern Ocean"/>
+		<connection t1="Sea of No Return" t2="The Passage"/>
+		<connection t1="Sea of No Return" t2="Waco SE Coast"/>
+		<connection t1="Sea of Peace" t2="The Blue Sea"/>
+		<connection t1="Sea of Tebuk" t2="South Central Sea"/>
+		<connection t1="Sea of Tebuk" t2="Southern Ocean"/>
+		<connection t1="Sea of Tebuk" t2="Tebuk E Coast"/>
+		<connection t1="South Central Sea" t2="The Blue Sea"/>
+		<connection t1="South Central Sea" t2="The Passage"/>
+		<connection t1="Southern Ocean" t2="Waco S Coast"/>
+		<connection t1="Southern Ocean" t2="Yorkton Coast"/>
+		<connection t1="St Lucia" t2="St Lucia E Coast"/>
+		<connection t1="St Lucia" t2="St Lucia S Coast"/>
+		<connection t1="St Lucia E Coast" t2="St Lucia S Coast"/>
+		<connection t1="Tebuk" t2="Tebuk E Coast"/>
+		<connection t1="Tebuk" t2="Tebuk S Coast"/>
+		<connection t1="Tebuk E Coast" t2="Tebuk S Coast"/>
+		<connection t1="The Blue Sea" t2="Western Ocean"/>
+		<connection t1="Waco" t2="Waco S Coast"/>
+		<connection t1="Waco" t2="Waco SE Coast"/>
+		<connection t1="Waco" t2="Yorkton"/>
+		<connection t1="Waco S Coast" t2="Waco SE Coast"/>
+		<connection t1="Waco S Coast" t2="Yorkton Coast"/>
+		<connection t1="Yorkton" t2="Yorkton Coast"/>
+		<connection t1="Yorkton Coast" t2="Waco"/>
+	</map>
+	<resourceList>
+		<resource name="PUs"/>
+		<resource name="Victory Points"/>
+	</resourceList>
+	<playerList>
+		<!-- In turn order -->
+		<player name="Blue" optional="true" canBeDisabled="true"/>
+		<player name="Red" optional="true" canBeDisabled="true"/>
+		<player name="Green" optional="true" canBeDisabled="true"/>
+		<player name="Yellow" optional="true" canBeDisabled="true"/>
+		<player name="Orange" optional="true" canBeDisabled="true"/>
+		<player name="Cyan" optional="true" canBeDisabled="true"/>
+		<player name="Purple" optional="true" canBeDisabled="true"/>
+		<player name="Brown" optional="true" canBeDisabled="true"/>
+		<player name="Neutrals" optional="true" defaultType="DoesNothing" isHidden="true"/>
+	</playerList>
+	<unitList>
+		<unit name="wealth"/>
+		<unit name="army"/>
+		<unit name="new_army"/>
+		<unit name="fort_defense"/>
+		<unit name="fleet"/>
+		<unit name="build_fleet"/>
+		<unit name="fort"/>
+		<unit name="build_fort"/>
+		<unit name="port"/>
+		<unit name="build_port"/>
+		<unit name="city"/>
+		<unit name="build_city"/>
+		<unit name="territory_wealth_0"/>
+		<unit name="territory_wealth_1"/>
+		<unit name="territory_wealth_2"/>
+		<unit name="territory_wealth_3"/>
+		<unit name="territory_wealth_4"/>
+		<unit name="territory_wealth_5"/>
+		<unit name="territory_wealth_6"/>
+		<unit name="wealth_roll_1"/>
+		<unit name="wealth_roll_2"/>
+		<unit name="wealth_roll_3"/>
+		<unit name="wealth_roll_4"/>
+		<unit name="wealth_roll_5"/>
+		<unit name="wealth_roll_6"/>
+	</unitList>
+    <territoryEffectList>
+        <territoryEffect name="Mountains"/>
+    </territoryEffectList>
+	<gamePlay>
+		<delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate" display="Initializing Delegates"/>
+        <delegate name="randomStartDelegate" javaClass="games.strategy.triplea.delegate.RandomStartDelegate" display="Choose Starting Locations"/>
+		<delegate name="fleet_place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Initial Fleets"/>
+		<delegate name="wealth_place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Accumulate Wealth"/>
+		<delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
+		<delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Armies"/>
+		<delegate name="structures_place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Structures &amp; Ships"/>
+		<delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Movement"/>
+		<delegate name="battle" javaClass="games.strategy.triplea.delegate.BattleDelegate" display="Combat"/>
+		<delegate name="update_vps" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Update VPs"/>
+		<delegate name="endTurn" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
+		<delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
+		<sequence>
+			<step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
+			<step name="setupRandomStartDelegate" delegate="randomStartDelegate" maxRunCount="1"/>
+			<!-- resetUnitStateAtStart is needed so that gold spawned this turn can move. -->
+			<!--
+			<forEach variable="$players$">
+				<step name="@players@FleetPlace" delegate="fleet_place" player="@players@" maxRunCount="1"/>
+			</forEach>
+			<forEach variable="$players$">
+				<step name="@players@WealthPlace" delegate="wealth_place" player="@players@"/>
+				<step name="@players@UpdateVPsPlace" delegate="update_vps" player="@players@"/>
+				<step name="@players@Purchase" delegate="purchase" player="@players@"/>
+				<step name="@players@Place" delegate="place" player="@players@"/>
+				<step name="@players@StructuresPlace" delegate="structures_place" player="@players@"/>
+				<step name="@players@UpdateVPsPlace" delegate="update_vps" player="@players@"/>
+				<step name="@players@CombatMove" delegate="move" player="@players@">
+					<stepProperty name="resetUnitStateAtStart" value="true"/>
+				</step>
+				<step name="@players@NonCombatMove" delegate="move" player="@players@"/>
+				<step name="@players@Battle" delegate="battle" player="@players@"/>
+				<step name="@players@UpdateVPsPlace" delegate="update_vps" player="@players@"/>
+				<step name="@players@EndTurn" delegate="endTurn" player="@players@"/>
+			</forEach>
+			-->
+
+			<!-- Place initial fleets -->
+			<step name="BlueFleetPlace" delegate="fleet_place" player="Blue" maxRunCount="1"/>
+			<step name="RedFleetPlace" delegate="fleet_place" player="Red" maxRunCount="1"/>
+			<step name="GreenFleetPlace" delegate="fleet_place" player="Green" maxRunCount="1"/>
+			<step name="YellowFleetPlace" delegate="fleet_place" player="Yellow" maxRunCount="1"/>
+			<step name="OrangeFleetPlace" delegate="fleet_place" player="Orange" maxRunCount="1"/>
+			<step name="CyanFleetPlace" delegate="fleet_place" player="Cyan" maxRunCount="1"/>
+			<step name="PurpleFleetPlace" delegate="fleet_place" player="Purple" maxRunCount="1"/>
+			<step name="BrownFleetPlace" delegate="fleet_place" player="Brown" maxRunCount="1"/>
+			<!-- Blue -->
+			<step name="BlueWealthPlace" delegate="wealth_place" player="Blue"/>
+			<step name="BlueUpdateVPsPlace" delegate="update_vps" player="Blue"/>
+			<step name="BluePurchase" delegate="purchase" player="Blue"/>
+			<step name="BluePlace" delegate="place" player="Blue"/>
+			<step name="BlueStructuresPlace" delegate="structures_place" player="Blue"/>
+			<step name="BlueUpdateVPsPlace" delegate="update_vps" player="Blue"/>
+			<step name="BlueCombatMove" delegate="move" player="Blue">
+                <stepProperty name="resetUnitStateAtStart" value="true"/>
+			</step>
+			<step name="BlueBattle" delegate="battle" player="Blue"/>
+			<step name="BlueUpdateVPsPlace" delegate="update_vps" player="Blue"/>
+			<step name="BlueEndTurn" delegate="endTurn" player="Blue"/>
+			<!-- Red -->
+			<step name="RedWealthPlace" delegate="wealth_place" player="Red"/>
+			<step name="RedUpdateVPsPlace" delegate="update_vps" player="Red"/>
+			<step name="RedPurchase" delegate="purchase" player="Red"/>
+			<step name="RedPlace" delegate="place" player="Red"/>
+			<step name="RedStructuresPlace" delegate="structures_place" player="Red"/>
+			<step name="RedUpdateVPsPlace" delegate="update_vps" player="Red"/>
+			<step name="RedCombatMove" delegate="move" player="Red">
+                <stepProperty name="resetUnitStateAtStart" value="true"/>
+			</step>
+			<step name="RedBattle" delegate="battle" player="Red"/>
+			<step name="RedUpdateVPsPlace" delegate="update_vps" player="Red"/>
+			<step name="RedEndTurn" delegate="endTurn" player="Red"/>
+			<!-- Green -->
+			<step name="GreenWealthPlace" delegate="wealth_place" player="Green"/>
+			<step name="GreenUpdateVPsPlace" delegate="update_vps" player="Green"/>
+			<step name="GreenPurchase" delegate="purchase" player="Green"/>
+			<step name="GreenPlace" delegate="place" player="Green"/>
+			<step name="GreenStructuresPlace" delegate="structures_place" player="Green"/>
+			<step name="GreenUpdateVPsPlace" delegate="update_vps" player="Green"/>
+			<step name="GreenCombatMove" delegate="move" player="Green">
+                <stepProperty name="resetUnitStateAtStart" value="true"/>
+			</step>
+			<step name="GreenBattle" delegate="battle" player="Green"/>
+			<step name="GreenUpdateVPsPlace" delegate="update_vps" player="Green"/>
+			<step name="GreenEndTurn" delegate="endTurn" player="Green"/>
+			<!-- Yellow -->
+			<step name="YellowWealthPlace" delegate="wealth_place" player="Yellow"/>
+			<step name="YellowUpdateVPsPlace" delegate="update_vps" player="Yellow"/>
+			<step name="YellowPurchase" delegate="purchase" player="Yellow"/>
+			<step name="YellowPlace" delegate="place" player="Yellow"/>
+			<step name="YellowStructuresPlace" delegate="structures_place" player="Yellow"/>
+			<step name="YellowUpdateVPsPlace" delegate="update_vps" player="Yellow"/>
+			<step name="YellowCombatMove" delegate="move" player="Yellow">
+                <stepProperty name="resetUnitStateAtStart" value="true"/>
+			</step>
+			<step name="YellowBattle" delegate="battle" player="Yellow"/>
+			<step name="YellowUpdateVPsPlace" delegate="update_vps" player="Yellow"/>
+			<step name="YellowEndTurn" delegate="endTurn" player="Yellow"/>
+			<!-- Orange -->
+			<step name="OrangeWealthPlace" delegate="wealth_place" player="Orange"/>
+			<step name="OrangeUpdateVPsPlace" delegate="update_vps" player="Orange"/>
+			<step name="OrangePurchase" delegate="purchase" player="Orange"/>
+			<step name="OrangePlace" delegate="place" player="Orange"/>
+			<step name="OrangeStructuresPlace" delegate="structures_place" player="Orange"/>
+			<step name="OrangeUpdateVPsPlace" delegate="update_vps" player="Orange"/>
+			<step name="OrangeCombatMove" delegate="move" player="Orange">
+                <stepProperty name="resetUnitStateAtStart" value="true"/>
+			</step>
+			<step name="OrangeBattle" delegate="battle" player="Orange"/>
+			<step name="OrangeUpdateVPsPlace" delegate="update_vps" player="Orange"/>
+			<step name="OrangeEndTurn" delegate="endTurn" player="Orange"/>
+			<!-- Cyan -->
+			<step name="CyanWealthPlace" delegate="wealth_place" player="Cyan"/>
+			<step name="CyanUpdateVPsPlace" delegate="update_vps" player="Cyan"/>
+			<step name="CyanPurchase" delegate="purchase" player="Cyan"/>
+			<step name="CyanPlace" delegate="place" player="Cyan"/>
+			<step name="CyanStructuresPlace" delegate="place" player="Cyan"/>
+			<step name="CyanUpdateVPsPlace" delegate="update_vps" player="Cyan"/>
+			<step name="CyanCombatMove" delegate="move" player="Cyan">
+                <stepProperty name="resetUnitStateAtStart" value="true"/>
+			</step>
+			<step name="CyanBattle" delegate="battle" player="Cyan"/>
+			<step name="CyanUpdateVPsPlace" delegate="update_vps" player="Cyan"/>
+			<step name="CyanEndTurn" delegate="endTurn" player="Cyan"/>
+			<!-- Purple -->
+			<step name="PurpleWealthPlace" delegate="wealth_place" player="Purple"/>
+			<step name="PurpleUpdateVPsPlace" delegate="update_vps" player="Purple"/>
+			<step name="PurplePurchase" delegate="purchase" player="Purple"/>
+			<step name="PurplePlace" delegate="place" player="Purple"/>
+			<step name="PurpleStructuresPlace" delegate="place" player="Purple"/>
+			<step name="PurpleUpdateVPsPlace" delegate="update_vps" player="Purple"/>
+			<step name="PurpleCombatMove" delegate="move" player="Purple">
+                <stepProperty name="resetUnitStateAtStart" value="true"/>
+			</step>
+			<step name="PurpleBattle" delegate="battle" player="Purple"/>
+			<step name="PurpleUpdateVPsPlace" delegate="update_vps" player="Purple"/>
+			<step name="PurpleEndTurn" delegate="endTurn" player="Purple"/>
+			<!-- Brown -->
+			<step name="BrownWealthPlace" delegate="wealth_place" player="Brown"/>
+			<step name="BrownUpdateVPsPlace" delegate="update_vps" player="Brown"/>
+			<step name="BrownPurchase" delegate="purchase" player="Brown"/>
+			<step name="BrownPlace" delegate="place" player="Brown"/>
+			<step name="BrownStructuresPlace" delegate="structures_place" player="Brown"/>
+			<step name="BrownUpdateVPsPlace" delegate="update_vps" player="Brown"/>
+			<step name="BrownCombatMove" delegate="move" player="Brown">
+                <stepProperty name="resetUnitStateAtStart" value="true"/>
+			</step>
+			<step name="BrownBattle" delegate="battle" player="Brown"/>
+			<step name="BrownUpdateVPsPlace" delegate="update_vps" player="Brown"/>
+			<step name="BrownEndTurn" delegate="endTurn" player="Brown"/>
+
+			<!-- Needed to make AI consider "Neutrals" a threat to keep one unit per territory -->
+			<step name="NeutralsCombatMove" delegate="move" player="Neutrals"/>
+			<step name="endRoundStep" delegate="endRound"/>
+		</sequence>
+	</gamePlay>
+	<!-- Needed so that the UI doesn't show default technologies. -->
+	<technology/>
+	<production>
+		<productionRule name="buyArmy">
+			<cost resource="PUs" quantity="1"/>
+			<result resourceOrUnit="new_army" quantity="1"/>
+		</productionRule>
+		<productionRule name="buyFleet">
+			<cost resource="PUs" quantity="1"/>
+			<result resourceOrUnit="build_fleet" quantity="1"/>
+		</productionRule>
+		<productionRule name="buyFortification">
+			<cost resource="PUs" quantity="3"/>
+			<result resourceOrUnit="build_fort" quantity="1"/>
+		</productionRule>
+		<productionRule name="buyPort">
+			<cost resource="PUs" quantity="4"/>
+			<result resourceOrUnit="build_port" quantity="1"/>
+		</productionRule>
+		<productionRule name="buyCity">
+			<cost resource="PUs" quantity="4"/>
+			<result resourceOrUnit="build_city" quantity="1"/>
+		</productionRule>
+		<productionFrontier name="production">
+			<frontierRules name="buyArmy"/>
+			<frontierRules name="buyFleet"/>
+			<frontierRules name="buyFortification"/>
+			<frontierRules name="buyPort"/>
+			<frontierRules name="buyCity"/>
+		</productionFrontier>
+		<playerProduction player="Blue" frontier="production"/>
+		<playerProduction player="Red" frontier="production"/>
+		<playerProduction player="Green" frontier="production"/>
+		<playerProduction player="Yellow" frontier="production"/>
+		<playerProduction player="Orange" frontier="production"/>
+		<playerProduction player="Cyan" frontier="production"/>
+		<playerProduction player="Purple" frontier="production"/>
+		<playerProduction player="Brown" frontier="production"/>
+	</production>
+	<attachmentList>
+		<attachment name="unitAttachment" attachTo="wealth" javaClass="UnitAttachment">
+			<option name="movement" value="1"/>
+			<option name="transportCost" value="1"/>
+			<option name="isInfrastructure" value="true"/>
+		</attachment>
+		<!-- Armies built this turn start as new_army units, which can't attack. -->
+		<attachment name="unitAttachment" attachTo="new_army" javaClass="UnitAttachment">
+			<option name="movement" value="1"/>
+			<!-- FIXME: Currently not transportable because our triggers aren't able to convert to army at sea. -->
+			<!-- <option name="transportCost" value="1"/> -->
+			<option name="attackingLimit" value="owned" count="0"/>
+			<option name="attack" value="2"/>
+			<option name="defense" value="2"/>
+			<option name="createsUnitsList" value="1:army"/>
+			<option name="consumesUnits" value="1:wealth"/>
+			<option name="requiresUnits" value="wealth"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="army" javaClass="UnitAttachment">
+			<option name="movement" value="1"/>
+			<option name="transportCost" value="1"/>
+			<option name="attack" value="2"/>
+			<option name="defense" value="2"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="fort_defense" javaClass="UnitAttachment">
+			<option name="movement" value="0"/>
+			<option name="isFirstStrike" value="true"/>
+			<option name="attack" value="0"/>
+			<option name="defense" value="2"/>
+			<option name="isSuicideOnDefense" value="true"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="fleet" javaClass="UnitAttachment">
+			<option name="movement" value="1"/>
+			<option name="isSea" value="true"/>
+			<option name="isCombatTransport" value="true"/>
+			<option name="transportCapacity" value="1"/>
+			<option name="attack" value="1"/>
+			<option name="defense" value="1"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="build_fleet" javaClass="UnitAttachment">
+			<option name="isInfrastructure" value="true"/>
+			<option name="consumesUnits" value="1:wealth"/>
+			<option name="requiresUnits" value="wealth"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="city" javaClass="UnitAttachment">
+			<option name="isInfrastructure" value="true"/>
+			<option name="isConstruction" value="true"/>
+			<option name="constructionType" value="city_structure"/>
+			<option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+			<option name="maxConstructionsPerTypePerTerr" value="1"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="build_city" javaClass="UnitAttachment">
+			<option name="isInfrastructure" value="true"/>
+			<option name="consumesUnits" value="4:wealth"/>
+			<option name="requiresUnits" value="wealth"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="port" javaClass="UnitAttachment">
+			<option name="canProduceUnits" value="true"/>
+			<option name="canProduceXUnits" value="20"/>
+			<option name="isInfrastructure" value="true"/>
+			<option name="isConstruction" value="true"/>
+			<option name="constructionType" value="factory"/>
+			<option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+			<option name="maxConstructionsPerTypePerTerr" value="1"/>
+			<!-- Disallow placements on non-coast territories -->
+			<option name="unitPlacementRestrictions" value="Anyang:Bac Lieu:Pskov:Tomsk:Leon:Bari"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="build_port" javaClass="UnitAttachment">
+			<option name="isInfrastructure" value="true"/>
+			<option name="consumesUnits" value="4:wealth"/>
+			<option name="requiresUnits" value="wealth"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="fort" javaClass="UnitAttachment">
+			<option name="isInfrastructure" value="true"/>
+			<option name="isConstruction" value="true"/>
+			<option name="constructionType" value="fort_structure"/>
+			<option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+			<option name="maxConstructionsPerTypePerTerr" value="1"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="build_fort" javaClass="UnitAttachment">
+			<option name="isInfrastructure" value="true"/>
+			<option name="consumesUnits" value="3:wealth"/>
+			<option name="requiresUnits" value="wealth"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="territory_wealth_0" javaClass="UnitAttachment">
+			<option name="isInfrastructure" value="true"/>
+			<option name="isConstruction" value="true"/>
+			<option name="constructionType" value="territory_wealth"/>
+			<option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+			<option name="maxConstructionsPerTypePerTerr" value="1"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="territory_wealth_@nums_1_to_6@" foreach="$nums_1_to_6$" javaClass="UnitAttachment">
+			<option name="isInfrastructure" value="true"/>
+			<option name="isConstruction" value="true"/>
+			<option name="constructionType" value="territory_wealth"/>
+			<option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+			<option name="maxConstructionsPerTypePerTerr" value="1"/>
+		</attachment>
+		<attachment name="unitAttachment" attachTo="wealth_roll_@nums_1_to_6@" foreach="$nums_1_to_6$" javaClass="UnitAttachment">
+			<option name="isInfrastructure" value="true"/>
+			<option name="isConstruction" value="true"/>
+			<option name="constructionType" value="wealth_roll"/>
+			<option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+			<option name="maxConstructionsPerTypePerTerr" value="1"/>
+		</attachment>
+		<attachment name="territoryAttachment" attachTo="@land_territories@" foreach="$land_territories$"
+			javaClass="TerritoryAttachment" type="territory">
+			<option name="production" value="100"/>
+		</attachment>
+		<attachment name="territoryAttachment" attachTo="@water_territories@" foreach="$water_territories$"
+			javaClass="TerritoryAttachment" type="territory">
+			<option name="production" value="0"/>
+		</attachment>
+		<attachment name="territoryAttachment" attachTo="Wealth Roll" javaClass="TerritoryAttachment" type="territory">
+			<option name="production" value="0"/>
+		</attachment>
+		<attachment name="territoryAttachment" attachTo="Threat" javaClass="TerritoryAttachment" type="territory">
+			<option name="production" value="0"/>
+			<option name="isImpassable" value="true"/>
+		</attachment>
+
+		<attachment name="territoryEffectAttachment" attachTo="Mountains" javaClass="TerritoryEffectAttachment" type="territoryEffect">
+			<option name="combatOffenseEffect" value="army" count="-1"/>
+			<option name="unitsNotAllowed" value="wealth"/>
+		</attachment>
+
+		<attachment name="playerAttachment" attachTo="@players@" foreach="$players$" javaClass="PlayerAttachment" type="player">
+			<option name="retainCapitalProduceNumber" value="0"/>
+		</attachment>
+
+		<attachment name="cond_true_@players_and_neutral@" attachTo="@players_and_neutral@" foreach="$players_and_neutral$" javaClass="RulesAttachment" type="player">
+			<option name="switch" value="true"/>
+		</attachment>
+
+        <attachment name="set_territory_effects" attachTo="Neutrals" javaClass="TriggerAttachment" type="player">
+            <option name="when" value="after:gameInitDelegate"/>
+			<option name="conditions" value="cond_true_Neutrals"/>
+            <option name="territories" value="$mountains$"/>
+		    <option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
+		    <option name="territoryProperty" value="territoryEffect" count="Mountains"/>
+        </attachment>
+
+		<!-- Generate wealth units in territories, based on the wealth die roll and territory wealth values. -->
+		<!-- Roll one dice and set its result in Wealth Roll. -->
+		<attachment name="wealth_die_not_present_@nums_1_to_6@_@players@" attachTo="@players@" foreach="$players$^$nums_1_to_6$" javaClass="RulesAttachment" type="player">
+			<option name="directExclusionTerritories" value="Wealth Roll"/>
+			<option name="unitPresence" count="0"
+				value="wealth_roll_1:wealth_roll_2:wealth_roll_3:wealth_roll_4:wealth_roll_5:wealth_roll_6"/>
+		</attachment>
+		<attachment name="notify_die_roll_@nums_1_to_6@_@players@" attachTo="@players@" foreach="$players$^$nums_1_to_6$"
+			javaClass="TriggerAttachment" type="player">
+			<option name="when" value="after:DummyNever"/>
+			<option name="notification" value="@players@_Roll_Wealth_@nums_1_to_6@"/>
+	        <option name="players" value="$players$"/>
+		</attachment>
+		<attachment name="roll_wealth_die_@nums_1_to_6@_@players@" attachTo="@players@" foreach="$players$^$nums_1_to_6$"
+			javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="wealth_die_not_present_@nums_1_to_6@_@players@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="Wealth Roll:wealth_roll_@nums_1_to_6@" count="1"/>
+			<option name="chance" value="1:@nums_1_to_6@"/>
+			<option name="activateTrigger" value="notify_die_roll_@nums_1_to_6@_@players@:1:false:false:false:false"/>
+		</attachment>
+
+		<attachment name="roll_wealth_die_@players@" attachTo="@players@" foreach="$players$"
+			javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="wealth_die_not_present_6_@players@"/>
+			<option name="when" value="before:@players@WealthPlace"/>
+			<!-- triggerName:numberOfTimes:useUses:testUses:testConditions:testChance, we want to test both the cond and the chance. -->
+			<!-- Note: Must be in reverse order since each has a 1:N chance to hit -->
+			<option name="activateTrigger" value="roll_wealth_die_6_@players@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="roll_wealth_die_5_@players@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="roll_wealth_die_4_@players@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="roll_wealth_die_3_@players@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="roll_wealth_die_2_@players@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="roll_wealth_die_1_@players@:1:false:false:true:false"/>
+		</attachment>
+
+		<attachment name="remove_wealth_die_@players@" attachTo="@players@" foreach="$players$"
+			javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_true_@players@"/>
+			<option name="when" value="after:@players@EndTurn"/>
+			<option name="removeUnits" value="Wealth Roll:wealth_roll_6" count="1"/>
+			<option name="removeUnits" value="Wealth Roll:wealth_roll_5" count="1"/>
+			<option name="removeUnits" value="Wealth Roll:wealth_roll_4" count="1"/>
+			<option name="removeUnits" value="Wealth Roll:wealth_roll_3" count="1"/>
+			<option name="removeUnits" value="Wealth Roll:wealth_roll_2" count="1"/>
+			<option name="removeUnits" value="Wealth Roll:wealth_roll_1" count="1"/>
+		</attachment>
+		
+		<attachment name="cond_has_city_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="city" count="1"/>
+		</attachment>
+		<attachment name="cond_no_city_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="city" count="1"/>
+			<option name="invert" value="true"/>
+		</attachment>
+		<attachment name="cond_territory_wealth_1_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="territory_wealth_1" count="1"/>
+		</attachment>
+		<attachment name="cond_territory_wealth_2_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="territory_wealth_2" count="1"/>
+		</attachment>
+		<attachment name="cond_territory_wealth_3_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="territory_wealth_3" count="1"/>
+		</attachment>
+		<attachment name="cond_territory_wealth_4_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="territory_wealth_4" count="1"/>
+		</attachment>
+		<attachment name="cond_territory_wealth_5_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="territory_wealth_5" count="1"/>
+		</attachment>
+		<attachment name="cond_territory_wealth_6_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="territory_wealth_6" count="1"/>
+		</attachment>
+
+		<attachment name="wealth_die_@nums_1_to_6@_@players@" attachTo="@players@" foreach="$players$^$nums_1_to_6$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="Wealth Roll" count="1"/>
+			<option name="unitPresence" count="1" value="wealth_roll_@nums_1_to_6@"/>
+		</attachment>
+		<attachment name="wealth_die_2_or_less_@players@" attachTo="@players@" foreach="$players$^$nums_1_to_6$" javaClass="RulesAttachment" type="player">
+			<option name="conditionType" value="OR"/>
+			<option name="conditions" value="wealth_die_1_@players@:wealth_die_2_@players@"/>
+		</attachment>
+		<attachment name="wealth_die_3_or_less_@players@" attachTo="@players@" foreach="$players$^$nums_1_to_6$" javaClass="RulesAttachment" type="player">
+			<option name="conditionType" value="OR"/>
+			<option name="conditions" value="wealth_die_3_@players@:wealth_die_2_or_less_@players@"/>
+		</attachment>
+		<attachment name="wealth_die_4_or_less_@players@" attachTo="@players@" foreach="$players$^$nums_1_to_6$" javaClass="RulesAttachment" type="player">
+			<option name="conditionType" value="OR"/>
+			<option name="conditions" value="wealth_die_4_@players@:wealth_die_3_or_less_@players@"/>
+		</attachment>
+		<attachment name="wealth_die_5_or_less_@players@" attachTo="@players@" foreach="$players$^$nums_1_to_6$" javaClass="RulesAttachment" type="player">
+			<option name="conditionType" value="OR"/>
+			<option name="conditions" value="wealth_die_5_@players@:wealth_die_4_or_less_@players@"/>
+		</attachment>
+
+		<attachment name="trigger_wealth_prod_1_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_1_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_no_city_@players@_@land_territories@"/>
+			<option name="conditions" value="wealth_die_1_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+		<attachment name="trigger_wealth_prod_city_1_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_1_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_has_city_@players@_@land_territories@"/>
+			<option name="conditions" value="wealth_die_2_or_less_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+
+		<attachment name="trigger_wealth_prod_2_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_2_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_no_city_@players@_@land_territories@"/>
+			<option name="conditions" value="wealth_die_2_or_less_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+		<attachment name="trigger_wealth_prod_city_2_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_2_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_has_city_@players@_@land_territories@"/>
+			<option name="conditions" value="wealth_die_3_or_less_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+
+		<attachment name="trigger_wealth_prod_3_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_3_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_no_city_@players@_@land_territories@"/>
+			<option name="conditions" value="wealth_die_3_or_less_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+		<attachment name="trigger_wealth_prod_city_3_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_3_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_has_city_@players@_@land_territories@"/>
+			<option name="conditions" value="wealth_die_4_or_less_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+		
+		<attachment name="trigger_wealth_prod_4_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_4_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_no_city_@players@_@land_territories@"/>
+			<option name="conditions" value="wealth_die_4_or_less_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+		<attachment name="trigger_wealth_prod_city_4_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_4_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_has_city_@players@_@land_territories@"/>
+			<option name="conditions" value="wealth_die_5_or_less_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+
+		<attachment name="trigger_wealth_prod_5_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_5_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_no_city_@players@_@land_territories@"/>
+			<option name="conditions" value="wealth_die_5_or_less_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+		<attachment name="trigger_wealth_prod_city_5_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_5_@players@_@land_territories@"/>
+			<option name="conditions" value="cond_has_city_@players@_@land_territories@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+		
+		<attachment name="trigger_wealth_prod_6_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_territory_wealth_6_@players@_@land_territories@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="placement" value="@land_territories@:wealth" count="1"/>
+		</attachment>
+
+		<!-- Give players PUs based on how many wealth units they have before purchase step. -->
+		<!-- Clear any unused PUs after purchase step, since the source of truth is wealth. -->
+		<attachment name="trigger_reset_PUs_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_true_@players@"/>
+			<option name="when" value="after:@players@Purchase"/>
+			<option name="resource" value="PUs"/>
+			<option name="resourceCount" value="-999"/>
+		</attachment>
+		<!-- Conditions for how much wealth they have in ports. -->
+		<attachment name="has_wealth_@nums_1_to_25@_@players@" attachTo="@players@" foreach="$nums_1_to_25$^$players$" javaClass="RulesAttachment" type="player">
+			<!-- Use 'each' so that multiple territories matching this multiply the resource award. -->
+			<option name="directPresenceTerritories" value="map" count="each"/>
+			<option name="unitPresence" value="port" count="1"/>
+			<option name="unitPresence" value="wealth" count="@nums_1_to_25@"/>
+		</attachment>
+		<!-- For each territory matching a count of wealth, give 1 PU.-->
+		<attachment name="set_PUs_@nums_1_to_25@_@players@" attachTo="@players@" foreach="$nums_1_to_25$^$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="has_wealth_@nums_1_to_25@_@players@"/>
+			<option name="when" value="before:@players@Purchase"/>
+			<option name="resource" value="PUs"/>
+			<option name="resourceCount" value="1"/>
+		</attachment>
+		<attachment name="enable_city_and_port_production_@players@" attachTo="@players@" foreach="$players$"  javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="has_wealth_4_@players@"/>
+			<option name="when" value="before:Never"/>
+			<option name='unitType' value='build_city:build_port'/>
+			<option name='unitProperty' value='maxBuiltPerPlayer' count='-1'/>
+		</attachment>
+		<attachment name="disable_city_and_port_production_@players@" attachTo="@players@" foreach="$players$"  javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_true_@players@"/>
+			<option name="when" value="before:@players@Purchase"/>
+			<!-- First, disable it. -->
+			<option name='unitType' value='build_city:build_port'/>
+			<option name='unitProperty' value='maxBuiltPerPlayer' count='0'/>
+			<!-- Then, enable it, if there's a port with 4+ wealth. -->
+			<option name="activateTrigger" value="enable_city_and_port_production_@players@:1:false:false:true:false"/>
+		</attachment>
+		<attachment name="enable_fort_production_@players@" attachTo="@players@" foreach="$players$"  javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="has_wealth_3_@players@"/>
+			<option name="when" value="before:Never"/>
+			<option name='unitType' value='build_fort'/>
+			<option name='unitProperty' value='maxBuiltPerPlayer' count='-1'/>
+		</attachment>
+		<attachment name="disable_fort_production_@players@" attachTo="@players@" foreach="$players$"  javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_true_@players@"/>
+			<option name="when" value="before:@players@Purchase"/>
+			<!-- First, disable it. -->
+			<option name='unitType' value='build_fort'/>
+			<option name='unitProperty' value='maxBuiltPerPlayer' count='0'/>
+			<!-- Then, enable it, if there's a port with 3+ wealth. -->
+			<option name="activateTrigger" value="enable_fort_production_@players@:1:false:false:true:false"/>
+		</attachment>
+		<!-- Logic for assigning wealth values to newly discovered territories. The cond trigger is duplicated so that we can evaluate it multiple times without caching. -->
+		<attachment name="cond_need_territory_wealth1_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directOwnershipTerritories" value="@land_territories@"/>
+			<option name="directExclusionTerritories" value="@land_territories@"/>
+			<option name="unitPresence" count="0" value="territory_wealth_0:territory_wealth_1:territory_wealth_2:territory_wealth_3:territory_wealth_4:territory_wealth_5:territory_wealth_6"/>
+		</attachment>
+		<attachment name="cond_need_territory_wealth2_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directOwnershipTerritories" value="@land_territories@"/>
+			<option name="directExclusionTerritories" value="@land_territories@"/>
+			<option name="unitPresence" count="0" value="territory_wealth_0:territory_wealth_1:territory_wealth_2:territory_wealth_3:territory_wealth_4:territory_wealth_5:territory_wealth_6"/>
+		</attachment>
+		<attachment name="cond_need_territory_wealth3_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directOwnershipTerritories" value="@land_territories@"/>
+			<option name="directExclusionTerritories" value="@land_territories@"/>
+			<option name="unitPresence" count="0" value="territory_wealth_0:territory_wealth_1:territory_wealth_2:territory_wealth_3:territory_wealth_4:territory_wealth_5:territory_wealth_6"/>
+		</attachment>
+		<attachment name="cond_need_territory_wealth4_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directOwnershipTerritories" value="@land_territories@"/>
+			<option name="directExclusionTerritories" value="@land_territories@"/>
+			<option name="unitPresence" count="0" value="territory_wealth_0:territory_wealth_1:territory_wealth_2:territory_wealth_3:territory_wealth_4:territory_wealth_5:territory_wealth_6"/>
+		</attachment>
+		<attachment name="cond_need_territory_wealth5_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directOwnershipTerritories" value="@land_territories@"/>
+			<option name="directExclusionTerritories" value="@land_territories@"/>
+			<option name="unitPresence" count="0" value="territory_wealth_0:territory_wealth_1:territory_wealth_2:territory_wealth_3:territory_wealth_4:territory_wealth_5:territory_wealth_6"/>
+		</attachment>
+		<attachment name="cond_need_territory_wealth6_@players@_@land_territories@" attachTo="@players@" foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directOwnershipTerritories" value="@land_territories@"/>
+			<option name="directExclusionTerritories" value="@land_territories@"/>
+			<option name="unitPresence" count="0" value="territory_wealth_0:territory_wealth_1:territory_wealth_2:territory_wealth_3:territory_wealth_4:territory_wealth_5:territory_wealth_6"/>
+		</attachment>
+		<attachment name="set_territory_wealth6_@players@_@new_world_land_territories@" attachTo="@players@" foreach="$players$^$new_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth6_@players@_@new_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@new_world_land_territories@:territory_wealth_6" count="1"/>
+            <option name="territories" value="@new_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="6"/>
+			<option name="chance" value="1:6"/>
+		</attachment>
+		<attachment name="set_territory_wealth5_@players@_@new_world_land_territories@" attachTo="@players@" foreach="$players$^$new_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth5_@players@_@new_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@new_world_land_territories@:territory_wealth_5" count="1"/>
+            <option name="territories" value="@new_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="5"/>
+			<option name="chance" value="1:5"/>
+		</attachment>
+		<attachment name="set_territory_wealth4_@players@_@new_world_land_territories@" attachTo="@players@" foreach="$players$^$new_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth4_@players@_@new_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@new_world_land_territories@:territory_wealth_4" count="1"/>
+            <option name="territories" value="@new_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="4"/>
+			<option name="chance" value="1:4"/>
+		</attachment>
+		<attachment name="set_territory_wealth3_@players@_@new_world_land_territories@" attachTo="@players@" foreach="$players$^$new_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth3_@players@_@new_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@new_world_land_territories@:territory_wealth_3" count="1"/>
+            <option name="territories" value="@new_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="3"/>
+			<option name="chance" value="1:3"/>
+		</attachment>
+		<attachment name="set_territory_wealth2_@players@_@new_world_land_territories@" attachTo="@players@" foreach="$players$^$new_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth2_@players@_@new_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@new_world_land_territories@:territory_wealth_2" count="1"/>
+            <option name="territories" value="@new_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="2"/>
+			<option name="chance" value="1:2"/>
+		</attachment>
+		<attachment name="set_territory_wealth1_@players@_@new_world_land_territories@" attachTo="@players@" foreach="$players$^$new_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth1_@players@_@new_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@new_world_land_territories@:territory_wealth_1" count="1"/>
+            <option name="territories" value="@new_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="1"/>
+			<option name="chance" value="1:1"/>
+		</attachment>
+		<attachment name="set_territory_wealth4_@players@_@old_world_land_territories@" attachTo="@players@" foreach="$players$^$old_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth4_@players@_@old_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@old_world_land_territories@:territory_wealth_4" count="1"/>
+            <option name="territories" value="@old_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="4"/>
+			<option name="chance" value="1:6"/>
+		</attachment>
+		<attachment name="set_territory_wealth3_@players@_@old_world_land_territories@" attachTo="@players@" foreach="$players$^$old_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth3_@players@_@old_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@old_world_land_territories@:territory_wealth_3" count="1"/>
+            <option name="territories" value="@old_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="3"/>
+			<option name="chance" value="1:5"/>
+		</attachment>
+		<attachment name="set_territory_wealth2_@players@_@old_world_land_territories@" attachTo="@players@" foreach="$players$^$old_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth2_@players@_@old_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@old_world_land_territories@:territory_wealth_2" count="1"/>
+            <option name="territories" value="@old_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="2"/>
+			<option name="chance" value="1:4"/>
+		</attachment>
+		<attachment name="set_territory_wealth1_@players@_@old_world_land_territories@" attachTo="@players@" foreach="$players$^$old_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth1_@players@_@old_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@old_world_land_territories@:territory_wealth_1" count="1"/>
+            <option name="territories" value="@old_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="1"/>
+			<option name="chance" value="1:3"/>
+		</attachment>
+		<attachment name="set_territory_wealth0_@players@_@old_world_land_territories@" attachTo="@players@" foreach="$players$^$old_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth6_@players@_@old_world_land_territories@"/>
+			<option name="when" value="after:DummyNever"/>
+			<option name="placement" value="@old_world_land_territories@:territory_wealth_0" count="1"/>
+            <option name="territories" value="@old_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="0"/>
+			<option name="chance" value="1:1"/>
+		</attachment>
+		<attachment name="set_territory_wealth_@players@_@old_world_land_territories@" attachTo="@players@" foreach="$players$^$old_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth4_@players@_@old_world_land_territories@"/>
+			<option name="when" value="after:@players@Battle"/>
+			<!-- triggerName:numberOfTimes:useUses:testUses:testConditions:testChance, we want to test both the cond and the chance. -->
+			<option name="activateTrigger" value="set_territory_wealth4_@players@_@old_world_land_territories@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="set_territory_wealth3_@players@_@old_world_land_territories@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="set_territory_wealth2_@players@_@old_world_land_territories@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="set_territory_wealth1_@players@_@old_world_land_territories@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="set_territory_wealth0_@players@_@old_world_land_territories@:1:false:false:true:true"/>
+		</attachment>
+		<attachment name="set_territory_wealth_@players@_@new_world_land_territories@" attachTo="@players@" foreach="$players$^$new_world_land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_need_territory_wealth6_@players@_@new_world_land_territories@"/>
+			<option name="when" value="after:@players@Battle"/>
+			<!-- triggerName:numberOfTimes:useUses:testUses:testConditions:testChance, we want to test both the cond and the chance. -->
+			<option name="activateTrigger" value="set_territory_wealth6_@players@_@new_world_land_territories@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="set_territory_wealth5_@players@_@new_world_land_territories@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="set_territory_wealth4_@players@_@new_world_land_territories@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="set_territory_wealth3_@players@_@new_world_land_territories@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="set_territory_wealth2_@players@_@new_world_land_territories@:1:false:false:true:true"/>
+			<option name="activateTrigger" value="set_territory_wealth1_@players@_@new_world_land_territories@:1:false:false:true:true"/>
+		</attachment>
+		<!-- Trigger for allowing building of structures - which first require building a "build unit" using wealth from ports, which gets converted later. -->
+		<attachment name="cond_build_fort_@players@" attachTo="@players@" foreach="$players$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="map" count="1"/>
+			<option name="unitPresence" value="build_fort" count="1"/>
+		</attachment>
+		<attachment name="trigger_build_fort_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_build_fort_@players@"/>
+			<option name="when" value="before:@players@StructuresPlace"/>
+			<option name="removeUnits" value="all:build_fort" count="1"/>
+			<option name="purchase" value="fort" count="1"/>
+		</attachment>
+		<attachment name="cond_build_port_@players@" attachTo="@players@" foreach="$players$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="map" count="1"/>
+			<option name="unitPresence" value="build_port" count="1"/>
+		</attachment>
+		<attachment name="trigger_build_port_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_build_port_@players@"/>
+			<option name="when" value="before:@players@StructuresPlace"/>
+			<option name="removeUnits" value="all:build_port" count="1"/>
+			<option name="purchase" value="port" count="1"/>
+		</attachment>
+		<attachment name="cond_build_city_@players@" attachTo="@players@" foreach="$players$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="map" count="1"/>
+			<option name="unitPresence" value="build_city" count="1"/>
+		</attachment>
+		<attachment name="trigger_build_city_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_build_city_@players@"/>
+			<option name="when" value="before:@players@StructuresPlace"/>
+			<option name="removeUnits" value="all:build_city" count="1"/>
+			<option name="purchase" value="city" count="1"/>
+		</attachment>
+		<attachment name="cond_build_fleet_@players@_@nums_1_to_25@" attachTo="@players@"
+				foreach="$players$^$nums_1_to_25$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="map" count="1"/>
+			<option name="unitPresence" value="build_fleet" count="1"/>
+		</attachment>
+		<attachment name="trigger_build_fleet_@players@_@nums_1_to_25@" attachTo="@players@"
+				foreach="$players$^$nums_1_to_25$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_build_fleet_@players@_@nums_1_to_25@"/>
+			<option name="when" value="before:@players@Never"/>
+			<option name="removeUnits" value="all:build_fleet" count="1"/>
+			<option name="purchase" value="fleet" count="1"/>
+		</attachment>
+		<attachment name="trigger_build_fleet_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_build_fleet_@players@_1"/>
+			<option name="when" value="before:@players@StructuresPlace"/>
+			<!-- triggerName:numberOfTimes:useUses:testUses:testConditions:testChance, we want to test the cond. -->
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_1:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_2:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_3:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_4:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_5:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_6:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_7:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_8:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_9:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_10:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_11:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_12:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_13:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_14:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_15:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_16:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_17:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_18:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_19:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_20:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_21:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_22:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_23:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_24:1:false:false:true:false"/>
+			<option name="activateTrigger" value="trigger_build_fleet_@players@_25:1:false:false:true:false"/>
+		</attachment>
+		<attachment name="has_port_@players@" attachTo="@players@" foreach="$players$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="map" count="1"/>
+			<option name="unitPresence" value="port" count="1"/>
+		</attachment>
+		<attachment name="has_port_@players@_@old_world_land_territories@" attachTo="@players@" foreach="$players$^$old_world_land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@old_world_land_territories@" count="1"/>
+			<option name="unitPresence" value="port" count="1"/>
+		</attachment>
+        <attachment name="place_initial_units_@players@_@old_world_land_territories@" attachTo="@players@" foreach="$players$^$old_world_land_territories$" javaClass="TriggerAttachment" type="player">
+            <option name="when" value="after:setupRandomStartDelegate"/>
+			<option name="conditions" value="has_port_@players@_@old_world_land_territories@"/>
+            <option name="territories" value="@old_world_land_territories@"/>
+            <option name="territoryProperty" value="production" count="6"/>
+			<option name="placement" value="@old_world_land_territories@:territory_wealth_6" count="1"/>
+			<option name="placement" value="@old_world_land_territories@:fort" count="1"/>
+			<option name="placement" value="@old_world_land_territories@:army" count="10"/>
+        </attachment>
+		
+		<attachment name="is_neutral_@old_world_land_territories@" attachTo="Neutrals"
+			foreach="$old_world_land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directOwnershipTerritories" value="@old_world_land_territories@"/>
+			<option name="players" value="Neutrals:Neutral"/>
+		</attachment>
+        <attachment name="set_up_old_world_neutrals_@old_world_land_territories@" attachTo="Blue" foreach="$old_world_land_territories$" javaClass="TriggerAttachment" type="player">
+            <option name="when" value="after:setupRandomStartDelegate"/>
+			<option name="conditions" value="is_neutral_@old_world_land_territories@"/>
+			<option name="players" value="Neutrals"/>
+			<option name="removeUnits" value="@old_world_land_territories@:army" count="1"/>
+			<option name="removeUnits" value="@old_world_land_territories@:fort" count="1"/>
+			<option name="placement" value="@old_world_land_territories@:army" count="1"/>
+			<option name="placement" value="@old_world_land_territories@:fort" count="1"/>
+			<option name='changeOwnership' value='@old_world_land_territories@:any:Neutrals:false'/>
+        </attachment>
+        <attachment name="produce_initial_fleet_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:@players@FleetPlace"/>
+			<option name="conditions" value="has_port_@players@"/>
+			<option name="purchase" value="fleet" count="5"/>
+			<option name="uses" value="1"/>
+        </attachment>
+
+		<attachment name="was_territory_abandoned_@players@_@land_territories@" attachTo="@players@"
+			foreach="$players$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directOwnershipTerritories" value="@land_territories@"/>
+			<option name="directExclusionTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army:new_army" count="0"/>
+		</attachment>
+        <attachment name="abandon_territory_@players@_@land_territories@" attachTo="@players@"
+			foreach="$players$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="after:@players@CombatMove"/>
+			<option name="conditions" value="was_territory_abandoned_@players@_@land_territories@"/>
+			<option name="changeOwnership" value="@land_territories@:@players@:Neutrals:true"/>			
+        </attachment>
+		<attachment name="remove_new_armies_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_true_@players@"/>
+			<option name="when" value="after:@players@EndTurn"/>
+			<option name="removeUnits" value="all:new_army" count="1000"/>
+		</attachment>
+		<!-- Counting victory points. We update at 3 different steps each turn. -->
+		<attachment name="trigger_reset_VPs_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_true_@players@"/>
+			<option name="when" value="before:@players@UpdateVPsPlace"/>
+			<option name="resource" value="Victory Points"/>
+			<option name="resourceCount" value="-999"/>
+		</attachment>
+		<!-- For each territory with a port, give 10 Victory Points. -->
+		<attachment name="port_count_@players@" attachTo="@players@" foreach="$players$" javaClass="RulesAttachment" type="player">
+			<!-- Use 'each' so that multiple territories matching this multiply the resource award. -->
+			<option name="directPresenceTerritories" value="map" count="each"/>
+			<option name="unitPresence" value="port" count="1"/>
+		</attachment>
+		<attachment name="add_port_VPs_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="port_count_@players@"/>
+			<option name="when" value="after:@players@UpdateVPsPlace"/>
+			<option name="resource" value="Victory Points"/>
+			<option name="resourceCount" value="10"/>
+		</attachment>
+		<!-- For each territory with a city, give 6 Victory Points. -->
+		<attachment name="city_count_@players@" attachTo="@players@" foreach="$players$" javaClass="RulesAttachment" type="player">
+			<!-- Use 'each' so that multiple territories matching this multiply the resource award. -->
+			<option name="directPresenceTerritories" value="map" count="each"/>
+			<option name="unitPresence" value="city" count="1"/>
+		</attachment>
+		<attachment name="add_city_VPs_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="city_count_@players@"/>
+			<option name="when" value="after:@players@UpdateVPsPlace"/>
+			<option name="resource" value="Victory Points"/>
+			<option name="resourceCount" value="6"/>
+		</attachment>
+		<!-- For each territory with a fort, give 2 Victory Points. -->
+		<attachment name="fort_count_@players@" attachTo="@players@" foreach="$players$" javaClass="RulesAttachment" type="player">
+			<!-- Use 'each' so that multiple territories matching this multiply the resource award. -->
+			<option name="directPresenceTerritories" value="map" count="each"/>
+			<option name="unitPresence" value="fort" count="1"/>
+		</attachment>
+		<attachment name="add_fort_VPs_@players@" attachTo="@players@" foreach="$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="fort_count_@players@"/>
+			<option name="when" value="after:@players@UpdateVPsPlace"/>
+			<option name="resource" value="Victory Points"/>
+			<option name="resourceCount" value="2"/>
+		</attachment>
+		<!-- For each territory matching a count of wealth, give 2 Victory Points.-->
+		<attachment name="wealth_count_@nums_1_to_25@_@players@" attachTo="@players@" foreach="$nums_1_to_25$^$players$" javaClass="RulesAttachment" type="player">
+			<!-- Use 'each' so that multiple territories matching this multiply the resource award. -->
+			<option name="directPresenceTerritories" value="map" count="each"/>
+			<option name="unitPresence" value="wealth" count="@nums_1_to_25@"/>
+		</attachment>
+		<attachment name="add_wealth_VPs_@nums_1_to_25@_@players@" attachTo="@players@" foreach="$nums_1_to_25$^$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="wealth_count_@nums_1_to_25@_@players@"/>
+			<option name="when" value="after:@players@UpdateVPsPlace"/>
+			<option name="resource" value="Victory Points"/>
+			<option name="resourceCount" value="2"/>
+		</attachment>
+		<!-- For each territory matching a count of armies, give 1 Victory Point.-->
+		<attachment name="zones_with_army_count_@nums_1_to_25@_@players@" attachTo="@players@"
+			foreach="$nums_1_to_25$^$players$" javaClass="RulesAttachment" type="player">
+			<!-- Use 'each' so that multiple territories matching this multiply the resource award. -->
+			<option name="directPresenceTerritories" value="map" count="each"/>
+			<option name="unitPresence" value="army:new_army" count="@nums_1_to_25@"/>
+		</attachment>
+		<attachment name="add_army_VPs_@nums_1_to_25@_@players@" attachTo="@players@" foreach="$nums_1_to_25$^$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="zones_with_army_count_@nums_1_to_25@_@players@"/>
+			<option name="when" value="after:@players@UpdateVPsPlace"/>
+			<option name="resource" value="Victory Points"/>
+			<option name="resourceCount" value="1"/>
+		</attachment>
+		<!-- For each territory matching a count of fleet, give 2 Victory Points.-->
+		<attachment name="zones_with_fleet_count_@nums_1_to_25@_@players@" attachTo="@players@"
+			foreach="$nums_1_to_25$^$players$" javaClass="RulesAttachment" type="player">
+			<!-- Use 'each' so that multiple territories matching this multiply the resource award. -->
+			<option name="directPresenceTerritories" value="map" count="each"/>
+			<option name="unitPresence" value="fleet" count="@nums_1_to_25@"/>
+		</attachment>
+		<attachment name="add_fleet_VPs_@nums_1_to_25@_@players@" attachTo="@players@" foreach="$nums_1_to_25$^$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="zones_with_fleet_count_@nums_1_to_25@_@players@"/>
+			<option name="when" value="after:@players@UpdateVPsPlace"/>
+			<option name="resource" value="Victory Points"/>
+			<option name="resourceCount" value="2"/>
+		</attachment>
+		<!-- For each territory matching territory wealth, give 2 * value Victory Points.-->
+		<attachment name="territory_wealth_@nums_1_to_6@_count_@players@" attachTo="@players@"
+			foreach="$nums_1_to_6$^$players$" javaClass="RulesAttachment" type="player">
+			<!-- Use 'each' so that multiple territories matching this multiply the resource award. -->
+			<option name="directPresenceTerritories" value="controlledNoWater" count="each"/>
+			<option name="unitPresence" value="territory_wealth_@nums_1_to_6@" count="1"/>
+		</attachment>
+		<attachment name="add_VPs_for_territory_wealth_@nums_1_to_6@_@players@" attachTo="@players@"
+			foreach="$nums_1_to_6$^$players$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="after:Never"/>
+			<option name="resource" value="Victory Points"/>
+			<option name="resourceCount" value="@nums_1_to_6@"/>
+		</attachment>
+		<attachment name="add_VPs_per_territory_wealth_@nums_1_to_6@_@players@" attachTo="@players@"
+			foreach="$nums_1_to_6$^$players$" javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="territory_wealth_@nums_1_to_6@_count_@players@"/>
+			<option name="when" value="after:@players@UpdateVPsPlace"/>
+			<!-- Activate twice, since we want 2 VPs per wealth value. -->
+			<option name="activateTrigger" value="add_VPs_for_territory_wealth_@nums_1_to_6@_@players@:1:false:false:false:false"/>
+			<option name="activateTrigger" value="add_VPs_for_territory_wealth_@nums_1_to_6@_@players@:1:false:false:false:false"/>
+		</attachment>
+
+		<attachment name="has_fort_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directOwnershipTerritories" value="@land_territories@"/>
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="fort" count="1"/>
+		</attachment>
+		
+		<attachment name="army_count_1_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="1"/>
+		</attachment>
+		<attachment name="army_count_2_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="2"/>
+		</attachment>
+		<attachment name="army_count_3_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="3"/>
+		</attachment>
+		<attachment name="army_count_4_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="4"/>
+		</attachment>
+		<attachment name="army_count_5_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="5"/>
+		</attachment>
+		<attachment name="army_count_6_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="6"/>
+		</attachment>
+		<attachment name="army_count_7_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="7"/>
+		</attachment>
+		<attachment name="army_count_8_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="8"/>
+		</attachment>
+		<attachment name="army_count_9_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="9"/>
+		</attachment>
+		<attachment name="army_count_10_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="10"/>
+		</attachment>
+		<attachment name="army_count_11_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="11"/>
+		</attachment>
+		<attachment name="army_count_12_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="12"/>
+		</attachment>
+		<attachment name="army_count_13_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="13"/>
+		</attachment>
+		<attachment name="army_count_14_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="14"/>
+		</attachment>
+		<attachment name="army_count_15_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="15"/>
+		</attachment>
+		<attachment name="army_count_16_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="16"/>
+		</attachment>
+		<attachment name="army_count_17_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="17"/>
+		</attachment>
+		<attachment name="army_count_18_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="18"/>
+		</attachment>
+		<attachment name="army_count_19_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="19"/>
+		</attachment>
+		<attachment name="army_count_20_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="RulesAttachment" type="player">
+			<option name="directPresenceTerritories" value="@land_territories@" count="1"/>
+			<option name="unitPresence" value="army" count="20"/>
+		</attachment>
+        <attachment name="add_fort_defense_1_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_1_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_2_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_2_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_3_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_3_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_4_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_4_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_5_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_5_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_6_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_6_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_7_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_7_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_8_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_8_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_9_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_9_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_10_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_10_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_11_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_11_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_12_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_12_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_13_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_13_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_14_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_14_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_15_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_15_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_16_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_16_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_17_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_17_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_18_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_18_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_19_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_19_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+        <attachment name="add_fort_defense_20_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="before:Never"/>
+			<option name="conditions" value="army_count_20_@players_and_neutral@_@land_territories@"/>
+			<option name="placement" value="@land_territories@:fort_defense" count="1"/>
+        </attachment>
+
+		<attachment name="remove_fort_defenses_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="after:Never"/>
+			<option name="removeUnits" value="@land_territories@:fort_defense" count="1000"/>
+		</attachment>
+		<attachment name="add_fort_defenses_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<option name="when" value="after:Never"/>
+			<option name="conditions" value="has_fort_@players_and_neutral@_@land_territories@"/>
+			<!-- triggerName:numberOfTimes:useUses:testUses:testConditions:testChance, we want to test the cond. -->
+			<option name="activateTrigger" value="add_fort_defense_1_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_2_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_3_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_4_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_5_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_6_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_7_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_8_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_9_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_10_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_11_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_12_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_13_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_14_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_15_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_16_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_17_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_18_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_19_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+			<option name="activateTrigger" value="add_fort_defense_20_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+		</attachment>
+
+		<attachment name="update_fort_defenses_@players_and_neutral@_@land_territories@" attachTo="@players_and_neutral@"
+			foreach="$players_and_neutral$^$land_territories$" javaClass="TriggerAttachment" type="player">
+			<!-- We need to do it for all players' phases because we're adding units for the defender. -->
+			<option name="when" value="before:BlueWealthPlace"/>
+			<option name="when" value="before:RedWealthPlace"/>
+			<option name="when" value="before:GreenWealthPlace"/>
+			<option name="when" value="before:YellowWealthPlace"/>
+			<option name="when" value="before:OrangeWealthPlace"/>
+			<option name="when" value="before:CyanWealthPlace"/>
+			<option name="when" value="before:PurpleWealthPlace"/>
+			<option name="when" value="before:BrownWealthPlace"/>
+			<option name="conditions" value="cond_true_@players_and_neutral@"/>
+			<!-- First, remove existing fort defenses, then re-add them -->
+			<!-- Note: We can't inline things, because ordering of remove is always after add, but activateTrigger is last. -->
+			<!-- triggerName:numberOfTimes:useUses:testUses:testConditions:testChance -->
+			<option name="activateTrigger" value="remove_fort_defenses_@players_and_neutral@_@land_territories@:1:false:false:false:false"/>
+			<option name="activateTrigger" value="add_fort_defenses_@players_and_neutral@_@land_territories@:1:false:false:true:false"/>
+		</attachment>
+
+		<attachment name="remove_own_fort_defense_@players@" attachTo="@players@" foreach="$players$"
+			javaClass="TriggerAttachment" type="player">
+			<option name="conditions" value="cond_true_@players@"/>
+			<option name="when" value="after:@players@WealthPlace"/>
+			<option name="removeUnits" value="all:fort_defense" count="1000"/>
+		</attachment>
+	</attachmentList>
+	<initialize>
+		<ownerInitialize>
+	        <territoryOwner territory="Anyang" owner="Neutrals"/>
+	        <territoryOwner territory="Bac Lieu" owner="Neutrals"/>
+	        <territoryOwner territory="Pskov" owner="Neutrals"/>
+	        <territoryOwner territory="Tomsk" owner="Neutrals"/>
+			<territoryOwner territory="Aduwa" owner="Neutrals"/>
+			<territoryOwner territory="Aki-Aki" owner="Neutrals"/>
+			<territoryOwner territory="Ambo" owner="Neutrals"/>
+			<territoryOwner territory="Andres" owner="Neutrals"/>
+			<territoryOwner territory="Bari" owner="Neutrals"/>
+			<territoryOwner territory="Billings" owner="Neutrals"/>
+			<territoryOwner territory="Cartagena" owner="Neutrals"/>
+			<territoryOwner territory="Cork" owner="Neutrals"/>
+			<territoryOwner territory="Culiacan" owner="Neutrals"/>
+			<territoryOwner territory="Dominica" owner="Neutrals"/>
+			<territoryOwner territory="Galway" owner="Neutrals"/>
+			<territoryOwner territory="Gondar" owner="Neutrals"/>
+			<territoryOwner territory="Helena" owner="Neutrals"/>
+			<territoryOwner territory="Juwara" owner="Neutrals"/>
+			<territoryOwner territory="Leon" owner="Neutrals"/>
+			<territoryOwner territory="Lodwar" owner="Neutrals"/>
+			<territoryOwner territory="Malden" owner="Neutrals"/>
+			<territoryOwner territory="Mersin" owner="Neutrals"/>
+			<territoryOwner territory="Nicosia" owner="Neutrals"/>
+			<territoryOwner territory="Oaxaca" owner="Neutrals"/>
+			<territoryOwner territory="Palma" owner="Neutrals"/>
+			<territoryOwner territory="Palmyra" owner="Neutrals"/>
+			<territoryOwner territory="Reno" owner="Neutrals"/>
+			<territoryOwner territory="St Lucia" owner="Neutrals"/>
+			<territoryOwner territory="Tebuk" owner="Neutrals"/>
+			<territoryOwner territory="Waco" owner="Neutrals"/>
+			<territoryOwner territory="Yorkton" owner="Neutrals"/>
+			<territoryOwner territory="Threat" owner="Neutrals"/>
+		</ownerInitialize>
+		<unitInitialize>
+            <unitPlacement unitType="army" territory="Threat" quantity="1" owner="Neutrals"/>
+            <unitPlacement unitType="fort" territory="Anyang" quantity="1" owner="Neutrals"/>
+            <unitPlacement unitType="army" territory="Anyang" quantity="1" owner="Neutrals"/>
+            <unitPlacement unitType="fort" territory="Bac Lieu" quantity="1" owner="Neutrals"/>
+            <unitPlacement unitType="army" territory="Bac Lieu" quantity="1" owner="Neutrals"/>
+            <unitPlacement unitType="fort" territory="Pskov" quantity="1" owner="Neutrals"/>
+            <unitPlacement unitType="army" territory="Pskov" quantity="1" owner="Neutrals"/>
+            <unitPlacement unitType="fort" territory="Tomsk" quantity="1" owner="Neutrals"/>
+            <unitPlacement unitType="army" territory="Tomsk" quantity="1" owner="Neutrals"/>
+			<heldUnits unitType="port" quantity="1" player="Blue"/>
+			<heldUnits unitType="port" quantity="1" player="Red"/>
+			<heldUnits unitType="port" quantity="1" player="Green"/>
+			<heldUnits unitType="port" quantity="1" player="Yellow"/>
+			<heldUnits unitType="port" quantity="1" player="Orange"/>
+			<heldUnits unitType="port" quantity="1" player="Cyan"/>
+			<heldUnits unitType="port" quantity="1" player="Purple"/>
+			<heldUnits unitType="port" quantity="1" player="Brown"/>
+		</unitInitialize>
+		<resourceInitialize>
+			<!-- Set VPs to the starting amount, before they get recalculated. -->
+            <resourceGiven player="Blue" resource="Victory Points" quantity="44"/>
+            <resourceGiven player="Red" resource="Victory Points" quantity="44"/>
+            <resourceGiven player="Green" resource="Victory Points" quantity="44"/>
+            <resourceGiven player="Yellow" resource="Victory Points" quantity="44"/>
+            <resourceGiven player="Orange" resource="Victory Points" quantity="44"/>
+            <resourceGiven player="Cyan" resource="Victory Points" quantity="44"/>
+            <resourceGiven player="Purple" resource="Victory Points" quantity="44"/>
+            <resourceGiven player="Brown" resource="Victory Points" quantity="44"/>			
+		</resourceInitialize>
+	</initialize>
+	<propertyList>
+		<property name="Use Triggers" value="true">
+			<boolean/>
+		</property>
+		<!-- HACK: Needed to make canProduceXUnits work! See UnitUtils.java -->
+		<property name="Damage From Bombing Done To Units Instead Of Territories" value="true">
+			<boolean/>
+		</property>
+		<!-- Required to have first strike work on defense. -->
+		<property name="Defending Subs Sneak Attack" value="true">
+			<boolean/>
+		</property>
+		<property name="Unit Placement Restrictions" value="true">
+			<boolean/>
+		</property>
+		<property name="Unit Placement In Enemy Seas" value="true">
+			<boolean/>
+		</property>
+		<property name="Land Battle Rounds" value="1">
+			<boolean/>
+		</property>
+		<!-- Introduced in 2.6. -->
+		<property name="Land Battles May Be Ignored" value="true">
+			<boolean/>
+		</property>
+		<property name="Abandoned Territories May Be Taken Over Immediately" value="true">
+			<boolean/>
+		</property>
+		<!-- Introduced in 2.6. -->
+		<property name="All Units Can Attack From Contested Territories" value="true">
+			<boolean/>
+		</property>
+		<property name="Sea Battle Rounds" value="1">
+			<boolean/>
+		</property>
+		<property name="Sea Battles May Be Ignored" value="true">
+			<boolean/>
+		</property>
+		<property name="Units Can Load In Hostile Sea Zones" value="true">
+			<boolean/>
+		</property>
+		<!-- Can remove if we support 2.6+ -->
+		<property name="mapName" value="imperialism_1974_board_game"/>
+		<property name="notes">
+			<value><![CDATA[
+				<h1>Imperialism - 1974 Board Game</h1>
+
+				<p>This map is an adaptation of the 1974 board game Imperialism to the TripleA engine:<br>
+				<a href="https://boardgamegeek.com/boardgame/14544/imperialism">https://boardgamegeek.com/boardgame/14544/imperialism</a>
+				</p>
+
+				<p>It has a number of unique mechanics that differ from other TripleA maps. At the same time,
+				various features of the original game are not currently possible with TripleA; these are documented
+				later.</p>
+
+				<p>The map is generally playable. AIs do not work properly with TripleA 2.5, but are better on 2.6
+				where they're able to play effectively on the main continent, but are not able to explore yet.</p>
+
+				<h3>Overview</h3>
+				<p>In this game, players start in the "old world" and sail to explore and gain control of
+				"new world" territories. When a territory is first captured, it will get a "wealth production"
+				rating (max 6 for new world or 4 for old world other than starting territories).</p>
+
+				<p>On your turn, you roll a die to determine which territories generate wealth. Each territory
+				with wealth production higher or equal to the die roll will spawn one wealth unit (so territory
+				wealth of 6 always succeeds and the lower the wealth roll the better). These wealth units must be
+				brought to ports so they can be used for purchasing units. A city will increase the wealth
+				production of a territory by 1.</p>
+
+				<br>
+
+				<h3>Additional rules</h3>
+				<ul>
+					<li>Players choose their starting territory, which must be on a coast in the old world (top left island).</li>
+					<li>Armies and fleets attack and defend on 2. Forts provide defense support with an extra strength 2 first strike roll per defending army. Note: This is different from the original board game combat rules, which TripleA isn't able to support.</li>
+					<li>Armies, fleet and wealth have a movement of 1. A fleet can transport an army or a wealth.</li>
+					<li>Structures and wealth are capturable.</li>
+					<li>Production and placement are before movement. No separate non-combat move.</li>
+					<li>Newly-built armies cannot participate in attacks.</li>
+					<li>Territories with no armies in them will revert back to Neutral control and will not generate wealth.</li>
+					<li>Unit production is done at ports and requires spending wealth units present in the port. To build structures, you will first purchase and place corresponding "build" units in the port territory with the required wealth, following which you'll be given the actual unit to place elsewhere on the map.</li>
+					<li>Ships are built in a similar way as structures, except the player should (honor system) then place them next to the port where they were built.</li>
+					<li>Loading and unloading units requires fleets to be on coasts, represented by seperate sea zones.</li>
+					<li>Armies attacking mountain territories attack on a 1 instead of 2.</li>
+				</ul>
+
+				<h3>Unit summary and victory points</h3>
+
+				<p>The goal is to have the most victory points at the end of the game, based on:</p>
+				<br>
+				<table border=1>
+				<tr><th>Entity</th><th>Victory Points</th><th>Note</th></tr>
+				<tr><td>Territory</td><td>2 * wealth production #</td><td>Produces wealth if die roll &lt;= value.</td></tr>
+				<tr><td>Port</td><td>10</td><td>Factory building. Capturable.</td></tr>
+				<tr><td>City</td><td>6</td><td>Increases territory wealth production. Capturable.</td></tr>
+				<tr><td>Fort</td><td>2</td><td>Gives Fort Defense bonus to Armies. Capturable.</td></tr>
+				<tr><td>Wealth</td><td>2</td><td>Spent to produce units at Ports. Capturable.</td></tr>
+				<tr><td>Fleet</td><td>2</td><td>Att/Def 2, Move 1, Transports 1 Army or 1 Wealth.</td></tr>
+				<tr><td>Army</td><td>1</td><td>Att/Def 2, Move 1. Fort Defense bonus at own Forts.</td></tr>
+				<tr><td>Fort Defense</td><td>0</td><td>Armies at own Forts get a First Strike 2 Def roll.</td></tr>
+				</table>
+
+				<p>Victory points are automatically tracked by the game as a resource.</p>
+
+				<p>The board game specifies that the game ends when the last card is drawn from the deck,
+				but the card mechanics are not implemented in this version. Players can instead agree on a
+				pretedetermined round number to end the game - or play until surrender.</p>
+				<br>
+
+				<h3>Original board game functionality missing from this adaptation</h3>
+				<ul>
+					<li>Randomization of player order, which can be done outside TripleA before starting</li>
+					<li>Drawing and playing cards from the deck</li>
+					<li>Random Storm/Pirate events</li>
+					<li>Terrain types - mountains, rivers, etc and their effects</li>
+					<li>Combat dice calculations matching the original game</li>
+					<li>Land battles being optional (except with TripleA 2.6+)</li>
+					<li>Being able to select which opponent(s) you fight when 3+ players in territory</li>
+					<li>Being able to leave contested land territories (except with TripleA 2.6+)</li>
+					<li>Being able to capture wealth cargo at sea</li>
+					<li>Being able to load newly-built armies on fleets</li>
+					<li>Ships on coasts being able to participate in adjacent sea combats</li>
+					<li>Ports being treated as a "territory"</li>
+					<li>Ships having to "retreat" from captured territory ports</li>
+				</ul>
+
+				<h3>Illegal moves allowed by the engine (honor system for humans)</h3>
+				<ul>
+					<li>Units being able to be loaded and unloaded on the same turn</li>
+					<li>Placing built fleets in ports elsewhere than where the wealth to build them came from</li> 
+					<li>Splitting up placement of the initial fleet</li> 
+				</ul>
+
+				<h3>Credits</h3>
+				<p>Some of the images (port icon, gear icon, etc) come from <a href="https://openmoji.org/">OpenMoji</a> – the open-source emoji and icon project. License: CC BY-SA 4.0</p>
+				]]></value>
+		</property>
+	</propertyList>
+</game>


### PR DESCRIPTION
For testing, Instead of downloading a full map, we use the game XMLs that are already checked in. To overcome resource loader issues, a flag is added to skip headless bot from using a map resource loader.

There is no real performance difference after this update.
