### PR TITLE
Builds: Update game-app/run/check to dynamically find sub-projects

### DIFF
--- a/game-app/run/check
+++ b/game-app/run/check
@@ -2,16 +2,13 @@
 
 set -e
 
+
 scriptDir=$(dirname "$0")
-"$scriptDir/../../gradlew" --parallel \
-  :game-app:ai:check \
-  :game-app:domain-data:check \
-  :game-app:game-core:check \
-  :game-app:game-headed:check \
-  :game-app:game-headless:check \
-  :game-app:game-relay-server:check \
-  :game-app:map-data:check \
-  :game-app:smoke-testing:check
+
+SUB_PROJECTS=$(find $scriptDir/../ -name "build.gradle" -type f | xargs dirname | sed 's|.*\.\./|:game-app:|'   | sed 's/$/:check/' | tr '\n' ' ')
+
+"$scriptDir/../../gradlew" --parallel $SUB_PROJECTS
+
 
 "$scriptDir/.build/check-links"
 


### PR DESCRIPTION
This update will cause the following command to be run:

```
./game-app/run/../../gradlew --parallel :game-app:game-core:check :game-app:game-headless:check
:game-app:domain-data:check :game-app:map-data:check :game-app:game-headed:check
:game-app:smoke-testing:check :game-app:game-relay-server:check :game-app:ai:check
```

Previously we had to explicitly list out of all of these subprojects. This update assumes any folders under neath 'game-app' will be a dependency runs tests in all of those folders.
