### PR TITLE
Fix stalemate logic to end 0 att plane vs. transport fights.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1301,6 +1301,10 @@ public class MustFightBattle extends DependentBattle
                 throw new IllegalStateException(
                     "Round 10,000 reached in a battle. Something must be wrong."
                         + " Please report this to TripleA.\n"
+                        + " Territory: "
+                        + battleSite
+                        + " Attacker: "
+                        + attacker.getName()
                         + " Attacking unit types: "
                         + attackingUnits.stream()
                             .map(Unit::getType)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -116,7 +116,8 @@ public class CheckGeneralBattleEnd implements BattleStep {
                     Properties.getLhtrHeavyBombers(battleState.getGameData().getProperties()))
                 .gameDiceSides(battleState.getGameData().getDiceSides())
                 .territoryEffects(battleState.getTerritoryEffects())
-                .build()).hasStrengthOrRolls();
+                .build())
+        .hasStrengthOrRolls();
   }
 
   private Iterable<FiringGroup> getAllFiringGroups(final BattleState.Side side) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -178,12 +178,8 @@ public class FakeBattleState implements BattleState {
     return List.of();
   }
 
-  public static FakeBattleState.FakeBattleStateBuilder givenBattleStateBuilder() {
-    final GameData gameData = givenGameData().build();
-    final GamePlayer attacker = mock(GamePlayer.class);
-    lenient().when(attacker.getData()).thenReturn(gameData);
-    final GamePlayer defender = mock(GamePlayer.class);
-    lenient().when(defender.getData()).thenReturn(gameData);
+  public static FakeBattleState.FakeBattleStateBuilder givenBattleStateBuilder(
+      final GamePlayer attacker, final GamePlayer defender) {
     return FakeBattleState.builder()
         .battleRound(2)
         .maxBattleRounds(-1)
@@ -199,9 +195,18 @@ public class FakeBattleState implements BattleState {
         .dependentUnits(List.of())
         .killed(List.of())
         .retreatUnits(new ArrayList<>())
-        .gameData(gameData)
+        .gameData(attacker.getData())
         .amphibious(false)
         .over(false)
         .attackerRetreatTerritories(List.of());
+  }
+
+  public static FakeBattleState.FakeBattleStateBuilder givenBattleStateBuilder() {
+    final GameData gameData = givenGameData().build();
+    final GamePlayer attacker = mock(GamePlayer.class);
+    lenient().when(attacker.getData()).thenReturn(gameData);
+    final GamePlayer defender = mock(GamePlayer.class);
+    lenient().when(defender.getData()).thenReturn(gameData);
+    return givenBattleStateBuilder(attacker, defender);
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEndTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEndTest.java
@@ -44,7 +44,9 @@ class CheckGeneralBattleEndTest {
   void setUp() {
     final GameData gameData = new GameData();
 
+    lenient().when(attacker.getName()).thenReturn("attacker");
     lenient().when(attacker.getData()).thenReturn(gameData);
+    lenient().when(defender.getName()).thenReturn("defender");
     lenient().when(defender.getData()).thenReturn(gameData);
   }
 
@@ -140,7 +142,7 @@ class CheckGeneralBattleEndTest {
   }
 
   @Test
-  void battleIsNotDoneIfOffenseHasUnitWithPower() {
+  void battleDoesNotEndIfOffenseHasUnitWithPower() {
     final Unit attackerUnit = givenUnitWithAttackPower(attacker);
     final Unit defenderUnit = givenAnyUnit();
     lenient().when(defenderUnit.getOwner()).thenReturn(defender);
@@ -169,7 +171,7 @@ class CheckGeneralBattleEndTest {
   }
 
   @Test
-  void battleIsNotDoneIfDefenseHasUnitWithPower() {
+  void battleDoesNotEndIfDefenseHasUnitWithPower() {
     final Unit attackerUnit = givenAnyUnit();
     when(attackerUnit.getOwner()).thenReturn(attacker);
     final Unit defenderUnit = givenUnitWithDefensePower(defender);
@@ -307,6 +309,51 @@ class CheckGeneralBattleEndTest {
             .defender(defender)
             .attackingUnits(List.of(attackerUnit))
             .defendingUnits(List.of(defenderUnit))
+            .build();
+
+    final CheckGeneralBattleEnd checkGeneralBattleEnd = givenCheckGeneralBattleEnd(battleState);
+    checkGeneralBattleEnd.execute(executionStack, delegateBridge);
+
+    verify(battleActions, times(1).description("No one can hit each other so it is a stalemate"))
+        .endBattle(IBattle.WhoWon.DRAW, delegateBridge);
+  }
+
+  @Test
+  void nobodyWinsIfBothCanNotTargetEachOtherInGeneralCombat2() {
+    final GameData gameData = givenGameData().withDiceSides(6).build();
+
+    final UnitType attackerUnitType = new UnitType("attacker", gameData);
+    final UnitAttachment attackerUnitAttachment =
+        new UnitAttachment("attacker", attackerUnitType, gameData);
+    attackerUnitAttachment.setAttack(0).setAttackRolls(0);
+    attackerUnitType.addAttachment(UNIT_ATTACHMENT_NAME, attackerUnitAttachment);
+
+    final UnitType defenderUnitType = new UnitType("defender", gameData);
+    final UnitAttachment defenderUnitAttachment =
+        new UnitAttachment("defender", defenderUnitType, gameData);
+    defenderUnitAttachment.setDefense(1).setDefenseRolls(1);
+    // A unit that can't target attacker.
+    defenderUnitAttachment.setCanNotTarget(Set.of(attackerUnitType));
+    defenderUnitType.addAttachment(UNIT_ATTACHMENT_NAME, defenderUnitAttachment);
+
+    final UnitType defenderUnitType2 = new UnitType("defender2", gameData);
+    final UnitAttachment defenderUnitAttachment2 =
+        new UnitAttachment("defender2", defenderUnitType2, gameData);
+    // A unit that can target attacker, but has no defense power.
+    defenderUnitAttachment2.setDefense(0).setDefenseRolls(1);
+    defenderUnitType2.addAttachment(UNIT_ATTACHMENT_NAME, defenderUnitAttachment2);
+
+    final Unit attackerUnit = attackerUnitType.createTemp(1, attacker).get(0);
+    final Unit defenderUnit = defenderUnitType.createTemp(1, defender).get(0);
+    final Unit defenderUnit2 = defenderUnitType2.createTemp(1, defender).get(0);
+
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .gameData(gameData)
+            .attacker(attacker)
+            .defender(defender)
+            .attackingUnits(List.of(attackerUnit))
+            .defendingUnits(List.of(defenderUnit, defenderUnit2))
             .build();
 
     final CheckGeneralBattleEnd checkGeneralBattleEnd = givenCheckGeneralBattleEnd(battleState);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEndTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEndTest.java
@@ -7,6 +7,7 @@ import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.given
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitSeaTransport;
 import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,6 +25,7 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.IBattle;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -37,6 +39,14 @@ class CheckGeneralBattleEndTest {
   @Mock BattleActions battleActions;
   @Mock GamePlayer attacker;
   @Mock GamePlayer defender;
+
+  @BeforeEach
+  void setUp() {
+    final GameData gameData = new GameData();
+
+    lenient().when(attacker.getData()).thenReturn(gameData);
+    lenient().when(defender.getData()).thenReturn(gameData);
+  }
 
   private CheckGeneralBattleEnd givenCheckGeneralBattleEnd(final BattleState battleState) {
     return new CheckGeneralBattleEnd(battleState, battleActions);
@@ -133,9 +143,10 @@ class CheckGeneralBattleEndTest {
   void battleIsNotDoneIfOffenseHasUnitWithPower() {
     final Unit attackerUnit = givenUnitWithAttackPower(attacker);
     final Unit defenderUnit = givenAnyUnit();
+    lenient().when(defenderUnit.getOwner()).thenReturn(defender);
 
     final BattleState battleState =
-        givenBattleStateBuilder()
+        givenBattleStateBuilder(attacker, defender)
             .gameData(givenGameData().withDiceSides(6).build())
             .attackingUnits(List.of(attackerUnit))
             .defendingUnits(List.of(defenderUnit))
@@ -252,8 +263,10 @@ class CheckGeneralBattleEndTest {
         givenBattleStateBuilder()
             .gameData(
                 givenGameData()
-                    .withLhtrHeavyBombers(false)
+                    .withAlliedAirIndependent(false)
+                    .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                     .withTransportCasualtiesRestricted(true)
+                    .withLhtrHeavyBombers(false)
                     .build())
             .attackingUnits(List.of(attackerUnit))
             .defendingUnits(List.of(defenderUnit))


### PR DESCRIPTION
## Change Summary & Additional Notes

Without this, we would trigger the 10K rounds limit in AI simulation when the battle ends up with a strat bomber (that has no attack or defense) faced off against a transport and/or subs, and neither would be able to damage the other.

Added a unit test. Also renames a couple of existing tests for clarity.

Fixes: https://github.com/triplea-game/triplea/issues/10936

Note: This problem does not exist in 2.5 (tested).

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
