### PR TITLE
Don't require an assets folder for headless operation.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -2,6 +2,7 @@ package games.strategy.triplea;
 
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.triplea.ui.OrderedProperties;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
@@ -48,11 +49,13 @@ public class ResourceLoader implements Closeable {
     this.assetPaths = assetPaths;
     List<URL> searchUrls = assetPaths.stream().map(PathUtils::toUrl).collect(Collectors.toList());
 
-    Path gameEngineAssets =
-        findDirectory(ClientFileSystemHelper.getRootFolder(), ASSETS_FOLDER)
-            .orElseThrow(GameAssetsNotFoundException::new);
+    if (!GameRunner.headless()) {
+      Path gameEngineAssets =
+          findDirectory(ClientFileSystemHelper.getRootFolder(), ASSETS_FOLDER)
+              .orElseThrow(GameAssetsNotFoundException::new);
 
-    searchUrls.add(PathUtils.toUrl(gameEngineAssets));
+      searchUrls.add(PathUtils.toUrl(gameEngineAssets));
+    }
 
     // Note: URLClassLoader does not always respect the ordering of the search URLs
     // To solve this we will get all matching paths and then filter by what matched


### PR DESCRIPTION
## Change Summary & Additional Notes

Don't require an assets folder for headless operation.
This fixes being able to start a bot from the triplea-game-headless.zip release, which doesn't include an assets folder.
I tested this by running a local bot and connecting to it and playing a full round.
Fixes: [9821](https://github.com/triplea-game/triplea/pulls/9821)

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
