### PR TITLE
Tweak AI isSub logic.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -92,7 +92,7 @@ public class ProPurchaseOption {
     transportCost = unitAttachment.getTransportCost() * quantity;
     carrierCost = unitAttachment.getCarrierCost() * quantity;
     isAir = unitAttachment.getIsAir();
-    isSub = !unitAttachment.getCanNotTarget().isEmpty();
+    isSub = unitAttachment.getCanEvade();
     isDestroyer = unitAttachment.getIsDestroyer();
     isTransport = unitAttachment.getTransportCapacity() > 0;
     isLandTransport = unitAttachment.isLandTransport();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
@@ -103,7 +103,9 @@ public class ProPurchaseOptionMap {
         ProLogger.debug("Air: " + ppo);
       } else if (Matches.unitTypeIsSea().test(unitType)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
-        seaDefenseOptions.add(ppo);
+        if (!ppo.isSub()) {
+          seaDefenseOptions.add(ppo);
+        }
         if (ppo.isTransport()) {
           seaTransportOptions.add(ppo);
         }


### PR DESCRIPTION
## Change Summary & Additional Notes

Previously, it was based on getCanNotTarget(), but actually getCanEvade() is the better option since canNotTarget can be set on non-sub units. This also restores the sub purchase logic that was changed in https://github.com/triplea-game/triplea/commit/caf296caf95f65ad81bace4dcca522304b34eac5.

I think this is a safer version of the change, since the above one may have had an effect where AI would start buying subs for defense, when it shouldn't.

Note: I verified all standard A&A maps and all the subs have canEvade set, so this should ensure the AI continues to behave as before on those maps.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
