### PR TITLE
Install4J updates

### DIFF
--- a/game-app/game-headed/build.install4j
+++ b/game-app/game-headed/build.install4j
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="9.0.6" transformSequenceNumber="9">
+<install4j version="10.0.6" transformSequenceNumber="10">
   <directoryPresets config=".triplea-root" />
   <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="https://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="11" jdkMode="jdk">
-    <jreBundles jdkProviderId="AdoptOpenJDK" release="11/jdk-11.0.9.1+1" />
+    <jreBundles jdkProviderId="AdoptOpenJDK" release="11/jdk-11.0.19+7" />
   </application>
-  <files preserveSymlinks="false">
+  <files>
     <mountPoints>
       <mountPoint id="28" location="assets" />
       <mountPoint id="23" location="bin" />
@@ -17,7 +17,7 @@
     </entries>
   </files>
   <launchers>
-    <launcher name="TripleA" id="33" menuName="TripleA-${compiler:sys.version}" macStaticAssociationsForInstallers="true">
+    <launcher name="TripleA" id="33" menuName="TripleA-${compiler:sys.version}">
       <executable name="TripleA" iconSet="true" stderrMode="append" executableMode="gui" checkConsoleParameter="true" dpiAware="true">
         <versionInfo internalName="TripleA" productName="TripleA Game" />
       </executable>
@@ -32,10 +32,6 @@
           <scanDirectory location="bin" failOnError="false" />
         </classPath>
       </java>
-      <macStaticAssociationActions mode="selected">
-        <id>554</id>
-        <id>263</id>
-      </macStaticAssociationActions>
       <vmOptionsFile mode="none" overwriteMode="3" />
       <iconImageFiles>
         <file path="./assets/icons/triplea_icon_16_16.png" />
@@ -45,6 +41,10 @@
         <file path="./assets/icons/triplea_icon_128_128.png" />
         <file path="./assets/icons/triplea_icon_256_256.png" />
       </iconImageFiles>
+      <macStaticAssociations>
+        <fileAssociation extension="tsvg" description="TripleA Savegame" />
+        <urlHandler scheme="triplea" />
+      </macStaticAssociations>
     </launcher>
   </launchers>
   <installerGui suggestPreviousLocations="false">
@@ -801,15 +801,18 @@ return true;</property>
     </styles>
   </installerGui>
   <mediaSets>
-    <windows name="Windows 32 bit" id="90" mediaFileName="${compiler:sys.fullName}_${compiler:sys.version}_windows-32bit" jreBitType="32">
+    <windows name="Windows 32 bit" id="90" mediaFileName="${compiler:sys.fullName}_${compiler:sys.version}_windows-32bit" architecture="32">
       <jreBundle usePack200="false" jreBundleSource="preCreated" includedJre="build/assets/install4j/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.4_11.tar.gz" manualJreEntry="true" bundleUrl="https://raw.githubusercontent.com/triplea-game/assets/master/install4j/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.4_11.tar.gz" directDownload="true" />
     </windows>
-    <windows name="Windows 64 bit" id="87" mediaFileName="${compiler:sys.fullName}_${compiler:sys.version}_windows-64bit">
+    <windows name="Windows 64 bit" id="87" mediaFileName="${compiler:sys.fullName}_${compiler:sys.version}_windows-64bit" architecture="64">
       <jreBundle usePack200="false" directDownload="true" />
     </windows>
-    <macosArchive name="macOS Single Bundle Archive" id="557" launcherId="33" />
+    <macosArchive name="macOS Single Bundle Archive" id="557" architecture="universal" launcherId="33" />
     <unixInstaller name="Unix" id="36">
       <jreBundle usePack200="false" directDownload="true" installOnlyIfNecessary="true" />
     </unixInstaller>
   </mediaSets>
+  <buildIds buildAll="false">
+    <mediaSet refId="557" />
+  </buildIds>
 </install4j>


### PR DESCRIPTION
## Change Summary & Additional Notes

- Switch to Install4J 10.0.6 (latest version) from 9.0.6
- Update bundled JDK version to latest java 11 patch (11.0.19+7)
- Switch Mac build to Universal (x86_64 + arm64) to support M1 macs

The bump to latest JDK11 patchlevel should also pick up a fix for this UI issue on Mac: https://bugs.openjdk.org/browse/JDK-8251377

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Add arm64 native arch to Mac app.<!--END_RELEASE_NOTE-->
<!--RELEASE_NOTE-->FIX|Unreadable tab titles on Mac.<!--END_RELEASE_NOTE-->
<!--RELEASE_NOTE-->CHANGE|Switch bundled Java to 11.0.19+7.<!--END_RELEASE_NOTE-->
