### PR TITLE
Fix duplicate key error with edit mode's unit deletion.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -344,11 +345,12 @@ public final class UnitChooser extends JPanel {
    * killed).
    */
   public List<Unit> getSelected(final boolean selectDependents) {
-    final List<Unit> selectedUnits = new ArrayList<>();
+    // Use a Set to avoid duplicates in the case where depends can be selected manually too.
+    final var selectedUnits = new HashSet<Unit>();
     for (final ChooserEntry entry : entries) {
       addToCollection(selectedUnits, entry, entry.getFinalHit(), selectDependents);
     }
-    return selectedUnits;
+    return new ArrayList<>(selectedUnits);
   }
 
   /** Only applicable if this dialog was constructed using multiple hit points. */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -345,7 +345,7 @@ public final class UnitChooser extends JPanel {
    * killed).
    */
   public List<Unit> getSelected(final boolean selectDependents) {
-    // Use a Set to avoid duplicates in the case where depends can be selected manually too.
+    // Use a Set to avoid duplicates in the case where dependents are also manually selected.
     final var selectedUnits = new HashSet<Unit>();
     for (final ChooserEntry entry : entries) {
       addToCollection(selectedUnits, entry, entry.getFinalHit(), selectDependents);


### PR DESCRIPTION
## Change Summary & Additional Notes

Fix duplicate key error with edit mode's unit deletion.

This can happen if a unit chooser is brought up and the user manually selects both a transport and a unit loaded onto it. The unit loaded onto it will be added twice due to also being added as a dependent.

Fixes: https://github.com/triplea-game/triplea/issues/11416
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
