### PR TITLE
Fix objectives tab name disappearing after switching to history.

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -379,23 +379,17 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
 
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getArrowKeyListener()));
 
-    addTab("Actions", actionButtons, KeyCode.C);
     actionButtons.setBorder(null);
     statsPanel = new StatPanel(data, uiContext);
-    addTab("Players", statsPanel, KeyCode.P);
     economyPanel = new EconomyPanel(data, uiContext);
-    addTab("Resources", economyPanel, KeyCode.R);
     objectivePanel = new ObjectivePanel(data, uiContext);
     if (objectivePanel.isEmpty()) {
       objectivePanel.removeDataChangeListener();
       objectivePanel = null;
-    } else {
-      String objectivePanelName = new ObjectiveProperties(uiContext.getResourceLoader()).getName();
-      addTab(objectivePanelName, objectivePanel, KeyCode.O);
     }
     territoryDetails = new TerritoryDetailPanel(mapPanel, data, uiContext, this);
-    addTab("Territory", territoryDetails, KeyCode.T);
     editPanel = new EditPanel(data, mapPanel, this);
+    addTabs(true);
     // Register a change listener
     tabsPanel.addChangeListener(
         evt -> {
@@ -1776,15 +1770,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
               new HistoryDetailsPanel(clonedGameData, mapPanel);
           tabsPanel.removeAll();
           tabsPanel.add("History", historyDetailPanel);
-          addTab("Players", statsPanel, KeyCode.P);
-          addTab("Resources", economyPanel, KeyCode.R);
-          if (objectivePanel != null && !objectivePanel.isEmpty()) {
-            addTab(objectivePanel.getName(), objectivePanel, KeyCode.O);
-          }
-          addTab("Territory", territoryDetails, KeyCode.T);
-          if (mapPanel.getEditMode()) {
-            tabsPanel.add("Edit", editPanel);
-          }
+          addTabs(false);
           actionButtons.getCurrent().ifPresent(actionPanel -> actionPanel.setActive(false));
           historyComponent.removeAll();
           historyComponent.setLayout(new BorderLayout());
@@ -1952,16 +1938,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
             tabsPanel.removeAll();
           }
           setWidgetActivation();
-          addTab("Actions", actionButtons, KeyCode.C);
-          addTab("Players", statsPanel, KeyCode.P);
-          addTab("Resources", economyPanel, KeyCode.R);
-          if (objectivePanel != null && !objectivePanel.isEmpty()) {
-            addTab(objectivePanel.getName(), objectivePanel, KeyCode.O);
-          }
-          addTab("Territory", territoryDetails, KeyCode.T);
-          if (mapPanel.getEditMode()) {
-            tabsPanel.add("Edit", editPanel);
-          }
+          addTabs(true);
           actionButtons.getCurrent().ifPresent(actionPanel -> actionPanel.setActive(true));
           gameMainPanel.removeAll();
           gameMainPanel.setLayout(new BorderLayout());
@@ -1973,6 +1950,22 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
           requestWindowFocus();
         });
     mapPanel.setRoute(null);
+  }
+
+  private void addTabs(boolean includeActionsTab) {
+    if (includeActionsTab) {
+      addTab("Actions", actionButtons, KeyCode.C);
+    }
+    addTab("Players", statsPanel, KeyCode.P);
+    addTab("Resources", economyPanel, KeyCode.R);
+    if (objectivePanel != null && !objectivePanel.isEmpty()) {
+      String objectivePanelName = new ObjectiveProperties(uiContext.getResourceLoader()).getName();
+      addTab(objectivePanelName, objectivePanel, KeyCode.O);
+    }
+    addTab("Territory", territoryDetails, KeyCode.T);
+    if (mapPanel.getEditMode()) {
+      tabsPanel.add("Edit", editPanel);
+    }
   }
 
   private void setWidgetActivation() {

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -389,7 +389,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     }
     territoryDetails = new TerritoryDetailPanel(mapPanel, data, uiContext, this);
     editPanel = new EditPanel(data, mapPanel, this);
-    addTabs(true);
+    addTabs(null);
     // Register a change listener
     tabsPanel.addChangeListener(
         evt -> {
@@ -514,6 +514,24 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
         () ->
             mapPanel.setScale(
                 mapPanel.getScale() - (ClientSetting.mapZoomFactor.getValueOrThrow() / 100f)));
+  }
+
+  private void addTabs(HistoryDetailsPanel historyDetailPanel) {
+    if (historyDetailPanel != null) {
+      tabsPanel.add("History", historyDetailPanel);
+    } else {
+      addTab("Actions", actionButtons, KeyCode.C);
+    }
+    addTab("Players", statsPanel, KeyCode.P);
+    addTab("Resources", economyPanel, KeyCode.R);
+    if (objectivePanel != null && !objectivePanel.isEmpty()) {
+      String objectivePanelName = new ObjectiveProperties(uiContext.getResourceLoader()).getName();
+      addTab(objectivePanelName, objectivePanel, KeyCode.O);
+    }
+    addTab("Territory", territoryDetails, KeyCode.T);
+    if (mapPanel.getEditMode()) {
+      tabsPanel.add("Edit", editPanel);
+    }
   }
 
   private void addTab(final String title, final Component component, final KeyCode hotkey) {
@@ -1769,8 +1787,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
           final HistoryDetailsPanel historyDetailPanel =
               new HistoryDetailsPanel(clonedGameData, mapPanel);
           tabsPanel.removeAll();
-          tabsPanel.add("History", historyDetailPanel);
-          addTabs(false);
+          addTabs(historyDetailPanel);
           actionButtons.getCurrent().ifPresent(actionPanel -> actionPanel.setActive(false));
           historyComponent.removeAll();
           historyComponent.setLayout(new BorderLayout());
@@ -1938,7 +1955,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
             tabsPanel.removeAll();
           }
           setWidgetActivation();
-          addTabs(true);
+          addTabs(null);
           actionButtons.getCurrent().ifPresent(actionPanel -> actionPanel.setActive(true));
           gameMainPanel.removeAll();
           gameMainPanel.setLayout(new BorderLayout());
@@ -1950,22 +1967,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
           requestWindowFocus();
         });
     mapPanel.setRoute(null);
-  }
-
-  private void addTabs(boolean includeActionsTab) {
-    if (includeActionsTab) {
-      addTab("Actions", actionButtons, KeyCode.C);
-    }
-    addTab("Players", statsPanel, KeyCode.P);
-    addTab("Resources", economyPanel, KeyCode.R);
-    if (objectivePanel != null && !objectivePanel.isEmpty()) {
-      String objectivePanelName = new ObjectiveProperties(uiContext.getResourceLoader()).getName();
-      addTab(objectivePanelName, objectivePanel, KeyCode.O);
-    }
-    addTab("Territory", territoryDetails, KeyCode.T);
-    if (mapPanel.getEditMode()) {
-      tabsPanel.add("Edit", editPanel);
-    }
   }
 
   private void setWidgetActivation() {


### PR DESCRIPTION
## Change Summary & Additional Notes

This was broken in 2.6 by https://github.com/triplea-game/triplea/pull/10839 which removed one call to objectivePanel.getName() but not two others.

This PR refactors the code to not duplicate logic and makes all three places use the correct logic for the name of that tab.

Fixes: https://github.com/triplea-game/triplea/issues/11305

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
