### PR TITLE
Use getProTerritory() to avoid NPE.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2412,7 +2412,8 @@ class ProNonCombatMoveAi {
             if (finalDestinationTest.test(t)) {
               Route r = data.getMap().getRouteForUnit(from, t, canMoveThrough, unit, player);
               while (r != null && r.hasSteps()) {
-                if (moveMap.get(r.getEnd()).isCanHold() && validateMove.test(r)) {
+                final ProTerritory proDestination = proData.getProTerritory(moveMap, r.getEnd());
+                if (proDestination.isCanHold() && validateMove.test(r)) {
                   destination.setValue(r.getEnd());
                   // End the search.
                   return false;


### PR DESCRIPTION
## Change Summary & Additional Notes

Speculative fix for https://github.com/triplea-game/triplea/issues/11655, which is a 2.6 issue in the new AI logic to move consumables to factories.

I don't have a repro, but this wrapper specifically handles the case when the map doesn't have an entry and we use it elsewhere, so seems like the right thing to do.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
