### PR TITLE
Improve message box text when not able to place sea units.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -619,7 +619,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       }
     }
     if (producers.size() == failingProducers.size()) {
-      return String.format("Adjacent territories to %s cannot produce because:\n\n%s", to.getName(), error);
+      return String.format(
+          "Adjacent territories to %s cannot produce because:\n\n%s", to.getName(), error);
     }
     return null;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -612,18 +612,14 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       if (errorP != null) {
         failingProducers.add(producer);
         // do not include the error for same territory, if water, because users do not want to see
-        // this error report for
-        // 99.9% of games
+        // this error report for 99.9% of games
         if (!(producer.equals(to) && producer.isWater())) {
-          error.append(", ").append(errorP);
+          error.append(errorP).append(".\n");
         }
       }
     }
     if (producers.size() == failingProducers.size()) {
-      return "Adjacent territories to "
-          + to.getName()
-          + " cannot produce, due to: \n "
-          + error.toString().replaceFirst(", ", "");
+      return String.format("Adjacent territories to %s cannot produce because:\n\n%s", to.getName(), error);
     }
     return null;
   }

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -243,8 +243,8 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
       if (production.isError()) {
         JOptionPane.showMessageDialog(
             getTopLevelAncestor(),
-            production.getErrorMessage(),
-            "No units",
+            production.getErrorMessage() + "\n\n",
+            "Cannot produce units",
             JOptionPane.INFORMATION_MESSAGE);
       }
       return production;


### PR DESCRIPTION
## Change Summary & Additional Notes
Before:
![cannot_produce_old](https://github.com/triplea-game/triplea/assets/17648/f9162275-b5e6-4c96-ad0d-f3b8912e90b8)

After:
![cannot_produce](https://github.com/triplea-game/triplea/assets/17648/2550d9a0-8d72-411a-8ea8-da6963a0b918)

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Improved message box text when sea units can't be placed.<!--END_RELEASE_NOTE-->
