### PR TITLE
Fix fighter images not switching to jets on tech.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameDataEvent.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameDataEvent.java
@@ -1,12 +1,14 @@
 package games.strategy.engine.data;
 
 import games.strategy.engine.data.changefactory.ObjectPropertyChange;
+import games.strategy.triplea.Constants;
 import java.util.Optional;
 
 /** Enum that represents various possible game data change events. */
 public enum GameDataEvent {
   UNIT_MOVED,
-  GAME_STEP_CHANGED;
+  GAME_STEP_CHANGED,
+  TECH_ATTACHMENT_CHANGED;
 
   /**
    * Converts a 'Change' object to a 'GameDataEvent' object, returns empty if the change object does
@@ -15,6 +17,12 @@ public enum GameDataEvent {
   static Optional<GameDataEvent> lookupEvent(final Change change) {
     if (hasMoveChange(change)) {
       return Optional.of(UNIT_MOVED);
+    }
+    if (change instanceof ChangeAttachmentChange) {
+      ChangeAttachmentChange attachmentChange = (ChangeAttachmentChange) change;
+      if (attachmentChange.getAttachmentName().equals(Constants.TECH_ATTACHMENT_NAME)) {
+        return Optional.of(TECH_ATTACHMENT_CHANGED);
+      }
     }
     return Optional.empty();
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -25,7 +25,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.imageio.ImageIO;
@@ -60,6 +62,7 @@ public class UnitImageFactory {
   private final Map<String, ImageIcon> icons = new HashMap<>();
   // Temporary colorized image files used for URLs for html views (e.g. unit stats table).
   private final Map<ImageKey, URL> colorizedTempFiles = new HashMap<>();
+  private final List<File> tempFiles = new ArrayList<>();
   // Scaling factor for unit images
   private final double scaleFactor;
   private final ResourceLoader resourceLoader;
@@ -74,6 +77,18 @@ public class UnitImageFactory {
     this.scaleFactor = unitScale;
     this.resourceLoader = resourceLoader;
     this.mapData = mapData;
+  }
+
+  public void clearCache() {
+    images.clear();
+    icons.clear();
+    deleteTempFiles();
+    colorizedTempFiles.clear();
+  }
+
+  public void deleteTempFiles() {
+    tempFiles.forEach(File::delete);
+    tempFiles.clear();
   }
 
   @Value
@@ -283,6 +298,7 @@ public class UnitImageFactory {
                 File file = Files.createTempFile(key.getFullName(), ".png").toFile();
                 // Delete the file on exit.
                 file.deleteOnExit();
+                tempFiles.add(file);
                 ImageIO.write(bufferedImage, "PNG", file);
                 return file.toURI().toURL();
               } catch (IOException e) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
@@ -69,25 +69,17 @@ class TechResultsDisplay extends JPanel {
     final JPanel dice = new JPanel();
     dice.setLayout(new BoxLayout(dice, BoxLayout.X_AXIS));
     final int remainder = msg.getRemainder();
+    final var diceFactory = uiContext.getDiceImageFactory();
     for (int i = 0; i < msg.getRolls().length; i++) {
       // add 1 since dice are 0 based
       final int roll = msg.getRolls()[i] + 1;
-      final JLabel die;
+      final Die.DieType dieType;
       if (remainder > 0) {
-        die =
-            new JLabel(
-                uiContext
-                    .getDiceImageFactory()
-                    .getDieIcon(roll, roll <= remainder ? Die.DieType.HIT : Die.DieType.MISS));
+        dieType = (roll <= remainder) ? Die.DieType.HIT : Die.DieType.MISS;
       } else {
-        die =
-            new JLabel(
-                uiContext
-                    .getDiceImageFactory()
-                    .getDieIcon(
-                        roll, roll == data.getDiceSides() ? Die.DieType.HIT : Die.DieType.MISS));
+        dieType = (roll == data.getDiceSides()) ? Die.DieType.HIT : Die.DieType.MISS;
       }
-      dice.add(die);
+      dice.add(new JLabel(diceFactory.getDieIcon(roll, dieType)));
       dice.add(Box.createHorizontalStrut(2));
       dice.setMaximumSize(new Dimension(200, (int) dice.getMaximumSize().getHeight()));
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -179,6 +179,7 @@ public class UiContext {
       }
       activeToDeactivate.clear();
       windowsToCloseOnShutdown.clear();
+      unitImageFactory.deleteTempFiles();
     }
     StackTraceReportModel.setCurrentMapName(null);
     resourceLoader.close();

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -441,8 +441,15 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     // force a data change event to update the UI for edit mode
     dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
     data.addDataChangeListener(dataChangeListener);
-    game.getData().addGameDataEventListener(GameDataEvent.GAME_STEP_CHANGED, this::updateStep);
+    data.addGameDataEventListener(GameDataEvent.GAME_STEP_CHANGED, this::updateStep);
+    // Clear cached unit images when getting standard tech like jet power.
+    data.addGameDataEventListener(
+        GameDataEvent.TECH_ATTACHMENT_CHANGED, this::clearCachedUnitImages);
     uiContext.addShutdownWindow(this);
+  }
+
+  private void clearCachedUnitImages() {
+    uiContext.getUnitImageFactory().clearCache();
   }
 
   /**


### PR DESCRIPTION
Adds a TECH_ATTACHMENT_CHANGED event that the UI listens for to invalidate the image cache.

Also, adds code to delete colorized temp files on game end as well as cleaning up some tech results display code.
Fixes: https://github.com/triplea-game/triplea/issues/7418 (not a 2.6 issue)

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--> FIX|Jet fighters not drawn with correct image after researching jet power tech.<!--END_RELEASE_NOTE-->
