### PR TITLE
Don't reset purchase selection on purchase error.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -185,13 +185,9 @@ public class PurchaseDelegate extends BaseTripleADelegate
 
           final int allowedBuild = maxBuilt - currentlyBuilt;
           if (allowedBuild - quantity < 0) {
-            return "May only build "
-                + allowedBuild
-                + " of "
-                + type.getName()
-                + " this turn, may only build "
-                + maxBuilt
-                + " total";
+            return String.format(
+                "May only build %s of %s this turn, may only build %s total",
+                allowedBuild, type.getName(), maxBuilt);
           }
         }
       }

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -147,7 +147,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
     if (GameStep.isTechStep(name)) {
       tech();
     } else if (GameStep.isPurchaseOrBidStep(name)) {
-      purchase(GameStepPropertiesHelper.isBid(getGameData()));
+      purchase(GameStepPropertiesHelper.isBid(getGameData()), false);
       if (!GameStepPropertiesHelper.isBid(getGameData())) {
         ui.waitForMoveForumPoster(this.getGamePlayer(), getPlayerBridge());
         // TODO only do forum post if there is a combat
@@ -414,7 +414,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
     return !(unitsCantFight.isEmpty() || ui.getOkToLetUnitsDie(unitsCantFight));
   }
 
-  private void purchase(final boolean bid) {
+  private void purchase(final boolean bid, final boolean keepCurrentPurchase) {
     if (getPlayerBridge().isGameOver()) {
       return;
     }
@@ -464,7 +464,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
           if (error != null) {
             ui.notifyError(error);
             // don't give up, keep going
-            purchase(bid);
+            purchase(bid, true);
           }
         }
       }
@@ -472,7 +472,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
     if (isOnlyRepairIfDisabled) {
       return;
     }
-    final IntegerMap<ProductionRule> prod = ui.getProduction(gamePlayer, bid);
+    final IntegerMap<ProductionRule> prod = ui.getProduction(gamePlayer, bid, keepCurrentPurchase);
     if (prod == null) {
       return;
     }
@@ -492,7 +492,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
     if (purchaseError != null) {
       ui.notifyError(purchaseError);
       // don't give up, keep going
-      purchase(bid);
+      purchase(bid, true);
     }
   }
 

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -143,7 +143,8 @@ public class ActionButtons extends JPanel {
     changeTo(gamePlayer, repairPanel);
   }
 
-  public void changeToProduce(final GamePlayer gamePlayer) {
+  public void changeToProduce(final GamePlayer gamePlayer, final boolean keepCurrentPurchase) {
+    purchasePanel.setKeepCurrentPurchase(keepCurrentPurchase);
     changeTo(gamePlayer, purchasePanel);
   }
 

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -24,6 +24,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+import lombok.Setter;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.SwingComponents;
@@ -43,6 +44,8 @@ public class PurchasePanel extends ActionPanel {
   private final SimpleUnitPanel purchasedUnits;
   private final JLabel purchasedLabel = createIndentedLabel();
   private final JButton buyButton;
+  @Setter
+  private boolean keepCurrentPurchase;
 
   private final AbstractAction purchaseAction =
       new AbstractAction("Buy") {
@@ -86,7 +89,13 @@ public class PurchasePanel extends ActionPanel {
   @Override
   public void display(final GamePlayer gamePlayer) {
     super.display(gamePlayer);
-    purchase = new IntegerMap<>();
+    // If keepCurrentPurchase is true, we're trying after showing an error to the user about their
+    // current selection. Don't clear everything and let the user correct it instead.
+    if (keepCurrentPurchase) {
+      keepCurrentPurchase = false;
+    } else {
+      purchase = new IntegerMap<>();
+    }
     SwingUtilities.invokeLater(
         () -> {
           removeAll();

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -44,8 +44,7 @@ public class PurchasePanel extends ActionPanel {
   private final SimpleUnitPanel purchasedUnits;
   private final JLabel purchasedLabel = createIndentedLabel();
   private final JButton buyButton;
-  @Setter
-  private boolean keepCurrentPurchase;
+  @Setter private boolean keepCurrentPurchase;
 
   private final AbstractAction purchaseAction =
       new AbstractAction("Buy") {

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -631,7 +631,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     bottomBar.setStatus(msg, mapPanel.getWarningImage());
   }
 
-  public IntegerMap<ProductionRule> getProduction(final GamePlayer player, final boolean bid, final boolean keepCurrentPurchase) {
+  public IntegerMap<ProductionRule> getProduction(
+      final GamePlayer player, final boolean bid, final boolean keepCurrentPurchase) {
     messageAndDialogThreadPool.waitForAll();
     actionButtons.changeToProduce(player, keepCurrentPurchase);
     return actionButtons.waitForPurchase(bid);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -631,9 +631,9 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     bottomBar.setStatus(msg, mapPanel.getWarningImage());
   }
 
-  public IntegerMap<ProductionRule> getProduction(final GamePlayer player, final boolean bid) {
+  public IntegerMap<ProductionRule> getProduction(final GamePlayer player, final boolean bid, final boolean keepCurrentPurchase) {
     messageAndDialogThreadPool.waitForAll();
-    actionButtons.changeToProduce(player);
+    actionButtons.changeToProduce(player, keepCurrentPurchase);
     return actionButtons.waitForPurchase(bid);
   }
 


### PR DESCRIPTION
## Change Summary & Additional Notes
For example, if you tried to buy too many of a unit. Previously, your full purchase selection will be cleared. Now, it will just bring you back to the purchase screen after showing error, keeping the previous selections.

Manually tested on 1941 Global Command Decision when trying to buy too many Army HQs.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Your purchase selections will no longer be reset when trying to select an invalid purchase (e.g. too many units of a type). You'll be brought back to the purchase screen to correct the error.<!--END_RELEASE_NOTE-->
