### PR TITLE
Fix issue a cause of "Could not find step name" (2.6 bug).

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1272,6 +1272,7 @@ public class MustFightBattle extends DependentBattle
       final boolean attacking,
       final boolean removeForNextRound) {
     int battleRound = (removeForNextRound ? round + 1 : round);
+    // Note: Also done in FiringGroupSplitterGeneral when determining step names. They must match.
     return CollectionUtils.getMatches(
         units,
         Matches.unitCanParticipateInCombat(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -142,7 +142,8 @@ public class BattleStepsTest {
     return unitAndAttachment.unit;
   }
 
-  public static Unit givenSeaUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(final UnitType otherType) {
+  public static Unit givenSeaUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(
+      final UnitType otherType) {
     final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -2000,4 +2000,42 @@ public class BattleStepsTest {
 
     assertThat(steps, is(basicFightStepStrings()));
   }
+
+  @Test
+  @DisplayName("Verify that extra steps won't be created due to canNotTarget and non-participants")
+  void nonParticipantsDontCreateExtraStepsWithCannotTarget() {
+    // Two attacking units of different types.
+    final Unit unit1 = givenAnyUnit();
+    lenient().when(unit1.getOwner()).thenReturn(attacker);
+    final Unit unit2 = givenAnyUnit();
+    lenient().when(unit2.getOwner()).thenReturn(attacker);
+    final UnitType unit2Type = unit2.getType();
+
+    // One defending unit that can only target one of the attackers.
+    final Unit unit3 = givenAnyUnit();
+    lenient().when(unit3.getOwner()).thenReturn(defender);
+    final UnitAttachment unit3Attachment = unit3.getUnitAttachment();
+    when(unit3Attachment.getCanNotTarget()).thenReturn(Set.of(unit2Type));
+    // And an infra unit on the defense that should not participate in combat.
+    final Unit unit4 = givenUnitIsInfrastructure();
+    lenient().when(unit4.getOwner()).thenReturn(defender);
+
+    final var unitTypeList =
+        List.of(unit1.getType(), unit2.getType(), unit3.getType(), unit4.getType());
+
+    final List<String> steps =
+        givenBattleSteps(
+            givenBattleStateBuilder()
+                .gameData(
+                    givenGameDataWithLenientProperties().withUnitTypeList(unitTypeList).build())
+                .attacker(attacker)
+                .defender(defender)
+                .attackingUnits(List.of(unit1, unit2))
+                .defendingUnits(List.of(unit3, unit4))
+                .battleSite(battleSite)
+                .amphibious(false)
+                .build());
+
+    assertThat(steps, is(basicFightStepStrings()));
+  }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -65,6 +65,10 @@ public class BattleStepsTest {
   @Mock GamePlayer defender;
   @Mock TechAttachment techAttachment;
 
+  public static MockGameData givenGameDataWithLenientProperties() {
+    return givenGameData().withLenientProperties();
+  }
+
   @BeforeEach
   public void givenPlayers() {
     lenient().when(attacker.getName()).thenReturn("mockAttacker");
@@ -333,9 +337,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -360,11 +362,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withNavalBombardCasualtiesReturnFire(false)
-                        .withCaptureUnitsOnEnteringTerritory(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -393,9 +391,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -419,10 +415,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .battleRound(1)
@@ -480,9 +473,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .battleRound(1)
@@ -506,9 +497,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -562,10 +551,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .battleRound(1)
@@ -699,8 +685,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withSubRetreatBeforeBattle(true)
                         .withSubmersibleSubs(true)
                         .withAlliedAirIndependent(true)
@@ -728,8 +713,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withSubRetreatBeforeBattle(true)
                         .withSubmersibleSubs(true)
                         .withAlliedAirIndependent(true)
@@ -757,9 +741,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -784,13 +766,9 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withTransportCasualtiesRestricted(false)
-                        .withCaptureUnitsOnEnteringTerritory(false)
+                    givenGameDataWithLenientProperties()
                         .withSubRetreatBeforeBattle(true)
                         .withSubmersibleSubs(true)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withWW2V2(false)
                         .withDefendingSubsSneakAttack(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -822,9 +800,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withTransportCasualtiesRestricted(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -850,10 +826,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -877,9 +850,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withTransportCasualtiesRestricted(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -906,10 +877,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -935,10 +903,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withWW2V2(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -968,11 +933,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withTransportCasualtiesRestricted(false)
-                        .withWW2V2(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -1003,11 +964,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withWW2V2(false)
-                        .withDefendingSubsSneakAttack(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -1036,13 +993,8 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
-                        .withTransportCasualtiesRestricted(false)
-                        .withWW2V2(false)
                         .withDefendingSubsSneakAttack(true)
                         .build())
                 .attacker(attacker)
@@ -1072,12 +1024,8 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
-                        .withTransportCasualtiesRestricted(false)
                         .withWW2V2(true)
                         .build())
                 .attacker(attacker)
@@ -1107,12 +1055,8 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
-                        .withTransportCasualtiesRestricted(false)
                         .withWW2V2(true)
                         .build())
                 .attacker(attacker)
@@ -1143,11 +1087,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withWW2V2(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withDefendingSubsSneakAttack(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -1177,11 +1117,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
-                        .withWW2V2(false)
+                    givenGameDataWithLenientProperties()
                         .withDefendingSubsSneakAttack(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1211,11 +1147,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1248,10 +1180,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1286,12 +1215,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
-                        .withWW2V2(false)
+                    givenGameDataWithLenientProperties()
                         .withDefendingSubsSneakAttack(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1324,10 +1248,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1360,10 +1281,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1395,10 +1313,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1431,10 +1346,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1468,10 +1380,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1501,11 +1410,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1537,11 +1442,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1573,11 +1474,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withWW2V2(true)
                         .withAlliedAirIndependent(true)
                         .build())
@@ -1610,13 +1507,8 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
-                        .withTransportCasualtiesRestricted(false)
-                        .withWW2V2(false)
                         .withSubmersibleSubs(true)
                         .build())
                 .attacker(attacker)
@@ -1646,13 +1538,8 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
-                        .withTransportCasualtiesRestricted(false)
-                        .withWW2V2(false)
                         .withDefendingSubsSneakAttack(true)
                         .withSubmersibleSubs(true)
                         .build())
@@ -1684,13 +1571,8 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
-                        .withTransportCasualtiesRestricted(false)
-                        .withWW2V2(false)
                         .withSubmersibleSubs(true)
                         .build())
                 .attacker(attacker)
@@ -1719,10 +1601,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withWW2V2(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -1758,10 +1637,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withWW2V2(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -1793,11 +1669,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withTransportCasualtiesRestricted(false)
-                        .withWW2V2(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -1830,11 +1702,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withWW2V2(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -1874,14 +1742,9 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withTransportCasualtiesRestricted(false)
-                        .withTerritoryHasNeighbors(battleTerritory, Set.of(retreatTerritory))
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withWW2V2(false)
-                        .withDefendingSubsSneakAttack(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
+                        .withTerritoryHasNeighbors(battleTerritory, Set.of(retreatTerritory))
                         .build())
                 .attacker(attacker)
                 .defender(defender)
@@ -1911,11 +1774,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withWW2V2(false)
-                        .withDefendingSubsSneakAttack(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -1946,11 +1805,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withTransportCasualtiesRestricted(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withWW2V2(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -1979,10 +1834,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withTransportCasualtiesRestricted(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -2010,10 +1862,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .withPartialAmphibiousRetreat(true)
                         .build())
@@ -2043,13 +1892,8 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withWW2V2(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
-                        .withAttackerRetreatPlanes(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withPartialAmphibiousRetreat(true)
                         .build())
                 .attacker(attacker)
@@ -2075,9 +1919,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .build())
                 .attacker(attacker)
@@ -2103,12 +1945,8 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
-                        .withPartialAmphibiousRetreat(false)
                         .withWW2V2(true)
                         .build())
                 .attacker(attacker)
@@ -2138,12 +1976,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withWW2V2(false)
-                        .withAttackerRetreatPlanes(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .withPartialAmphibiousRetreat(true)
                         .build())
@@ -2170,13 +2003,8 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withSubRetreatBeforeBattle(false)
-                        .withWW2V2(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
-                        .withPartialAmphibiousRetreat(false)
                         .withAttackerRetreatPlanes(true)
                         .build())
                 .attacker(attacker)
@@ -2202,10 +2030,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameData()
-                        .withCaptureUnitsOnEnteringTerritory(false)
-                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                        .withSubRetreatBeforeBattle(false)
+                    givenGameDataWithLenientProperties()
                         .withAlliedAirIndependent(true)
                         .withTransportCasualtiesRestricted(true)
                         .build())

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -79,8 +79,8 @@ public class BattleStepsTest {
 
   @Value
   public static class UnitAndAttachment {
-    private Unit unit;
-    private UnitAttachment unitAttachment;
+    Unit unit;
+    UnitAttachment unitAttachment;
   }
 
   public static UnitAndAttachment newUnitAndAttachment() {
@@ -767,6 +767,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(true)
                         .withSubmersibleSubs(true)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
@@ -1051,6 +1052,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withAlliedAirIndependent(true)
@@ -1085,6 +1087,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withAlliedAirIndependent(true)
@@ -1582,6 +1585,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withAlliedAirIndependent(true)
@@ -1654,6 +1658,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withAlliedAirIndependent(true)
@@ -1975,6 +1980,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withAlliedAirIndependent(true)
@@ -2066,6 +2072,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withSubRetreatBeforeBattle(false)
                         .withAlliedAirIndependent(true)
@@ -2100,6 +2107,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withWW2V2(false)
                         .withAttackerRetreatPlanes(false)
@@ -2131,6 +2139,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withWW2V2(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
@@ -2162,6 +2171,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withSubRetreatBeforeBattle(false)
                         .withAlliedAirIndependent(true)

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -93,6 +93,12 @@ public class BattleStepsTest {
     return new UnitAndAttachment(unit, unitAttachment);
   }
 
+  public static UnitAndAttachment newSeaUnitAndAttachment() {
+    final var result = newUnitAndAttachment();
+    lenient().when(result.unitAttachment.getIsSea()).thenReturn(true);
+    return result;
+  }
+
   public static Unit givenAnyUnit() {
     return newUnitAndAttachment().unit;
   }
@@ -105,63 +111,69 @@ public class BattleStepsTest {
 
   public static Unit givenUnitFirstStrike() {
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
+    return unitAndAttachment.unit;
+  }
+
+  public static Unit givenSeaUnitFirstStrike() {
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     lenient().when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     return unitAndAttachment.unit;
   }
 
-  public static Unit givenUnitFirstStrikeSuicideOnAttack() {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+  public static Unit givenSeaUnitFirstStrikeSuicideOnAttack() {
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     lenient().when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     lenient().when(unitAndAttachment.unitAttachment.getIsSuicideOnAttack()).thenReturn(true);
     return unitAndAttachment.unit;
   }
 
-  public static Unit givenUnitFirstStrikeSuicideOnDefense() {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+  public static Unit givenSeaUnitFirstStrikeSuicideOnDefense() {
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     lenient().when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     lenient().when(unitAndAttachment.unitAttachment.getIsSuicideOnDefense()).thenReturn(true);
     return unitAndAttachment.unit;
   }
 
-  public static Unit givenUnitFirstStrikeAndEvade() {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+  public static Unit givenSeaUnitFirstStrikeAndEvade() {
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
     return unitAndAttachment.unit;
   }
 
-  public static Unit givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(final UnitType otherType) {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+  public static Unit givenSeaUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(final UnitType otherType) {
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
     when(unitAndAttachment.unitAttachment.getCanNotBeTargetedBy()).thenReturn(Set.of(otherType));
     return unitAndAttachment.unit;
   }
 
-  public static Unit givenUnitCanEvadeAndCanNotBeTargetedByRandomUnit() {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+  public static Unit givenSeaUnitCanEvadeAndCanNotBeTargetedByRandomUnit() {
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
     when(unitAndAttachment.unitAttachment.getCanNotBeTargetedBy())
         .thenReturn(Set.of(mock(UnitType.class)));
     return unitAndAttachment.unit;
   }
 
-  public static Unit givenUnitCanNotBeTargetedBy(final UnitType otherType) {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+  public static Unit givenSeaUnitCanNotBeTargetedBy(final UnitType otherType) {
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     when(unitAndAttachment.unitAttachment.getCanNotBeTargetedBy()).thenReturn(Set.of(otherType));
     return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitDestroyer() {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     lenient().when(unitAndAttachment.unitAttachment.getIsDestroyer()).thenReturn(true);
+    lenient().when(unitAndAttachment.unitAttachment.getIsSea()).thenReturn(true);
     return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitSeaTransport() {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     when(unitAndAttachment.unitAttachment.getTransportCapacity()).thenReturn(2);
-    when(unitAndAttachment.unitAttachment.getIsSea()).thenReturn(true);
     return unitAndAttachment.unit;
   }
 
@@ -211,9 +223,7 @@ public class BattleStepsTest {
   }
 
   public static Unit givenUnitIsSea() {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.unitAttachment.getIsSea()).thenReturn(true);
-    return unitAndAttachment.unit;
+    return newSeaUnitAndAttachment().unit;
   }
 
   public static Unit givenUnitWasAmphibious() {
@@ -395,8 +405,8 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify impossible sea battle with bombarding will not add a bombarding step")
   void impossibleSeaBattleWithBombarding() {
-    final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenAnyUnit();
+    final Unit unit1 = givenUnitIsSea();
+    final Unit unit2 = givenUnitIsSea();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
@@ -538,8 +548,8 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify impossible sea battle with paratroopers will not add a paratrooper step")
   void impossibleSeaBattleWithParatroopers() {
-    final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenAnyUnit();
+    final Unit unit1 = givenUnitIsSea();
+    final Unit unit2 = givenUnitIsSea();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
@@ -760,7 +770,7 @@ public class BattleStepsTest {
           + "if SUB_RETREAT_BEFORE_BATTLE and SUBMERSIBLE_SUBS are true")
   void defendingFirstStrikeSubmergeBeforeBattleIfSubmersibleSubsAndRetreatBeforeBattle() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -797,7 +807,7 @@ public class BattleStepsTest {
   @DisplayName("Verify unescorted attacking transports are removed if casualties are restricted")
   void unescortedAttackingTransportsAreRemovedWhenCasualtiesAreRestricted() {
     final Unit unit1 = givenUnitSeaTransport();
-    final Unit unit2 = givenAnyUnit();
+    final Unit unit2 = givenUnitIsSea();
 
     final List<String> steps =
         givenBattleSteps(
@@ -824,9 +834,9 @@ public class BattleStepsTest {
   @DisplayName(
       "Verify unescorted attacking transports are not removed if casualties are not restricted")
   void unescortedAttackingTransportsAreNotRemovedWhenCasualtiesAreNotRestricted() {
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     final Unit unit1 = unitAndAttachment.unit;
-    final Unit unit2 = givenAnyUnit();
+    final Unit unit2 = givenUnitIsSea();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
@@ -851,7 +861,7 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify unescorted defending transports are removed if casualties are restricted")
   void unescortedDefendingTransportsAreRemovedWhenCasualtiesAreRestricted() {
-    final Unit unit1 = givenAnyUnit();
+    final Unit unit1 = givenUnitIsSea();
     final Unit unit2 = givenUnitSeaTransport();
 
     final List<String> steps =
@@ -879,8 +889,8 @@ public class BattleStepsTest {
   @DisplayName(
       "Verify unescorted defending transports are removed if casualties are not restricted")
   void unescortedDefendingTransportsAreNotRemovedWhenCasualtiesAreNotRestricted() {
-    final Unit unit1 = givenAnyUnit();
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit1 = givenUnitIsSea();
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     final Unit unit2 = unitAndAttachment.unit;
 
     final List<String> steps =
@@ -909,7 +919,7 @@ public class BattleStepsTest {
       "Verify basic attacker firstStrike "
           + "(no other attackers, no special defenders, all options false)")
   void attackingFirstStrikeBasic() {
-    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
@@ -942,7 +952,7 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify attacker firstStrike with destroyers")
   void attackingFirstStrikeWithDestroyers() {
-    final Unit unit1 = givenUnitFirstStrike();
+    final Unit unit1 = givenSeaUnitFirstStrike();
     final Unit unit2 = givenUnitDestroyer();
 
     final List<String> steps =
@@ -977,7 +987,7 @@ public class BattleStepsTest {
           + "(no other attackers, no special defenders, all options false)")
   void defendingFirstStrikeBasic() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1010,7 +1020,7 @@ public class BattleStepsTest {
   @DisplayName("Verify defender firstStrike with DEFENDING_SUBS_SNEAK_ATTACK true")
   void defendingFirstStrikeWithSneakAttackAllowed() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1046,7 +1056,7 @@ public class BattleStepsTest {
   @DisplayName("Verify defender firstStrike with WW2v2 true")
   void defendingFirstStrikeWithWW2v2() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1081,7 +1091,7 @@ public class BattleStepsTest {
   @DisplayName("Verify defender firstStrike with WW2v2 true and attacker destroyers")
   void defendingFirstStrikeWithWW2v2AndDestroyers() {
     final Unit unit1 = givenUnitDestroyer();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1116,8 +1126,8 @@ public class BattleStepsTest {
       "Verify basic attacker and defender firstStrikes "
           + "(no other attackers, no special defenders, all options false)")
   void attackingDefendingFirstStrikeBasic() {
-    final Unit unit1 = givenUnitFirstStrikeAndEvade();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1150,8 +1160,8 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify attacking/defender firstStrikes with DEFENDING_SUBS_SNEAK_ATTACK true")
   void attackingDefendingFirstStrikeWithSneakAttackAllowed() {
-    final Unit unit1 = givenUnitFirstStrikeAndEvade();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1184,14 +1194,15 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify attacking/defender firstStrikes with WW2v2 true")
   void attackingDefendingFirstStrikeWithWW2v2() {
-    final Unit unit1 = givenUnitFirstStrikeAndEvade();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withSubRetreatBeforeBattle(false)
                         .withTransportCasualtiesRestricted(false)
@@ -1218,8 +1229,8 @@ public class BattleStepsTest {
   @DisplayName(
       "Verify attacking/defender firstStrikes with WW2v2 true and attacker/defender destroyers")
   void attackingDefendingFirstStrikeWithWW2v2AndDestroyers() {
-    final Unit unit1 = givenUnitFirstStrike();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrike();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
     final Unit unit4 = givenUnitDestroyer();
 
@@ -1257,8 +1268,8 @@ public class BattleStepsTest {
       "Verify attacking/defender firstStrikes with "
           + "DEFENDING_SUBS_SNEAK_ATTACK true and defender destroyers")
   void attackingDefendingFirstStrikeWithSneakAttackAllowedAndDefendingDestroyers() {
-    final Unit unit1 = givenUnitFirstStrike();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrike();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     final List<String> steps =
@@ -1266,6 +1277,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withSubRetreatBeforeBattle(false)
                         .withTransportCasualtiesRestricted(false)
@@ -1294,8 +1306,8 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify attacking/defender firstStrikes with WW2v2 true and defender destroyers")
   void attackingDefendingFirstStrikeWithWW2v2AndDefendingDestroyers() {
-    final Unit unit1 = givenUnitFirstStrike();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrike();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     final List<String> steps =
@@ -1330,8 +1342,8 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify attacking/defender firstStrikes with WW2v2 true and attacking destroyers")
   void attackingDefendingFirstStrikeWithWW2v2AndAttackingDestroyers() {
-    final Unit unit1 = givenUnitFirstStrikeAndEvade();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     final List<String> steps =
@@ -1367,7 +1379,7 @@ public class BattleStepsTest {
   @DisplayName("Verify attacking firstStrikes against air")
   void attackingFirstStrikeVsAir() {
     final Unit unit2 = givenUnitIsAir();
-    final Unit unit1 = givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit2.getType());
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit2.getType());
 
     final List<String> steps =
         givenBattleSteps(
@@ -1401,9 +1413,9 @@ public class BattleStepsTest {
   @DisplayName("Verify attacking firstStrikes against air with other units on both sides")
   void attackingFirstStrikeVsAirWithOtherUnits() {
     final Unit unit2 = givenUnitIsAir();
-    final Unit unit1 = givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit2.getType());
-    final Unit unit3 = givenAnyUnit();
-    final Unit unit4 = givenAnyUnit();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit2.getType());
+    final Unit unit3 = givenUnitIsSea();
+    final Unit unit4 = givenUnitIsSea();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1439,7 +1451,7 @@ public class BattleStepsTest {
   @DisplayName("Verify attacking firstStrikes against air with destroyer")
   void attackingFirstStrikeVsAirAndDestroyer() {
     final Unit unit2 = givenUnitIsAir();
-    final Unit unit1 = givenUnitFirstStrike();
+    final Unit unit1 = givenSeaUnitFirstStrike();
     final Unit unit3 = givenUnitDestroyer();
 
     final List<String> steps =
@@ -1473,13 +1485,14 @@ public class BattleStepsTest {
   @DisplayName("Verify defending firstStrikes against air")
   void defendingFirstStrikeVsAir() {
     final Unit unit1 = givenUnitIsAir();
-    final Unit unit2 = givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit1.getType());
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit1.getType());
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withSubRetreatBeforeBattle(false)
                         .withTransportCasualtiesRestricted(false)
@@ -1507,7 +1520,7 @@ public class BattleStepsTest {
   @DisplayName("Verify defending firstStrikes against air with destroyer")
   void defendingFirstStrikeVsAirAndDestroyer() {
     final Unit unit1 = givenUnitIsAir();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     final List<String> steps =
@@ -1515,6 +1528,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withSubRetreatBeforeBattle(false)
                         .withTransportCasualtiesRestricted(false)
@@ -1541,15 +1555,16 @@ public class BattleStepsTest {
   @DisplayName("Verify defending firstStrikes against air with other units on both sides")
   void defendingFirstStrikeVsAirWithOtherUnits() {
     final Unit unit2 = givenUnitIsAir();
-    final Unit unit1 = givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit2.getType());
-    final Unit unit3 = givenAnyUnit();
-    final Unit unit4 = givenAnyUnit();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit2.getType());
+    final Unit unit3 = givenUnitIsSea();
+    final Unit unit4 = givenUnitIsSea();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withSubRetreatBeforeBattle(false)
                         .withTransportCasualtiesRestricted(false)
@@ -1578,7 +1593,7 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify attacking firstStrike can submerge if SUBMERSIBLE_SUBS is true")
   void attackingFirstStrikeCanSubmergeIfSubmersibleSubs() {
-    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
@@ -1615,7 +1630,7 @@ public class BattleStepsTest {
   @DisplayName("Verify defending firstStrike can submerge if SUBMERSIBLE_SUBS is true")
   void defendingFirstStrikeCanSubmergeIfSubmersibleSubs() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1653,7 +1668,7 @@ public class BattleStepsTest {
       "Verify defending firstStrike can submerge if SUBMERSIBLE_SUBS is true even with destroyers")
   void defendingFirstStrikeCanSubmergeIfSubmersibleSubsAndDestroyers() {
     final Unit unit1 = givenUnitDestroyer();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1687,7 +1702,7 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify attacking firstStrike can withdraw when SUBMERSIBLE_SUBS is false")
   void attackingFirstStrikeWithdrawIfAble() {
-    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
@@ -1726,7 +1741,7 @@ public class BattleStepsTest {
       "Verify attacking firstStrike can't withdraw when "
           + "SUBMERSIBLE_SUBS is false and no retreat territories")
   void attackingFirstStrikeNoWithdrawIfEmptyTerritories() {
-    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
@@ -1761,7 +1776,7 @@ public class BattleStepsTest {
       "Verify attacking firstStrike can't withdraw when "
           + "SUBMERSIBLE_SUBS is false and destroyers present")
   void attackingFirstStrikeNoWithdrawIfDestroyers() {
-    final Unit unit1 = givenUnitFirstStrike();
+    final Unit unit1 = givenSeaUnitFirstStrike();
     final Unit unit2 = givenUnitDestroyer();
 
     final List<String> steps =
@@ -1796,8 +1811,8 @@ public class BattleStepsTest {
       "Verify attacking firstStrike can withdraw when "
           + "SUBMERSIBLE_SUBS is false and defenseless transports with non restricted casualties")
   void attackingFirstStrikeWithdrawIfNonRestrictedDefenselessTransports() {
-    final Unit unit1 = givenUnitFirstStrikeAndEvade();
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
+    final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     final Unit unit2 = unitAndAttachment.unit;
 
     final List<String> steps =
@@ -1837,7 +1852,7 @@ public class BattleStepsTest {
   @DisplayName("Verify defending firstStrike can withdraw when SUBMERSIBLE_SUBS is false")
   void defendingFirstStrikeWithdrawIfAble() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final Territory retreatTerritory = mock(Territory.class);
     when(retreatTerritory.isWater()).thenReturn(true);
@@ -1877,7 +1892,7 @@ public class BattleStepsTest {
           + "SUBMERSIBLE_SUBS is false and no retreat territories")
   void defendingFirstStrikeNoWithdrawIfEmptyTerritories() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1912,7 +1927,7 @@ public class BattleStepsTest {
           + "SUBMERSIBLE_SUBS is false and destroyers present")
   void defendingFirstStrikeNoWithdrawIfDestroyers() {
     final Unit unit1 = givenUnitDestroyer();
-    final Unit unit2 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1944,7 +1959,7 @@ public class BattleStepsTest {
   @DisplayName("Verify attacking air units at sea can withdraw")
   void attackingAirUnitsAtSeaCanWithdraw() {
     final Unit unit1 = givenUnitIsAir();
-    final Unit unit2 = givenAnyUnit();
+    final Unit unit2 = givenUnitIsSea();
 
     final List<String> steps =
         givenBattleSteps(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -1017,6 +1017,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withAlliedAirIndependent(true)
@@ -1621,6 +1622,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withAlliedAirIndependent(true)
@@ -2013,6 +2015,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(false)
                         .withWW2V2(false)
                         .withAlliedAirIndependent(true)

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -337,9 +337,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -362,9 +360,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -391,9 +387,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .battleRound(2)
@@ -415,9 +409,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .battleRound(1)
                 .attacker(attacker)
                 .defender(defender)
@@ -473,9 +465,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .battleRound(1)
                 .attacker(attacker)
                 .defender(defender)
@@ -497,9 +487,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .battleRound(2)
@@ -551,9 +539,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .battleRound(1)
                 .attacker(attacker)
                 .defender(defender)
@@ -741,9 +727,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -826,9 +810,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -877,9 +859,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -903,9 +883,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -933,9 +911,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -964,9 +940,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1087,9 +1061,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1601,9 +1573,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1637,9 +1607,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1669,9 +1637,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1702,9 +1668,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1774,9 +1738,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1805,9 +1767,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1834,9 +1794,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1919,9 +1877,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .gameData(
-                    givenGameDataWithLenientProperties()
-                        .withAlliedAirIndependent(true)
-                        .build())
+                    givenGameDataWithLenientProperties().withAlliedAirIndependent(true).build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1, unit3))

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -111,7 +111,7 @@ public class BattleStepsTest {
 
   public static Unit givenUnitFirstStrike() {
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
+    lenient().when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     return unitAndAttachment.unit;
   }
 
@@ -132,6 +132,13 @@ public class BattleStepsTest {
     final UnitAndAttachment unitAndAttachment = newSeaUnitAndAttachment();
     lenient().when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     lenient().when(unitAndAttachment.unitAttachment.getIsSuicideOnDefense()).thenReturn(true);
+    return unitAndAttachment.unit;
+  }
+
+  public static Unit givenUnitFirstStrikeAndEvade() {
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
+    when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
     return unitAndAttachment.unit;
   }
 
@@ -770,7 +777,7 @@ public class BattleStepsTest {
       "Verify defending firstStrike submerge before battle "
           + "if SUB_RETREAT_BEFORE_BATTLE and SUBMERSIBLE_SUBS are true")
   void defendingFirstStrikeSubmergeBeforeBattleIfSubmersibleSubsAndRetreatBeforeBattle() {
-    final Unit unit1 = givenAnyUnit();
+    final Unit unit1 = givenUnitIsSea();
     final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
@@ -778,6 +785,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withTransportCasualtiesRestricted(false)
                         .withCaptureUnitsOnEnteringTerritory(false)
                         .withSubRetreatBeforeBattle(true)
                         .withSubmersibleSubs(true)
@@ -790,7 +798,7 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .battleSite(battleSite)
+                .battleSite(givenSeaBattleSite())
                 .build());
 
     assertThat(
@@ -961,6 +969,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withTransportCasualtiesRestricted(false)
                         .withWW2V2(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withSubRetreatBeforeBattle(false)
@@ -970,7 +979,7 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .battleSite(battleSite)
+                .battleSite(givenSeaBattleSite())
                 .build());
 
     assertThat(
@@ -988,7 +997,7 @@ public class BattleStepsTest {
           + "(no other attackers, no special defenders, all options false)")
   void defendingFirstStrikeBasic() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1020,7 +1029,7 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify defender firstStrike with DEFENDING_SUBS_SNEAK_ATTACK true")
   void defendingFirstStrikeWithSneakAttackAllowed() {
-    final Unit unit1 = givenAnyUnit();
+    final Unit unit1 = givenUnitIsSea();
     final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
@@ -1040,7 +1049,7 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .battleSite(battleSite)
+                .battleSite(givenSeaBattleSite())
                 .build());
 
     assertThat(
@@ -1057,7 +1066,7 @@ public class BattleStepsTest {
   @DisplayName("Verify defender firstStrike with WW2v2 true")
   void defendingFirstStrikeWithWW2v2() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1110,7 +1119,7 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .battleSite(battleSite)
+                .battleSite(givenSeaBattleSite())
                 .build());
 
     assertThat(
@@ -1127,8 +1136,8 @@ public class BattleStepsTest {
       "Verify basic attacker and defender firstStrikes "
           + "(no other attackers, no special defenders, all options false)")
   void attackingDefendingFirstStrikeBasic() {
-    final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
-    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1595,7 +1604,7 @@ public class BattleStepsTest {
   @DisplayName("Verify attacking firstStrike can submerge if SUBMERSIBLE_SUBS is true")
   void attackingFirstStrikeCanSubmergeIfSubmersibleSubs() {
     final Unit unit1 = givenSeaUnitFirstStrikeAndEvade();
-    final Unit unit2 = givenAnyUnit();
+    final Unit unit2 = givenUnitIsSea();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1614,7 +1623,7 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .battleSite(battleSite)
+                .battleSite(givenSeaBattleSite())
                 .build());
 
     assertThat(
@@ -1630,7 +1639,7 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify defending firstStrike can submerge if SUBMERSIBLE_SUBS is true")
   void defendingFirstStrikeCanSubmergeIfSubmersibleSubs() {
-    final Unit unit1 = givenAnyUnit();
+    final Unit unit1 = givenUnitIsSea();
     final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
     final List<String> steps =
@@ -1651,7 +1660,7 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .battleSite(battleSite)
+                .battleSite(givenSeaBattleSite())
                 .build());
 
     assertThat(
@@ -1688,7 +1697,7 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .battleSite(battleSite)
+                .battleSite(givenSeaBattleSite())
                 .build());
 
     assertThat(
@@ -1785,6 +1794,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withTransportCasualtiesRestricted(false)
                         .withWW2V2(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withSubRetreatBeforeBattle(false)
@@ -1795,7 +1805,7 @@ public class BattleStepsTest {
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
                 .attackerRetreatTerritories(List.of(battleSite))
-                .battleSite(battleSite)
+                .battleSite(givenSeaBattleSite())
                 .build());
 
     assertThat(
@@ -1852,9 +1862,10 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify defending firstStrike can withdraw when SUBMERSIBLE_SUBS is false")
   void defendingFirstStrikeWithdrawIfAble() {
-    final Unit unit1 = givenAnyUnit();
+    final Unit unit1 = givenUnitIsSea();
     final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
 
+    final Territory battleTerritory = givenSeaBattleSite();
     final Territory retreatTerritory = mock(Territory.class);
     when(retreatTerritory.isWater()).thenReturn(true);
     when(retreatTerritory.getUnitCollection()).thenReturn(mock(UnitCollection.class));
@@ -1864,7 +1875,8 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
-                        .withTerritoryHasNeighbors(battleSite, Set.of(retreatTerritory))
+                        .withTransportCasualtiesRestricted(false)
+                        .withTerritoryHasNeighbors(battleTerritory, Set.of(retreatTerritory))
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withWW2V2(false)
                         .withDefendingSubsSneakAttack(false)
@@ -1875,7 +1887,7 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .battleSite(battleSite)
+                .battleSite(battleTerritory)
                 .build());
 
     assertThat(
@@ -1893,7 +1905,7 @@ public class BattleStepsTest {
           + "SUBMERSIBLE_SUBS is false and no retreat territories")
   void defendingFirstStrikeNoWithdrawIfEmptyTerritories() {
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenSeaUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
@@ -1935,6 +1947,7 @@ public class BattleStepsTest {
             givenBattleStateBuilder()
                 .gameData(
                     givenGameData()
+                        .withTransportCasualtiesRestricted(false)
                         .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
                         .withWW2V2(false)
                         .withSubRetreatBeforeBattle(false)
@@ -1944,7 +1957,7 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .battleSite(battleSite)
+                .battleSite(givenSeaBattleSite())
                 .build());
 
     assertThat(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -32,9 +32,11 @@ import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.ResourceList;
 import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.delegate.TechTracker;
+import java.util.List;
 import java.util.Set;
 
 public class MockGameData {
@@ -194,6 +196,16 @@ public class MockGameData {
 
   public MockGameData withLowLuck(final boolean value) {
     when(gameProperties.get(LOW_LUCK, false)).thenReturn(value);
+    return this;
+  }
+
+  public MockGameData withUnitTypeList(final List<UnitType> types) {
+    UnitTypeList unitTypeList = new UnitTypeList(gameData);
+    for (var unitType : types) {
+      lenient().when(unitType.getData()).thenReturn(gameData);
+      unitTypeList.addUnitType(unitType);
+    }
+    when(gameData.getUnitTypeList()).thenReturn(unitTypeList);
     return this;
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -16,6 +16,9 @@ import static games.strategy.triplea.Constants.SUBMERSIBLE_SUBS;
 import static games.strategy.triplea.Constants.SUB_RETREAT_BEFORE_BATTLE;
 import static games.strategy.triplea.Constants.TRANSPORT_CASUALTIES_RESTRICTED;
 import static games.strategy.triplea.Constants.WW2V2;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -99,6 +102,11 @@ public class MockGameData {
 
   public MockGameData withTechnologyFrontier() {
     when(gameData.getTechnologyFrontier()).thenReturn(mock(TechnologyFrontier.class));
+    return this;
+  }
+
+  public MockGameData withLenientProperties() {
+    lenient().when(gameProperties.get(anyString(), anyBoolean())).thenReturn(false);
     return this;
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -16,7 +16,6 @@ import static games.strategy.triplea.Constants.SUBMERSIBLE_SUBS;
 import static games.strategy.triplea.Constants.SUB_RETREAT_BEFORE_BATTLE;
 import static games.strategy.triplea.Constants.TRANSPORT_CASUALTIES_RESTRICTED;
 import static games.strategy.triplea.Constants.WW2V2;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/suicide/RemoveFirstStrikeSuicideTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/suicide/RemoveFirstStrikeSuicideTest.java
@@ -4,8 +4,8 @@ import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
 import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenAnyUnit;
-import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitFirstStrikeSuicideOnAttack;
-import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitFirstStrikeSuicideOnDefense;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenSeaUnitFirstStrikeSuicideOnAttack;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenSeaUnitFirstStrikeSuicideOnDefense;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -34,8 +34,8 @@ public class RemoveFirstStrikeSuicideTest {
   void suicideUnitsRemoved() {
     when(delegateBridge.getDisplayChannelBroadcaster()).thenReturn(mock(IDisplay.class));
 
-    final List<Unit> attackers = List.of(givenAnyUnit(), givenUnitFirstStrikeSuicideOnAttack());
-    final List<Unit> defenders = List.of(givenAnyUnit(), givenUnitFirstStrikeSuicideOnDefense());
+    final List<Unit> attackers = List.of(givenAnyUnit(), givenSeaUnitFirstStrikeSuicideOnAttack());
+    final List<Unit> defenders = List.of(givenAnyUnit(), givenSeaUnitFirstStrikeSuicideOnDefense());
     final MockGameData gameData = MockGameData.givenGameData();
     final BattleState battleState =
         givenBattleStateBuilder()

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.delegate.battle.steps.fire.air;
 
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenAnyUnit;
-import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitCanNotBeTargetedBy;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenSeaUnitCanNotBeTargetedBy;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitDestroyer;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,7 +35,7 @@ class AirAttackVsNonSubsStepTest {
             "Attacker has air units and no destroyers vs Defender subs",
             givenBattleStateBuilder()
                 .attackingUnits(List.of(givenAnyUnit(), givenUnitIsAir()))
-                .defendingUnits(List.of(givenUnitCanNotBeTargetedBy(mock(UnitType.class))))
+                .defendingUnits(List.of(givenSeaUnitCanNotBeTargetedBy(mock(UnitType.class))))
                 .build(),
             true),
         Arguments.of(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.delegate.battle.steps.fire.air;
 
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenAnyUnit;
-import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitCanNotBeTargetedBy;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenSeaUnitCanNotBeTargetedBy;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitDestroyer;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,7 +34,7 @@ class AirDefendVsNonSubsStepTest {
         Arguments.of(
             "Defender has air units and no destroyers vs Attacker subs",
             givenBattleStateBuilder()
-                .attackingUnits(List.of(givenUnitCanNotBeTargetedBy(mock(UnitType.class))))
+                .attackingUnits(List.of(givenSeaUnitCanNotBeTargetedBy(mock(UnitType.class))))
                 .defendingUnits(List.of(givenAnyUnit(), givenUnitIsAir()))
                 .build(),
             true),

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneralTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneralTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
@@ -29,6 +30,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.steps.fire.FiringGroup;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -39,6 +41,16 @@ class FiringGroupSplitterGeneralTest {
 
   @Mock GamePlayer attacker;
   @Mock GamePlayer defender;
+
+  @BeforeEach
+  void setUp() {
+    final GameData gameData = new GameData();
+
+    lenient().when(attacker.getName()).thenReturn("attacker");
+    lenient().when(attacker.getData()).thenReturn(gameData);
+    lenient().when(defender.getName()).thenReturn("defender");
+    lenient().when(defender.getData()).thenReturn(gameData);
+  }
 
   @Test
   void oneFiringUnitVsOneTargetableUnitMakesOneFiringGroup() {
@@ -216,14 +228,6 @@ class FiringGroupSplitterGeneralTest {
     assertThat(firingGroups.get(0).getFiringUnits(), contains(fireUnit, fireUnit2));
     assertThat(firingGroups.get(0).getTargetUnits(), contains(targetUnit));
     assertThat(firingGroups.get(0).isSuicideOnHit(), is(false));
-
-    verify(
-            fireUnit,
-            never()
-                .description(
-                    "Units on defense with AlliedAirIndependent == false"
-                        + "should never call getOwner"))
-        .getOwner();
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneralTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneralTest.java
@@ -18,8 +18,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
@@ -5,7 +5,7 @@ import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
 import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenAnyUnit;
-import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitCanEvadeAndCanNotBeTargetedByRandomUnit;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenSeaUnitCanEvadeAndCanNotBeTargetedByRandomUnit;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
 import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -90,7 +90,7 @@ class SubmergeSubsVsOnlyAirStepTest extends AbstractClientSettingTestCase {
         Arguments.of(
             "Attacking evaders vs ALL air",
             givenBattleStateBuilder()
-                .attackingUnits(List.of(givenUnitCanEvadeAndCanNotBeTargetedByRandomUnit()))
+                .attackingUnits(List.of(givenSeaUnitCanEvadeAndCanNotBeTargetedByRandomUnit()))
                 .defendingUnits(List.of(givenUnitIsAir(), givenUnitIsAir()))
                 .build(),
             true),
@@ -98,7 +98,7 @@ class SubmergeSubsVsOnlyAirStepTest extends AbstractClientSettingTestCase {
             "Defending evaders vs ALL air",
             givenBattleStateBuilder()
                 .attackingUnits(List.of(givenUnitIsAir(), givenUnitIsAir()))
-                .defendingUnits(List.of(givenUnitCanEvadeAndCanNotBeTargetedByRandomUnit()))
+                .defendingUnits(List.of(givenSeaUnitCanEvadeAndCanNotBeTargetedByRandomUnit()))
                 .build(),
             true));
   }


### PR DESCRIPTION
## Change Summary & Additional Notes

This was happening because the code to generate step names was not excluding units that would not participate in combat, resulting in infrastructure units getting their own steps (which later did not match what the engine generated once the filtering took place).

Uses the same logic as what's done for the battle to exclude units.

This change required adjusting a bunch of tests that were previously not careful about which had mistakes in setting up mock battles where the units didn't match the territory (in terms of sea vs. land). Also makes the tests to mock game data properties leniently, so that only the ones being set to true need to be specified (removing lots of LOC).

Includes a unit test.

Fixes: https://github.com/triplea-game/triplea/issues/10647
Note: Doesn't fix https://github.com/triplea-game/triplea/issues/11617, as the root cause of that error is different, despite the actual error being the same. I will fix that in a separate PR.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
