### PR TITLE
Fix NPE with loaded save games from past versions.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -395,6 +395,14 @@ public class GameData implements Serializable, GameState {
     }
   }
 
+  @RemoveOnNextMajorRelease
+  public void fixUpNullPlayersInDelegates() {
+    BattleDelegate battleDelegate = (BattleDelegate) getDelegate("battle");
+    if (battleDelegate != null) {
+      battleDelegate.getBattleTracker().fixUpNullPlayers(playerList.getNullPlayer());
+    }
+  }
+
   public interface Unlocker extends Closeable {
     @Override
     void close();

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -74,6 +74,9 @@ public final class GameDataManager {
       final GameData data = (GameData) input.readObject();
       data.postDeSerialize();
       loadDelegates(input, data);
+      data.getBattleDelegate()
+          .getBattleTracker()
+          .fixUpNullPlayers(data.getPlayerList().getNullPlayer());
       return Optional.of(data);
     } catch (final Throwable e) {
       log.warn(

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -74,9 +74,7 @@ public final class GameDataManager {
       final GameData data = (GameData) input.readObject();
       data.postDeSerialize();
       loadDelegates(input, data);
-      data.getBattleDelegate()
-          .getBattleTracker()
-          .fixUpNullPlayers(data.getPlayerList().getNullPlayer());
+      data.fixUpNullPlayersInDelegates();
       return Optional.of(data);
     } catch (final Throwable e) {
       log.warn(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import org.triplea.java.ObjectUtils;
 import org.triplea.java.RemoveOnNextMajorRelease;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
@@ -42,7 +43,7 @@ abstract class AbstractBattle implements IBattle {
   boolean headless = false;
 
   @Getter final Territory battleSite;
-  final GamePlayer attacker;
+  GamePlayer attacker;
   GamePlayer defender;
   final BattleTracker battleTracker;
   int round = 1;
@@ -225,6 +226,16 @@ abstract class AbstractBattle implements IBattle {
   @Override
   public GamePlayer getDefender() {
     return defender;
+  }
+
+  @Override
+  public void fixUpNullPlayer(GamePlayer nullPlayer) {
+    if (attacker.isNull() && !ObjectUtils.referenceEquals(attacker, nullPlayer)) {
+      attacker = nullPlayer;
+    }
+    if (defender.isNull() && !ObjectUtils.referenceEquals(defender, nullPlayer)) {
+      defender = nullPlayer;
+    }
   }
 
   public void setHeadless(final boolean headless) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -51,6 +51,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.triplea.java.RemoveOnNextMajorRelease;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.sound.ISound;
@@ -174,6 +175,13 @@ public class BattleTracker implements Serializable {
       }
     }
     return false;
+  }
+
+  @RemoveOnNextMajorRelease
+  public void fixUpNullPlayers(GamePlayer nullPlayer) {
+    for (var b : pendingBattles) {
+      b.fixUpNullPlayer(nullPlayer);
+    }
   }
 
   void clearFinishedBattles(final IDelegateBridge bridge) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
 /** Represents a battle. */
 public interface IBattle extends Serializable {
@@ -164,6 +165,9 @@ public interface IBattle extends Serializable {
   GamePlayer getAttacker();
 
   GamePlayer getDefender();
+
+  @RemoveOnNextMajorRelease
+  void fixUpNullPlayer(GamePlayer nullPlayer);
 
   UUID getBattleId();
 }


### PR DESCRIPTION
## Change Summary & Additional Notes

The issue is that old saved games may save references to the GamePlayer on various objects, including pending battles.

Since 2.6 has an invariant that all GamePlayer objects have a non-null getData(), which was not true in 2.5 and earlier, we need to update these after loading the game. In particular, we need to fix up all references to the null player with the instance from the game data.

This was already being done for units and territories via GameData::fixUpNullPlayers(). This adds it also for pending battles.

Fixes: https://github.com/triplea-game/triplea/issues/11151
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
