### PR TITLE
Omit attachment order data from saves by default.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -588,12 +588,14 @@ public class GameData implements Serializable, GameState {
    * header. Returns empty if the 'map.yml' or game notes file cannot be found.
    */
   public String loadGameNotes(final Path mapLocation) {
-    // Given a game name, the map.yml file can tell us the path to the game xml file.
     // From the game-xml file name, we can find the game-notes file.
+    return getGameXmlPath(mapLocation).map(GameNotes::loadGameNotes).orElse("");
+  }
+
+  public Optional<Path> getGameXmlPath(final Path mapLocation) {
+    // Given a game name, the map.yml file can tell us the path to the game xml file.
     return findMapDescriptionYaml(mapLocation)
-        .flatMap(yaml -> yaml.getGameXmlPathByGameName(getGameName()))
-        .map(GameNotes::loadGameNotes)
-        .orElse("");
+        .flatMap(yaml -> yaml.getGameXmlPathByGameName(getGameName()));
   }
 
   private Optional<MapDescriptionYaml> findMapDescriptionYaml(final Path mapLocation) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -7,7 +7,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.delegate.IDelegate;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.delegate.IDelegate;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -129,7 +130,7 @@ public final class GameDataManager {
       try (OutputStream os = Files.newOutputStream(tempFile);
           OutputStream bufferedOutStream = new BufferedOutputStream(os);
           OutputStream zippedOutStream = new GZIPOutputStream(bufferedOutStream)) {
-        saveGameUncompressed(zippedOutStream, gameData, Options.withEverything());
+        saveGameUncompressed(zippedOutStream, gameData, Options.forSaveGame());
       }
 
       // now write to sink (ensure sink is closed per method contract)
@@ -150,6 +151,12 @@ public final class GameDataManager {
 
     public static Options withEverything() {
       return builder().withDelegates(true).withHistory(true).withAttachmentXmlData(true).build();
+    }
+
+    public static Options forSaveGame() {
+      // Omit attachment data as it uses a lot of memory and is only needed for XML exports, which
+      // now reads it from the original XML instead.
+      return builder().withDelegates(true).withHistory(true).withAttachmentXmlData(false).build();
     }
 
     public static Options forBattleCalculator() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -173,8 +173,6 @@ public final class GameDataManager {
         if (!options.withHistory) {
           data.resetHistory();
         }
-        // TODO: Attachment order data is only used for XML export and takes up lots of memory.
-        // Could we remove it and just get the info again from the XML when exporting?
         final var attachments = data.getAttachmentOrderAndValues();
         if (!options.withAttachmentXmlData) {
           data.setAttachmentOrderAndValues(null);

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -15,7 +15,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Observable;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import lombok.Getter;
@@ -29,9 +28,6 @@ import org.triplea.java.ThreadRunner;
  */
 @Slf4j
 public class GameSelectorModel extends Observable implements GameSelector {
-
-  private final Function<Path, Optional<GameData>> gameParser;
-
   @Nullable
   @Getter(onMethod_ = {@Override})
   private GameData gameData = null;
@@ -46,9 +42,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
   @Setter @Getter private ClientModel clientModelForHostBots = null;
   private Optional<String> saveGameToLoad = Optional.empty();
 
-  public GameSelectorModel() {
-    this.gameParser = GameParser::parse;
-  }
+  public GameSelectorModel() {}
 
   /**
    * Loads game data by parsing a given file.
@@ -102,7 +96,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
 
   @Nullable
   private GameData parseAndValidate(final Path file) {
-    final GameData gameData = gameParser.apply(file).orElse(null);
+    final GameData gameData = GameParser.parse(file, false).orElse(null);
     if (gameData == null) {
       return null;
     }

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
@@ -26,7 +26,8 @@ final class GameParserTest {
   void backwardCompatibilityCheck() throws Exception {
     final Path mapFile = getTestMap("v1_8_map__270BC.xml");
     final GameData gameData =
-        GameParser.parse(mapFile, new XmlGameElementMapper(), new Version("2.0.0")).orElseThrow();
+        GameParser.parse(mapFile, new XmlGameElementMapper(), new Version("2.0.0"), false)
+            .orElseThrow();
     assertNotNullGameData(gameData);
 
     verifyLegacyPropertiesAreUpdated(gameData);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -78,7 +78,8 @@ public enum TestMapGameData {
             new XmlGameElementMapper(
                 Map.of("TestDelegate", TestDelegate::new),
                 Map.of("TestAttachment", TestAttachment::new)),
-            new Version("2.0.0"))
+            new Version("2.0.0"),
+            false)
         .orElseThrow(() -> new IllegalStateException("Error parsing: " + mapUri));
   }
 }

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -91,6 +91,13 @@ final class ExportMenu extends JMenu {
   }
 
   private void exportXmlFile() {
+    // The existing XML file is needed for attachment ordering data.
+    final Path gameXmlPath = gameData.getGameXmlPath(uiContext.getMapLocation()).orElse(null);
+    if (gameXmlPath == null) {
+      JOptionPane.showMessageDialog(frame, "Error: Existing XML file not found.");
+      return;
+    }
+
     final JFileChooser chooser = new JFileChooser();
     chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
 
@@ -109,7 +116,7 @@ final class ExportMenu extends JMenu {
       return;
     }
     try (GameData.Unlocker ignored = gameData.acquireReadLock()) {
-      final Game xmlGameModel = GameDataExporter.convertToXmlModel(gameData);
+      final Game xmlGameModel = GameDataExporter.convertToXmlModel(gameData, gameXmlPath);
       GameXmlWriter.exportXml(xmlGameModel, chooser.getSelectedFile().toPath());
     }
   }

--- a/game-app/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
+++ b/game-app/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
@@ -55,7 +55,7 @@ public class GameTestUtils {
     }
 
     GameData gameData =
-        GameParser.parse(xmlFilePath)
+        GameParser.parse(xmlFilePath, false)
             .orElseThrow(() -> new RuntimeException("Error parsing file: " + xmlFilePath));
     Map<String, PlayerTypes.Type> playerTypes = new HashMap<>();
     for (var player : gameData.getPlayerList().getPlayers()) {

--- a/game-app/smoke-testing/src/test/java/games/strategy/engine/data/ParseGameXmlsTest.java
+++ b/game-app/smoke-testing/src/test/java/games/strategy/engine/data/ParseGameXmlsTest.java
@@ -22,7 +22,7 @@ class ParseGameXmlsTest {
   void parseGameFiles(final Path xmlFile) {
     final Optional<GameData> result =
         GameParser.parse(
-            xmlFile, new XmlGameElementMapper(), ProductVersionReader.getCurrentVersion());
+            xmlFile, new XmlGameElementMapper(), ProductVersionReader.getCurrentVersion(), false);
     assertThat(result, OptionalMatchers.isPresent());
   }
 


### PR DESCRIPTION
## Change Summary & Additional Notes

This data is only needed for the "export to XML" function which is only used by mapmakers. However, the data is a huge contributor to save file size (and saving time). With this change, Imperialism 1974 saves go from 1.2MB in size to 800K (1/3 reduction).

The functionality to export to XML is maintained by re-reading the attachment order data from the original XML file when the export function is used.

Tested exporting map XML and confirmed it still worked.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
