### PR TITLE
Fix 2.6 NoSuchElementException in AA code.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -669,7 +669,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsAaOfTypeAa(final String typeAa) {
-    return u -> u.getUnitAttachment().getTypeAa().matches(typeAa);
+    return u -> u.getUnitAttachment().getTypeAa().equals(typeAa);
   }
 
   public static Predicate<Unit> unitAaShotDamageableInsteadOfKillingInstantly() {


### PR DESCRIPTION
## Change Summary & Additional Notes

Fix 2.6 NoSuchElementException in AA code.

This would happen if a unit has special chars in its aaType, causing it to be evaluated as a regex instead of an exact match. This specifically broke the code pattern (e.g. in FiringGroupSplitterAa):

    final List<String> typeAas = UnitAttachment.getAllOfTypeAas(aaUnits);
    for (final String typeAa : typeAas) {
      final Collection<Unit> firingUnits =
          CollectionUtils.getMatches(aaUnits, Matches.unitIsAaOfTypeAa(typeAa));

Causing an empty `firingUnits` due to typeAa being evaluated as a regex. I checked all the callsites and verified none of them actually require the regex behavior.

Fixes: https://github.com/triplea-game/triplea/issues/11458

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
