### PR TITLE
Revert "Disable pack200 compression in install4j. (#11765)"

### DIFF
--- a/game-app/game-headed/build.install4j
+++ b/game-app/game-headed/build.install4j
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <install4j version="9.0.6" transformSequenceNumber="9">
   <directoryPresets config=".triplea-root" />
-  <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="false" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="https://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="11" jdkMode="jdk">
+  <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="https://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="11" jdkMode="jdk">
     <jreBundles jdkProviderId="AdoptOpenJDK" release="11/jdk-11.0.19+7" />
   </application>
   <files preserveSymlinks="false">


### PR DESCRIPTION
## Change Summary & Additional Notes
This reverts commit 25234345e2d7afaf7c94ca1faea8ab5c69c3321a.

Looks like despite the warnings, pack200 was still having a good impact on size.
If we compare:
https://github.com/triplea-game/triplea/releases/tag/2.6.14408
vs.:
https://github.com/triplea-game/triplea/releases/tag/2.6.14407

We can see that the installers went up in size (e.g. +22MB on Windows 64-bit). Only mac was not affected.

So this PR re-enables pack200.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
