### PR TITLE
Fix NPE with returnFire field.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundStepsFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundStepsFactory.java
@@ -25,8 +25,10 @@ public class FireRoundStepsFactory {
   @Nonnull final BattleActions battleActions;
   @Nonnull final Function<BattleState, Collection<FiringGroup>> firingGroupSplitter;
   @Nonnull final BattleState.Side side;
+
   @RemoveOnNextMajorRelease("This is ReturnFire.ALL or null for everything except old saves")
   final MustFightBattle.ReturnFire returnFire;
+
   @Nonnull final BiFunction<IDelegateBridge, RollDiceStep, DiceRoll> diceRoller;
   @Nonnull final BiFunction<IDelegateBridge, SelectCasualties, CasualtyDetails> casualtySelector;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundStepsFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundStepsFactory.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Builder;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
 /** Build the steps for the fire round (roll dice, select casualties, and mark casualties) */
 @Builder
@@ -24,7 +25,8 @@ public class FireRoundStepsFactory {
   @Nonnull final BattleActions battleActions;
   @Nonnull final Function<BattleState, Collection<FiringGroup>> firingGroupSplitter;
   @Nonnull final BattleState.Side side;
-  @Nonnull final MustFightBattle.ReturnFire returnFire;
+  @RemoveOnNextMajorRelease("This is ReturnFire.ALL or null for everything except old saves")
+  final MustFightBattle.ReturnFire returnFire;
   @Nonnull final BiFunction<IDelegateBridge, RollDiceStep, DiceRoll> diceRoller;
   @Nonnull final BiFunction<IDelegateBridge, SelectCasualties, CasualtyDetails> casualtySelector;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MarkCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MarkCasualties.java
@@ -45,7 +45,7 @@ public class MarkCasualties implements BattleStep {
 
   private final FireRoundState fireRoundState;
 
-  @RemoveOnNextMajorRelease("This is ReturnFire.ALL for everything except old saves")
+  @RemoveOnNextMajorRelease("This is ReturnFire.ALL or null for everything except old saves")
   private final MustFightBattle.ReturnFire returnFire;
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/DefensiveFirstStrike.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/DefensiveFirstStrike.java
@@ -19,6 +19,7 @@ import games.strategy.triplea.delegate.battle.steps.fire.general.FiringGroupSpli
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
 /** Generates fire steps for the first strike battle phase for the defensive player */
 public class DefensiveFirstStrike implements BattleStep {
@@ -39,6 +40,7 @@ public class DefensiveFirstStrike implements BattleStep {
 
   protected final State state;
 
+  @RemoveOnNextMajorRelease("This is ReturnFire.ALL or null for everything except old saves")
   protected transient ReturnFire returnFire = ReturnFire.ALL;
 
   public DefensiveFirstStrike(final BattleState battleState, final BattleActions battleActions) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/OffensiveFirstStrike.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/OffensiveFirstStrike.java
@@ -19,6 +19,7 @@ import games.strategy.triplea.delegate.battle.steps.fire.general.FiringGroupSpli
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
 /** Generates fire steps for the first strike battle phase for the offensive player */
 public class OffensiveFirstStrike implements BattleStep {
@@ -39,6 +40,7 @@ public class OffensiveFirstStrike implements BattleStep {
 
   protected final State state;
 
+  @RemoveOnNextMajorRelease("This is ReturnFire.ALL or null for everything except old saves")
   protected transient ReturnFire returnFire = ReturnFire.ALL;
 
   public OffensiveFirstStrike(final BattleState battleState, final BattleActions battleActions) {


### PR DESCRIPTION
## Change Summary & Additional Notes
The field was marked as transient in two classes, meaning it would not be serialized and was null on deserialization, but the code did not handle it properly. Since the leaf code using it was marked with  `@RemoveOnNextMajorRelease` and could handle null, simply remove the non-null tag and propagate the deprecation tag.

Fixes https://github.com/triplea-game/triplea/issues/11097.
Issue was introduced by: https://github.com/triplea-game/triplea/pull/7497 (2.6 problem)

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
