### PR TITLE
Rewrite findTargets for better performance.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/TargetGroup.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/TargetGroup.java
@@ -7,7 +7,6 @@ import games.strategy.triplea.delegate.Matches;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -44,13 +43,13 @@ class TargetGroup {
    */
   public static List<TargetGroup> newTargetGroups(
       final Collection<Unit> units, final Collection<Unit> enemyUnits) {
-
     final Set<UnitType> unitTypes = units.stream().map(Unit::getType).collect(Collectors.toSet());
+    final boolean destroyerPresent = unitTypes.stream().anyMatch(Matches.unitTypeIsDestroyer());
     final Set<UnitType> enemyUnitTypes =
         enemyUnits.stream().map(Unit::getType).collect(Collectors.toSet());
     final List<TargetGroup> targetGroups = new ArrayList<>();
     for (final UnitType unitType : unitTypes) {
-      final Set<UnitType> targets = findTargets(unitType, unitTypes, enemyUnitTypes);
+      final Set<UnitType> targets = findTargets(unitType, destroyerPresent, enemyUnitTypes);
       if (targets.isEmpty()) {
         continue;
       }
@@ -65,15 +64,21 @@ class TargetGroup {
   }
 
   private static Set<UnitType> findTargets(
-      final UnitType unitType, final Set<UnitType> unitTypes, final Set<UnitType> enemyUnitTypes) {
-    final Set<UnitType> targets = new HashSet<>(enemyUnitTypes);
-    targets.removeAll(unitType.getUnitAttachment().getCanNotTarget());
-    return unitTypes.stream().anyMatch(Matches.unitTypeIsDestroyer())
-        ? targets
-        : targets.stream()
-            .filter(
-                target -> !target.getUnitAttachment().getCanNotBeTargetedBy().contains(unitType))
-            .collect(Collectors.toSet());
+      UnitType unitType, boolean destroyerPresent, Set<UnitType> enemyUnitTypes) {
+    Set<UnitType> cannotTarget = unitType.getUnitAttachment().getCanNotTarget();
+    // Note: uses a single stream instead of a sequence of removeAll() calls for performance.
+    return enemyUnitTypes.stream()
+        .filter(
+            ut -> {
+              if (cannotTarget.contains(ut)) {
+                return false;
+              }
+              if (destroyerPresent) {
+                return true;
+              }
+              return !ut.getUnitAttachment().getCanNotBeTargetedBy().contains(unitType);
+            })
+        .collect(Collectors.toSet());
   }
 
   private static Optional<TargetGroup> findTargetsInTargetGroups(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/TargetGroup.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/TargetGroup.java
@@ -69,14 +69,14 @@ class TargetGroup {
     // Note: uses a single stream instead of a sequence of removeAll() calls for performance.
     return enemyUnitTypes.stream()
         .filter(
-            ut -> {
-              if (cannotTarget.contains(ut)) {
+            targetUnitType -> {
+              if (cannotTarget.contains(targetUnitType)) {
                 return false;
               }
               if (destroyerPresent) {
                 return true;
               }
-              return !ut.getUnitAttachment().getCanNotBeTargetedBy().contains(unitType);
+              return !targetUnitType.getUnitAttachment().getCanNotBeTargetedBy().contains(unitType);
             })
         .collect(Collectors.toSet());
   }


### PR DESCRIPTION
## Change Summary & Additional Notes

- Avoids O(n^2) destroyer checks.
- Avoids an expensive removeAll() call.
- Uses a single stream filter to process, removing an unnecessary intermediate collection in the common case when no destroyers are present.

Note: This was showing up in performance profiles.
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
