### PR TITLE
Add missing test runs

### DIFF
--- a/game-app/run/check
+++ b/game-app/run/check
@@ -4,9 +4,13 @@ set -e
 
 scriptDir=$(dirname "$0")
 "$scriptDir/../../gradlew" --parallel \
+  :game-app:ai:check \
+  :game-app:domain-data:check \
+  :game-app:game-core:check \
   :game-app:game-headed:check \
   :game-app:game-headless:check \
   :game-app:game-relay-server:check \
+  :game-app:map-data:check \
   :game-app:smoke-testing:check
 
 "$scriptDir/.build/check-links"


### PR DESCRIPTION
The build for #11505 is green even though it shouldn't. This should put back the missing checks that were not executed on the PR build