### PR TITLE
Fix: Apply PlayerAttachment stack limits when placing units.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -226,19 +226,36 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
 
   @Override
   public boolean remove(final Object object) {
-    final boolean result = units.remove(object);
-    holder.notifyChanged();
-    return result;
+    final boolean changed = units.remove(object);
+    if (changed) {
+      holder.notifyChanged();
+    }
+    return changed;
+  }
+
+  @Override
+  public boolean removeIf(final Predicate<? super Unit> predicate) {
+    final boolean changed = units.removeIf(predicate);
+    if (changed) {
+      holder.notifyChanged();
+    }
+    return changed;
   }
 
   @Override
   public boolean retainAll(final Collection<?> collection) {
-    return units.retainAll(collection);
+    final boolean changed = units.retainAll(collection);
+    if (changed) {
+      holder.notifyChanged();
+    }
+    return changed;
   }
 
   @Override
   public void clear() {
-    units.clear();
-    holder.notifyChanged();
+    if (!units.isEmpty()) {
+      units.clear();
+      holder.notifyChanged();
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -93,7 +93,7 @@ public class PlayerAttachment extends DefaultAttachment {
     placementLimit = value;
   }
 
-  private Set<Triple<Integer, String, Set<UnitType>>> getPlacementLimit() {
+  public Set<Triple<Integer, String, Set<UnitType>>> getPlacementLimit() {
     return getSetProperty(placementLimit);
   }
 
@@ -112,7 +112,7 @@ public class PlayerAttachment extends DefaultAttachment {
     movementLimit = value;
   }
 
-  private Set<Triple<Integer, String, Set<UnitType>>> getMovementLimit() {
+  public Set<Triple<Integer, String, Set<UnitType>>> getMovementLimit() {
     return getSetProperty(movementLimit);
   }
 
@@ -131,7 +131,7 @@ public class PlayerAttachment extends DefaultAttachment {
     attackingLimit = value;
   }
 
-  private Set<Triple<Integer, String, Set<UnitType>>> getAttackingLimit() {
+  public Set<Triple<Integer, String, Set<UnitType>>> getAttackingLimit() {
     return getSetProperty(attackingLimit);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -7,19 +7,12 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Resource;
-import games.strategy.engine.data.Territory;
-import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.gameparser.GameParseException;
-import games.strategy.triplea.delegate.Matches;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 import javax.annotation.Nullable;
-import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Triple;
 
@@ -163,64 +156,6 @@ public class PlayerAttachment extends DefaultAttachment {
       }
     }
     return Triple.of(max, s[1].intern(), types);
-  }
-
-  /**
-   * Returns {@code true} if the specified units can move into the specified territory without
-   * violating the specified stacking limit (movement, attack, or placement).
-   */
-  public static boolean getCanTheseUnitsMoveWithoutViolatingStackingLimit(
-      final String limitType,
-      final Collection<Unit> unitsMoving,
-      final Territory toMoveInto,
-      final GamePlayer owner) {
-    final PlayerAttachment pa = PlayerAttachment.get(owner);
-    if (pa == null) {
-      return true;
-    }
-    final Set<Triple<Integer, String, Set<UnitType>>> stackingLimits;
-    switch (limitType) {
-      case "movementLimit":
-        stackingLimits = pa.getMovementLimit();
-        break;
-      case "attackingLimit":
-        stackingLimits = pa.getAttackingLimit();
-        break;
-      case "placementLimit":
-        stackingLimits = pa.getPlacementLimit();
-        break;
-      default:
-        throw new IllegalStateException("Invalid limitType: " + limitType);
-    }
-    if (stackingLimits.isEmpty()) {
-      return true;
-    }
-    final Predicate<Unit> notOwned = Matches.unitIsOwnedBy(owner).negate();
-    final Predicate<Unit> notAllied = Matches.alliedUnit(owner).negate();
-    for (final Triple<Integer, String, Set<UnitType>> currentLimit : stackingLimits) {
-      // first make a copy of unitsMoving
-      final Collection<Unit> copyUnitsMoving = new ArrayList<>(unitsMoving);
-      final Collection<Unit> currentInTerritory = new ArrayList<>(toMoveInto.getUnits());
-      final String type = currentLimit.getSecond();
-      // first remove units that do not apply to our current type
-      if (type.equals("owned")) {
-        currentInTerritory.removeAll(CollectionUtils.getMatches(currentInTerritory, notOwned));
-        copyUnitsMoving.removeAll(CollectionUtils.getMatches(copyUnitsMoving, notOwned));
-      } else if (type.equals("allied")) {
-        currentInTerritory.removeAll(CollectionUtils.getMatches(currentInTerritory, notAllied));
-        copyUnitsMoving.removeAll(CollectionUtils.getMatches(copyUnitsMoving, notAllied));
-      }
-      // now remove units that are not part of our list
-      final Predicate<Unit> matchesUnits = Matches.unitIsOfTypes(currentLimit.getThird());
-      currentInTerritory.retainAll(CollectionUtils.getMatches(currentInTerritory, matchesUnits));
-      copyUnitsMoving.retainAll(CollectionUtils.getMatches(copyUnitsMoving, matchesUnits));
-      // now test
-      final Integer max = currentLimit.getFirst();
-      if (max < (currentInTerritory.size() + copyUnitsMoving.size())) {
-        return false;
-      }
-    }
-    return true;
   }
 
   private void setSuicideAttackTargets(final String value) throws GameParseException {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -15,6 +15,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.engine.data.gameparser.GameParseException;
+import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
@@ -3442,22 +3443,32 @@ public class UnitAttachment extends DefaultAttachment {
     }
   }
 
+  public int getStackingLimitMax(final Tuple<Integer, String> stackingLimit) {
+    int max = stackingLimit.getFirst();
+    if (max != Integer.MAX_VALUE) {
+      return max;
+    }
+    // under certain rules (classic rules) there can only be 1 aa gun in a territory.
+    final GameProperties properties = getData().getProperties();
+    if ((getIsAaForBombingThisUnitOnly() || getIsAaForCombatOnly())
+        && !(Properties.getWW2V2(properties)
+        || Properties.getWW2V3(properties)
+        || Properties.getMultipleAaPerTerritory(properties))) {
+      max = 1;
+    }
+    return max;
+  }
+
   private void addStackingLimitDescription(
       final Tuple<Integer, String> stackingLimit,
       final String description,
       final Formatter formatter) {
     if (stackingLimit != null) {
-      if (stackingLimit.getFirst() == Integer.MAX_VALUE
-          && (getIsAaForBombingThisUnitOnly() || getIsAaForCombatOnly())
-          && !(Properties.getWW2V2(getData().getProperties())
-              || Properties.getWW2V3(getData().getProperties())
-              || Properties.getMultipleAaPerTerritory(getData().getProperties()))) {
-        formatter.append(
-            "Max " + stackingLimit.getSecond() + " Units " + description + " per Territory", "1");
-      } else if (stackingLimit.getFirst() < 10000) {
+      int max = getStackingLimitMax(stackingLimit);
+      if (max < 10000) {
         formatter.append(
             "Max " + stackingLimit.getSecond() + " Units " + description + " per Territory",
-            String.valueOf(stackingLimit.getFirst()));
+            String.valueOf(max));
       }
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2553,7 +2553,8 @@ public class UnitAttachment extends DefaultAttachment {
 
   /**
    * Returns the subset of units that are valid with respect to any stacking limits in effect.
-   * Note: The passed list of units should have already been filtered for placement restrictions
+   *
+   * <p>Note: The passed list of units should have already been filtered for placement restrictions
    * as otherwise this could return a subset of units that cannot be placed for other reasons.
    */
   public static Collection<Unit> filterUnitsByStackingLimit(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2581,9 +2581,8 @@ public class UnitAttachment extends DefaultAttachment {
     // correctly handle stacking limits that apply to multiple unit types.
     final var unitsAllowedSoFar = new ArrayList<Unit>();
     for (final Unit unit : units) {
-      final UnitType ut = unit.getType();
-      final Tuple<Integer, String> stackingLimit =
-          stackingLimitGetter.apply(ut.getUnitAttachment());
+      UnitType ut = unit.getType();
+      Tuple<Integer, String> stackingLimit = stackingLimitGetter.apply(ut.getUnitAttachment());
       int maxAllowed =
           getMaximumNumberOfThisUnitTypeToReachStackingLimit(
               ut, t, owner, stackingLimit, playerStackingLimits, unitsAllowedSoFar);
@@ -2617,11 +2616,11 @@ public class UnitAttachment extends DefaultAttachment {
       if (!unitTypes.contains(ut)) {
         continue;
       }
-      final String type = limit.getSecond();
+      final String stackingType = limit.getSecond();
       Predicate<Unit> stackingMatch = Matches.unitIsOfTypes(unitTypes);
-      if (type.equals("owned")) {
+      if (stackingType.equals("owned")) {
         stackingMatch = stackingMatch.and(Matches.unitIsOwnedBy(owner));
-      } else if (type.equals("allied")) {
+      } else if (stackingType.equals("allied")) {
         stackingMatch = stackingMatch.and(Matches.alliedUnit(owner));
       }
       final int totalInTerritory = CollectionUtils.countMatches(existingUnits, stackingMatch);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2597,7 +2597,7 @@ public class UnitAttachment extends DefaultAttachment {
       if (type.equals("owned")) {
         stackingMatch = stackingMatch.and(Matches.unitIsOwnedBy(owner));
       } else if (type.equals("allied")) {
-        stackingMatch = stackingMatch.and(Matches.isUnitAllied(owner));
+        stackingMatch = stackingMatch.and(Matches.alliedUnit(owner));
       }
       final int totalInTerritory = CollectionUtils.countMatches(t.getUnits(), stackingMatch);
       final Integer limitMax = currentLimit.getFirst();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.attachments;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterables;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.DefaultNamed;
@@ -16,7 +15,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.engine.data.gameparser.GameParseException;
-import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
@@ -34,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -42,7 +39,6 @@ import lombok.Value;
 import org.triplea.java.ChangeOnNextMajorRelease;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
-import org.triplea.util.Triple;
 import org.triplea.util.Tuple;
 
 /**
@@ -2491,7 +2487,7 @@ public class UnitAttachment extends DefaultAttachment {
     placementLimit = value;
   }
 
-  private @Nullable Tuple<Integer, String> getPlacementLimit() {
+  public @Nullable Tuple<Integer, String> getPlacementLimit() {
     return placementLimit;
   }
 
@@ -2549,118 +2545,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public void resetCanRetreatOnStalemate() {
     canRetreatOnStalemate = null;
-  }
-
-  /**
-   * Returns the subset of units that are valid with respect to any stacking limits in effect.
-   *
-   * <p>Note: The passed list of units should have already been filtered for placement restrictions
-   * as otherwise this could return a subset of units that cannot be placed for other reasons.
-   */
-  public static Collection<Unit> filterUnitsByStackingLimit(
-      final Collection<Unit> units,
-      final String limitType,
-      final GamePlayer owner,
-      final Territory t) {
-    final PlayerAttachment pa = PlayerAttachment.get(owner);
-    final Function<UnitAttachment, Tuple<Integer, String>> stackingLimitGetter;
-    final Set<Triple<Integer, String, Set<UnitType>>> playerStackingLimits;
-    switch (limitType) {
-      case "movementLimit":
-        stackingLimitGetter = UnitAttachment::getMovementLimit;
-        playerStackingLimits = (pa == null ? Set.of() : pa.getMovementLimit());
-        break;
-      case "attackingLimit":
-        stackingLimitGetter = UnitAttachment::getAttackingLimit;
-        playerStackingLimits = (pa == null ? Set.of() : pa.getAttackingLimit());
-        break;
-      case "placementLimit":
-        stackingLimitGetter = UnitAttachment::getPlacementLimit;
-        playerStackingLimits = (pa == null ? Set.of() : pa.getPlacementLimit());
-        break;
-      default:
-        throw new IllegalArgumentException("Invalid limitType: " + limitType);
-    }
-
-    // Note: This must check each unit individually and track the ones that passed in order to
-    // correctly handle stacking limits that apply to multiple unit types.
-    final var unitsAllowedSoFar = new ArrayList<Unit>();
-    for (final Unit unit : units) {
-      UnitType ut = unit.getType();
-      Tuple<Integer, String> stackingLimit = stackingLimitGetter.apply(ut.getUnitAttachment());
-      int maxAllowed =
-          getMaximumNumberOfThisUnitTypeToReachStackingLimit(
-              ut, t, owner, stackingLimit, playerStackingLimits, unitsAllowedSoFar);
-      if (maxAllowed > 0) {
-        unitsAllowedSoFar.add(unit);
-      }
-    }
-    return unitsAllowedSoFar;
-  }
-
-  /**
-   * Returns the maximum number of units of the specified type that can be placed in the specified
-   * territory according to the specified stacking limit (movement, attack, or placement).
-   *
-   * @return {@link Integer#MAX_VALUE} if there is no stacking limit for the specified conditions.
-   */
-  private static int getMaximumNumberOfThisUnitTypeToReachStackingLimit(
-      final UnitType ut,
-      final Territory t,
-      final GamePlayer owner,
-      final Tuple<Integer, String> stackingLimit,
-      final Set<Triple<Integer, String, Set<UnitType>>> playerStackingLimits,
-      final Collection<Unit> pendingUnits) {
-    int max = Integer.MAX_VALUE;
-    final UnitAttachment ua = ut.getUnitAttachment();
-    // Concat the territory units with the pending units without copying.
-    final var existingUnits = Iterables.concat(t.getUnits(), pendingUnits);
-    // Apply stacking limits coming from the PlayerAttachment.
-    for (final Triple<Integer, String, Set<UnitType>> limit : playerStackingLimits) {
-      final var unitTypes = limit.getThird();
-      if (!unitTypes.contains(ut)) {
-        continue;
-      }
-      final String stackingType = limit.getSecond();
-      Predicate<Unit> stackingMatch = Matches.unitIsOfTypes(unitTypes);
-      if (stackingType.equals("owned")) {
-        stackingMatch = stackingMatch.and(Matches.unitIsOwnedBy(owner));
-      } else if (stackingType.equals("allied")) {
-        stackingMatch = stackingMatch.and(Matches.alliedUnit(owner));
-      }
-      final int totalInTerritory = CollectionUtils.countMatches(existingUnits, stackingMatch);
-      final Integer limitMax = limit.getFirst();
-      max = Math.min(max, limitMax - totalInTerritory);
-    }
-
-    if (stackingLimit == null) {
-      return max;
-    }
-    max = Math.min(max, stackingLimit.getFirst());
-    // under certain rules (classic rules) there can only be 1 aa gun in a territory.
-    final GameProperties properties = t.getData().getProperties();
-    if (max == Integer.MAX_VALUE
-        && (ua.getIsAaForBombingThisUnitOnly() || ua.getIsAaForCombatOnly())
-        && !(Properties.getWW2V2(properties)
-            || Properties.getWW2V3(properties)
-            || Properties.getMultipleAaPerTerritory(properties))) {
-      max = 1;
-    }
-    final Predicate<Unit> stackingMatch;
-    final String stackingType = stackingLimit.getSecond();
-    switch (stackingType) {
-      case "owned":
-        stackingMatch = Matches.unitIsOfType(ut).and(Matches.unitIsOwnedBy(owner));
-        break;
-      case "allied":
-        stackingMatch = Matches.unitIsOfType(ut).and(Matches.isUnitAllied(owner));
-        break;
-      default:
-        stackingMatch = Matches.unitIsOfType(ut);
-        break;
-    }
-    final int totalInTerritory = CollectionUtils.countMatches(existingUnits, stackingMatch);
-    return Math.max(0, max - totalInTerritory);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2551,7 +2551,11 @@ public class UnitAttachment extends DefaultAttachment {
     canRetreatOnStalemate = null;
   }
 
-  /** Returns the subset of units that are valid with respect to any stacking limits in effect. */
+  /**
+   * Returns the subset of units that are valid with respect to any stacking limits in effect.
+   * Note: The passed list of units should have already been filtered for placement restrictions
+   * as otherwise this could return a subset of units that cannot be placed for other reasons.
+   */
   public static Collection<Unit> filterUnitsByStackingLimit(
       final Collection<Unit> units,
       final String limitType,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3452,8 +3452,8 @@ public class UnitAttachment extends DefaultAttachment {
     final GameProperties properties = getData().getProperties();
     if ((getIsAaForBombingThisUnitOnly() || getIsAaForCombatOnly())
         && !(Properties.getWW2V2(properties)
-        || Properties.getWW2V3(properties)
-        || Properties.getMultipleAaPerTerritory(properties))) {
+            || Properties.getWW2V3(properties)
+            || Properties.getMultipleAaPerTerritory(properties))) {
       max = 1;
     }
     return max;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -842,21 +842,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     if (!canWeConsumeUnits(units, to, false, null)) {
       return "Not Enough Units To Upgrade or Be Consumed";
     }
-    // now check for stacking limits
-    final Collection<UnitType> typesAlreadyChecked = new ArrayList<>();
-    for (final Unit currentUnit : units) {
-      final UnitType ut = currentUnit.getType();
-      if (typesAlreadyChecked.contains(ut)) {
-        continue;
-      }
-      typesAlreadyChecked.add(ut);
-      final int maxForThisType =
-          UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit(
-              "placementLimit", ut, to, player);
-      if (CollectionUtils.countMatches(units, Matches.unitIsOfType(ut)) > maxForThisType) {
-        return "UnitType " + ut.getName() + " is over stacking limit of " + maxForThisType;
-      }
-    }
     // now return null (valid placement) if we have placement restrictions disabled in game options
     if (!Properties.getUnitPlacementRestrictions(getData().getProperties())) {
       return null;
@@ -968,20 +953,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       }
     }
     // now check stacking limits
-    final Collection<Unit> placeableUnits2 = new ArrayList<>();
-    final var typesAlreadyChecked = new HashSet<UnitType>();
-    for (final Unit currentUnit : placeableUnits) {
-      final UnitType ut = currentUnit.getType();
-      if (typesAlreadyChecked.contains(ut)) {
-        continue;
-      }
-      typesAlreadyChecked.add(ut);
-      int max =
-          UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit(
-              "placementLimit", ut, to, player);
-      placeableUnits2.addAll(
-          CollectionUtils.getNMatches(placeableUnits, max, Matches.unitIsOfType(ut)));
-    }
+    final Collection<Unit> placeableUnits2 =
+        UnitAttachment.filterUnitsByStackingLimit(placeableUnits, "placementLimit", player, to);
     if (!Properties.getUnitPlacementRestrictions(properties)) {
       return placeableUnits2;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -176,12 +176,15 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
 
   @Override
   public PlaceableUnits getPlaceableUnits(final Collection<Unit> units, final Territory to) {
+    System.err.println("getPlaceableUnits: " + units);
     final String error = canProduce(to, units, player);
     if (error != null) {
       return new PlaceableUnits(error);
     }
     final Collection<Unit> placeableUnits = getUnitsToBePlaced(to, units, player);
+    System.err.println("-> placeableUnits: " + placeableUnits);
     final int maxUnits = getMaxUnitsToBePlaced(placeableUnits, to, player);
+    System.err.println("-> maxUnits: " + maxUnits);
     return new PlaceableUnits(placeableUnits, maxUnits);
   }
 
@@ -835,7 +838,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       }
       // make sure all units are land
       if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsNotSea())) {
-        return "Cant place sea units on land";
+        return "Can't place sea units on land";
       }
     }
     // make sure we can place consuming units
@@ -859,6 +862,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     }
     if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit(
         "placementLimit", units, to, player)) {
+      System.err.println("Err1");
       return "Units Cannot Go Over Stacking Limit";
     }
     // now return null (valid placement) if we have placement restrictions disabled in game options
@@ -972,6 +976,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       }
     }
     // now check stacking limits
+    System.err.println("Checking stacking limit...");
     final Collection<Unit> placeableUnits2 = new ArrayList<>();
     final var typesAlreadyChecked = new HashSet<UnitType>();
     for (final Unit currentUnit : placeableUnits) {
@@ -983,6 +988,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       int max =
           UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit(
               "placementLimit", ut, to, player);
+      System.err.println("Max:" + max);
       placeableUnits2.addAll(
           CollectionUtils.getNMatches(placeableUnits, max, Matches.unitIsOfType(ut)));
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.delegate;
 
+import static games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter.PLACEMENT_LIMIT;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
@@ -21,6 +23,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import games.strategy.triplea.delegate.move.validation.AirMovementValidator;
+import games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
@@ -978,7 +981,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       placeableUnits2 = placeableUnits;
     }
     // now check stacking limits
-    return UnitAttachment.filterUnitsByStackingLimit(placeableUnits2, "placementLimit", player, to);
+    return UnitStackingLimitFilter.filterUnits(placeableUnits2, PLACEMENT_LIMIT, player, to);
   }
 
   private Predicate<Unit> unitIsCarrierOwnedByCombinedPlayers(GamePlayer player) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -981,7 +981,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       placeableUnits2 = placeableUnits;
     }
     // now check stacking limits
-    return UnitStackingLimitFilter.filterUnits(placeableUnits2, PLACEMENT_LIMIT, player, to);
+    return UnitStackingLimitFilter.filterUnits(
+        placeableUnits2, PLACEMENT_LIMIT, player, to, produced.getOrDefault(to, List.of()));
   }
 
   private Predicate<Unit> unitIsCarrierOwnedByCombinedPlayers(GamePlayer player) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -860,11 +860,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         return "UnitType " + ut.getName() + " is over stacking limit of " + maxForThisType;
       }
     }
-    if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit(
-        "placementLimit", units, to, player)) {
-      System.err.println("Err1");
-      return "Units Cannot Go Over Stacking Limit";
-    }
     // now return null (valid placement) if we have placement restrictions disabled in game options
     if (!Properties.getUnitPlacementRestrictions(getData().getProperties())) {
       return null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -176,15 +176,12 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
 
   @Override
   public PlaceableUnits getPlaceableUnits(final Collection<Unit> units, final Territory to) {
-    System.err.println("getPlaceableUnits: " + units);
     final String error = canProduce(to, units, player);
     if (error != null) {
       return new PlaceableUnits(error);
     }
     final Collection<Unit> placeableUnits = getUnitsToBePlaced(to, units, player);
-    System.err.println("-> placeableUnits: " + placeableUnits);
     final int maxUnits = getMaxUnitsToBePlaced(placeableUnits, to, player);
-    System.err.println("-> maxUnits: " + maxUnits);
     return new PlaceableUnits(placeableUnits, maxUnits);
   }
 
@@ -971,7 +968,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       }
     }
     // now check stacking limits
-    System.err.println("Checking stacking limit...");
     final Collection<Unit> placeableUnits2 = new ArrayList<>();
     final var typesAlreadyChecked = new HashSet<UnitType>();
     for (final Unit currentUnit : placeableUnits) {
@@ -983,7 +979,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       int max =
           UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit(
               "placementLimit", ut, to, player);
-      System.err.println("Max:" + max);
       placeableUnits2.addAll(
           CollectionUtils.getNMatches(placeableUnits, max, Matches.unitIsOfType(ut)));
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.delegate;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import java.util.ArrayList;
@@ -158,21 +157,6 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       }
     }
     // now check stacking limits
-    final Collection<Unit> placeableUnits2 = new ArrayList<>();
-    final Collection<UnitType> typesAlreadyChecked = new ArrayList<>();
-    for (final Unit currentUnit : placeableUnits) {
-      final UnitType ut = currentUnit.getType();
-      if (typesAlreadyChecked.contains(ut)) {
-        continue;
-      }
-      typesAlreadyChecked.add(ut);
-      placeableUnits2.addAll(
-          CollectionUtils.getNMatches(
-              placeableUnits,
-              UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit(
-                  "placementLimit", ut, to, player),
-              Matches.unitIsOfType(ut)));
-    }
-    return placeableUnits2;
+    return UnitAttachment.filterUnitsByStackingLimit(placeableUnits, "placementLimit", player, to);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -1,10 +1,12 @@
 package games.strategy.triplea.delegate;
 
+import static games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter.PLACEMENT_LIMIT;
+
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.PlayerAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -157,6 +159,6 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       }
     }
     // now check stacking limits
-    return UnitAttachment.filterUnitsByStackingLimit(placeableUnits, "placementLimit", player, to);
+    return UnitStackingLimitFilter.filterUnits(placeableUnits, PLACEMENT_LIMIT, player, to);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -17,7 +17,6 @@ import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.CanalAttachment;
-import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -824,10 +823,6 @@ public class MoveValidator {
                 "UnitType " + ut.getName() + " has reached stacking limit", unit);
           }
         }
-        if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit(
-            "attackingLimit", units, t, player)) {
-          return result.setErrorReturnResult("Units Cannot Go Over Stacking Limit");
-        }
       } else {
         for (final Unit unit : unitsWithStackingLimits) {
           final UnitType ut = unit.getType();
@@ -841,10 +836,6 @@ public class MoveValidator {
             result.addDisallowedUnit(
                 "UnitType " + ut.getName() + " has reached stacking limit", unit);
           }
-        }
-        if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit(
-            "movementLimit", units, t, player)) {
-          return result.setErrorReturnResult("Units Cannot Go Over Stacking Limit");
         }
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -810,12 +810,12 @@ public class MoveValidator {
       final String limitType;
       if (Matches.isTerritoryEnemyAndNotUnownedWater(player).test(t)
           || t.getUnitCollection().anyMatch(Matches.unitIsEnemyOf(player))) {
-        limitType = "attackingLimit";
+        limitType = UnitStackingLimitFilter.ATTACKING_LIMIT;
       } else {
-        limitType = "movementLimit";
+        limitType = UnitStackingLimitFilter.MOVEMENT_LIMIT;
       }
       final Collection<Unit> allowedUnits =
-          UnitAttachment.filterUnitsByStackingLimit(unitsWithStackingLimits, limitType, player, t);
+          UnitStackingLimitFilter.filterUnits(unitsWithStackingLimits, limitType, player, t);
       for (Unit unit : CollectionUtils.difference(unitsWithStackingLimits, allowedUnits)) {
         result.addDisallowedUnit(
             "Unit type " + unit.getType().getName() + " has reached stacking limit", unit);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
@@ -5,8 +5,6 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.data.properties.GameProperties;
-import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
@@ -1,0 +1,139 @@
+package games.strategy.triplea.delegate.move.validation;
+
+import com.google.common.collect.Iterables;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.properties.GameProperties;
+import games.strategy.triplea.Properties;
+import games.strategy.triplea.attachments.PlayerAttachment;
+import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.Matches;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.triplea.java.collections.CollectionUtils;
+import org.triplea.util.Triple;
+import org.triplea.util.Tuple;
+
+public class UnitStackingLimitFilter {
+  public static final String MOVEMENT_LIMIT = "movementLimit";
+  public static final String ATTACKING_LIMIT = "attackingLimit";
+  public static final String PLACEMENT_LIMIT = "placementLimit";
+
+  /**
+   * Returns the subset of units that are valid with respect to any stacking limits in effect.
+   *
+   * <p>Note: The passed list of units should have already been filtered for placement restrictions
+   * as otherwise this could return a subset of units that cannot be placed for other reasons.
+   */
+  public static Collection<Unit> filterUnits(
+      final Collection<Unit> units,
+      final String limitType,
+      final GamePlayer owner,
+      final Territory t) {
+    final PlayerAttachment pa = PlayerAttachment.get(owner);
+    final Function<UnitAttachment, Tuple<Integer, String>> stackingLimitGetter;
+    final Set<Triple<Integer, String, Set<UnitType>>> playerStackingLimits;
+    switch (limitType) {
+      case MOVEMENT_LIMIT:
+        stackingLimitGetter = UnitAttachment::getMovementLimit;
+        playerStackingLimits = (pa == null ? Set.of() : pa.getMovementLimit());
+        break;
+      case ATTACKING_LIMIT:
+        stackingLimitGetter = UnitAttachment::getAttackingLimit;
+        playerStackingLimits = (pa == null ? Set.of() : pa.getAttackingLimit());
+        break;
+      case PLACEMENT_LIMIT:
+        stackingLimitGetter = UnitAttachment::getPlacementLimit;
+        playerStackingLimits = (pa == null ? Set.of() : pa.getPlacementLimit());
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid limitType: " + limitType);
+    }
+
+    // Note: This must check each unit individually and track the ones that passed in order to
+    // correctly handle stacking limits that apply to multiple unit types.
+    final var unitsAllowedSoFar = new ArrayList<Unit>();
+    for (final Unit unit : units) {
+      UnitType ut = unit.getType();
+      Tuple<Integer, String> stackingLimit = stackingLimitGetter.apply(ut.getUnitAttachment());
+      int maxAllowed =
+          getMaximumNumberOfThisUnitTypeToReachStackingLimit(
+              ut, t, owner, stackingLimit, playerStackingLimits, unitsAllowedSoFar);
+      if (maxAllowed > 0) {
+        unitsAllowedSoFar.add(unit);
+      }
+    }
+    return unitsAllowedSoFar;
+  }
+
+  /**
+   * Returns the maximum number of units of the specified type that can be placed in the specified
+   * territory according to the specified stacking limit (movement, attack, or placement).
+   *
+   * @return {@link Integer#MAX_VALUE} if there is no stacking limit for the specified conditions.
+   */
+  private static int getMaximumNumberOfThisUnitTypeToReachStackingLimit(
+      final UnitType ut,
+      final Territory t,
+      final GamePlayer owner,
+      final Tuple<Integer, String> stackingLimit,
+      final Set<Triple<Integer, String, Set<UnitType>>> playerStackingLimits,
+      final Collection<Unit> pendingUnits) {
+    int max = Integer.MAX_VALUE;
+    final UnitAttachment ua = ut.getUnitAttachment();
+    // Concat the territory units with the pending units without copying.
+    final var existingUnits = Iterables.concat(t.getUnits(), pendingUnits);
+    // Apply stacking limits coming from the PlayerAttachment.
+    for (final Triple<Integer, String, Set<UnitType>> limit : playerStackingLimits) {
+      final var unitTypes = limit.getThird();
+      if (!unitTypes.contains(ut)) {
+        continue;
+      }
+      final String stackingType = limit.getSecond();
+      Predicate<Unit> stackingMatch = Matches.unitIsOfTypes(unitTypes);
+      if (stackingType.equals("owned")) {
+        stackingMatch = stackingMatch.and(Matches.unitIsOwnedBy(owner));
+      } else if (stackingType.equals("allied")) {
+        stackingMatch = stackingMatch.and(Matches.alliedUnit(owner));
+      }
+      final int totalInTerritory = CollectionUtils.countMatches(existingUnits, stackingMatch);
+      final Integer limitMax = limit.getFirst();
+      max = Math.min(max, limitMax - totalInTerritory);
+    }
+
+    if (stackingLimit == null) {
+      return max;
+    }
+    max = Math.min(max, stackingLimit.getFirst());
+    // under certain rules (classic rules) there can only be 1 aa gun in a territory.
+    final GameProperties properties = t.getData().getProperties();
+    if (max == Integer.MAX_VALUE
+        && (ua.getIsAaForBombingThisUnitOnly() || ua.getIsAaForCombatOnly())
+        && !(Properties.getWW2V2(properties)
+        || Properties.getWW2V3(properties)
+        || Properties.getMultipleAaPerTerritory(properties))) {
+      max = 1;
+    }
+    final Predicate<Unit> stackingMatch;
+    final String stackingType = stackingLimit.getSecond();
+    switch (stackingType) {
+      case "owned":
+        stackingMatch = Matches.unitIsOfType(ut).and(Matches.unitIsOwnedBy(owner));
+        break;
+      case "allied":
+        stackingMatch = Matches.unitIsOfType(ut).and(Matches.isUnitAllied(owner));
+        break;
+      default:
+        stackingMatch = Matches.unitIsOfType(ut);
+        break;
+    }
+    final int totalInTerritory = CollectionUtils.countMatches(existingUnits, stackingMatch);
+    return Math.max(0, max - totalInTerritory);
+  }
+
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
@@ -79,7 +79,7 @@ public class UnitStackingLimitFilter {
         unitsAllowedSoFar.add(unit);
       }
     }
-    return unitsAllowedSoFar;
+    return unitsAllowedSoFar.subList(existingUnitsToBePlaced.size(), unitsAllowedSoFar.size());
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
@@ -137,5 +137,4 @@ public class UnitStackingLimitFilter {
     final int totalInTerritory = CollectionUtils.countMatches(existingUnits, stackingMatch);
     return Math.max(0, max - totalInTerritory);
   }
-
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
@@ -34,6 +34,7 @@ public abstract class AbstractDelegateTestCase extends AbstractClientSettingTest
   protected Territory sfeSeaZone = gameData.getMap().getTerritory("Soviet Far East Sea Zone");
   protected Territory brazil = gameData.getMap().getTerritory("Brazil");
   protected Territory westCanada = gameData.getMap().getTerritory("West Canada");
+  protected Territory westCanadaSeaZone = gameData.getMap().getTerritory("West Canada Sea Zone");
   protected Territory germany = gameData.getMap().getTerritory("Germany");
   protected Territory syria = gameData.getMap().getTerritory("Syria Jordan");
   protected Territory manchuria = gameData.getMap().getTerritory("Manchuria");

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
@@ -81,6 +81,7 @@ public abstract class AbstractDelegateTestCase extends AbstractClientSettingTest
   protected UnitType aaGun = GameDataTestUtil.aaGun(gameData);
   protected UnitType fighter = GameDataTestUtil.fighter(gameData);
   protected UnitType bomber = GameDataTestUtil.bomber(gameData);
+  protected UnitType battleship = GameDataTestUtil.battleship(gameData);
   protected UnitType carrier = GameDataTestUtil.carrier(gameData);
   protected Resource pus = gameData.getResourceList().getResource("PUs");
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -170,7 +170,7 @@ class PlaceDelegateTest extends AbstractDelegateTestCase {
     assertValid(delegate.canUnitsBePlaced(uk, fourTanks, british));
 
     // we can't place 5 per the unit attachment's placementLimit
-    Collection<Unit> fiveTanks = create(british, armour,5);
+    Collection<Unit> fiveTanks = create(british, armour, 5);
     assertError(delegate.canUnitsBePlaced(uk, fiveTanks, british));
 
     // we can't place 3, if 2 are already scheduled to be placed
@@ -199,7 +199,7 @@ class PlaceDelegateTest extends AbstractDelegateTestCase {
     assertError(delegate.canUnitsBePlaced(northSea, units, british));
 
     // we can also place 2 battleships and a carrier
-    units = create(british, battleship,2);
+    units = create(british, battleship, 2);
     units.addAll(create(british, carrier, 1));
     assertValid(delegate.canUnitsBePlaced(northSea, units, british));
     // but not 2 battleships and 2 carriers

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -1,23 +1,19 @@
 package games.strategy.triplea.delegate;
 
-import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
-import static games.strategy.triplea.delegate.GameDataTestUtil.battleship;
-import static games.strategy.triplea.delegate.GameDataTestUtil.carrier;
-import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
 import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
+import static games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate.BidMode.NOT_BID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
-import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import java.util.Collection;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.triplea.java.collections.IntegerMap;
 
 class PlaceDelegateTest extends AbstractDelegateTestCase {
   private PlaceDelegate delegate;
@@ -31,197 +27,156 @@ class PlaceDelegateTest extends AbstractDelegateTestCase {
     delegate.start();
   }
 
+  private Collection<Unit> create(GamePlayer player, UnitType unitType, int quantity) {
+    var units = unitType.create(quantity, player);
+    player.getUnitCollection().addAll(units);
+    return units;
+  }
+
   @Test
   void testValid() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(infantry, 2);
-    final String response =
-        delegate.placeUnits(
-            GameDataTestUtil.getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    final String response = delegate.placeUnits(create(british, infantry, 2), uk, NOT_BID);
     assertValid(response);
   }
 
   @Test
   void testNotCorrectUnitsValid() {
-    final String response =
-        delegate.placeUnits(
-            infantry.create(3, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    final var unitsNotHeldByPlayer = infantry.create(3, british);
+    final String response = delegate.placeUnits(unitsNotHeldByPlayer, uk, NOT_BID);
     assertError(response);
   }
 
   @Test
   void testOnlySeaInSeaZone() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(infantry, 2);
     final String response =
-        delegate.canUnitsBePlaced(northSea, GameDataTestUtil.getUnits(map, british), british);
+        delegate.canUnitsBePlaced(northSea, create(british, infantry, 2), british);
     assertError(response);
   }
 
   @Test
   void testSeaCanGoInSeaZone() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(transport, 2);
     final String response =
-        delegate.canUnitsBePlaced(northSea, GameDataTestUtil.getUnits(map, british), british);
+        delegate.canUnitsBePlaced(northSea, create(british, transport, 2), british);
     assertValid(response);
   }
 
   @Test
   void testLandCanGoInLandZone() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(infantry, 2);
-    final String response =
-        delegate.placeUnits(
-            GameDataTestUtil.getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    final String response = delegate.placeUnits(create(british, infantry, 2), uk, NOT_BID);
     assertValid(response);
   }
 
   @Test
   void testSeaCantGoInSeaInLandZone() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(transport, 2);
-    final String response =
-        delegate.canUnitsBePlaced(uk, GameDataTestUtil.getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(uk, create(british, transport, 2), british);
     assertError(response);
   }
 
   @Test
   void testNoGoIfOpposingTroopsSea() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(transport, 2);
     final String response =
-        delegate.canUnitsBePlaced(northSea, GameDataTestUtil.getUnits(map, japanese), japanese);
+        delegate.canUnitsBePlaced(northSea, create(japanese, transport, 2), japanese);
     assertError(response);
   }
 
   @Test
   void testNoGoIfOpposingTroopsLand() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(infantry, 2);
-    final String response =
-        delegate.canUnitsBePlaced(japan, GameDataTestUtil.getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(japan, create(british, infantry, 2), british);
     assertError(response);
   }
 
   @Test
   void testOnlyOneFactoryPlaced() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(factory, 1);
-    final String response =
-        delegate.canUnitsBePlaced(uk, GameDataTestUtil.getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(uk, create(british, factory, 1), british);
     assertError(response);
   }
 
   @Test
   void testCantPlaceAaWhenOneAlreadyThere() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(aaGun, 1);
-    final String response =
-        delegate.canUnitsBePlaced(uk, GameDataTestUtil.getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(uk, create(british, aaGun, 1), british);
     assertError(response);
   }
 
   @Test
   void testCantPlaceTwoAa() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(aaGun, 2);
     final String response =
-        delegate.canUnitsBePlaced(westCanada, GameDataTestUtil.getUnits(map, british), british);
+        delegate.canUnitsBePlaced(westCanada, create(british, aaGun, 2), british);
     assertError(response);
   }
 
   @Test
   void testProduceFactory() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(factory, 1);
-    final String response =
-        delegate.canUnitsBePlaced(egypt, GameDataTestUtil.getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(egypt, create(british, factory, 1), british);
     assertValid(response);
   }
 
   @Test
   void testMustOwnToPlace() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(infantry, 2);
     final String response =
-        delegate.canUnitsBePlaced(germany, GameDataTestUtil.getUnits(map, british), british);
+        delegate.canUnitsBePlaced(germany, create(british, infantry, 2), british);
     assertError(response);
   }
 
   @Test
   void testCanProduce() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(infantry, 2);
     final PlaceableUnits response =
-        delegate.getPlaceableUnits(GameDataTestUtil.getUnits(map, british), westCanada);
+        delegate.getPlaceableUnits(create(british, infantry, 2), westCanada);
     assertFalse(response.isError());
   }
 
   @Test
   void testCanProduceInSea() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(transport, 2);
     final PlaceableUnits response =
-        delegate.getPlaceableUnits(GameDataTestUtil.getUnits(map, british), northSea);
+        delegate.getPlaceableUnits(create(british, transport, 2), northSea);
     assertFalse(response.isError());
   }
 
   @Test
   void testCanNotProduceThatManyUnits() {
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(infantry, 3);
     final PlaceableUnits response =
-        delegate.getPlaceableUnits(GameDataTestUtil.getUnits(map, british), westCanada);
+        delegate.getPlaceableUnits(create(british, infantry, 3), westCanada);
     assertEquals(2, response.getMaxUnits());
   }
 
   @Test
   void testAlreadyProducedUnits() {
-    delegate.setProduced(Map.of(westCanada, infantry(gameData).create(2, british)));
-    final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(infantry, 1);
+    delegate.setProduced(Map.of(westCanada, create(british, infantry, 2)));
     final PlaceableUnits response =
-        delegate.getPlaceableUnits(GameDataTestUtil.getUnits(map, british), westCanada);
+        delegate.getPlaceableUnits(create(british, infantry, 1), westCanada);
     assertEquals(0, response.getMaxUnits());
   }
 
   @Test
   void testMultipleFactories() {
-    IntegerMap<UnitType> map = new IntegerMap<>();
-    map.add(factory, 1);
-    String response =
-        delegate.canUnitsBePlaced(egypt, GameDataTestUtil.getUnits(map, british), british);
+    String response = delegate.canUnitsBePlaced(egypt, create(british, factory, 1), british);
     // we can place 1 factory
     assertValid(response);
     // we can't place 2
-    map = new IntegerMap<>();
-    map.add(factory, 2);
-    response = delegate.canUnitsBePlaced(egypt, GameDataTestUtil.getUnits(map, british), british);
+    response = delegate.canUnitsBePlaced(egypt, create(british, factory, 2), british);
     assertError(response);
   }
 
   @Test
   void testUnitAttachmentStackingLimit() {
     // we can place 4
-    Collection<Unit> fourTanks = armour(gameData).create(4, british);
+    Collection<Unit> fourTanks = create(british, armour, 4);
     assertValid(delegate.canUnitsBePlaced(uk, fourTanks, british));
 
     // we can't place 5 per the unit attachment's placementLimit
-    Collection<Unit> fiveTanks = armour(gameData).create(5, british);
+    Collection<Unit> fiveTanks = create(british, armour,5);
     assertError(delegate.canUnitsBePlaced(uk, fiveTanks, british));
 
     // we can't place 3, if 2 are already scheduled to be placed
-    delegate.setProduced(Map.of(uk, armour(gameData).create(2, british)));
-    Collection<Unit> threeTanks = armour(gameData).create(5, british);
+    delegate.setProduced(Map.of(uk, create(british, armour, 2)));
+    Collection<Unit> threeTanks = create(british, armour, 3);
     assertError(delegate.canUnitsBePlaced(uk, threeTanks, british));
     // but we can place 2
-    Collection<Unit> twoTanks = armour(gameData).create(2, british);
+    Collection<Unit> twoTanks = create(british, armour, 2);
     assertValid(delegate.canUnitsBePlaced(uk, twoTanks, british));
 
     // we also can't place 3, if there's one in the territory and another scheduled to be placed.
-    delegate.setProduced(Map.of(uk, armour(gameData).create(1, british)));
-    uk.getUnitCollection().addAll(armour(gameData).create(1, british));
+    delegate.setProduced(Map.of(uk, create(british, armour, 1)));
+    uk.getUnitCollection().addAll(create(british, armour, 1));
     assertError(delegate.canUnitsBePlaced(uk, threeTanks, british));
     // but we can place 2
     assertValid(delegate.canUnitsBePlaced(uk, twoTanks, british));
@@ -230,18 +185,18 @@ class PlaceDelegateTest extends AbstractDelegateTestCase {
   @Test
   void testPlayerAttachmentStackingLimit() {
     // we can place 3 battleships
-    Collection<Unit> units = battleship(gameData).create(3, british);
+    Collection<Unit> units = create(british, battleship, 3);
     assertValid(delegate.canUnitsBePlaced(northSea, units, british));
     // but not 4
-    units = battleship(gameData).create(4, british);
+    units = create(british, battleship, 4);
     assertError(delegate.canUnitsBePlaced(northSea, units, british));
 
     // we can also place 2 battleships and a carrier
-    units = battleship(gameData).create(2, british);
-    units.addAll(carrier(gameData).create(1, british));
+    units = create(british, battleship,2);
+    units.addAll(create(british, carrier, 1));
     assertValid(delegate.canUnitsBePlaced(northSea, units, british));
     // but not 2 battleships and 2 carriers
-    units.addAll(carrier(gameData).create(1, british));
+    units.addAll(create(british, carrier, 1));
     assertError(delegate.canUnitsBePlaced(northSea, units, british));
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
@@ -1,0 +1,76 @@
+package games.strategy.triplea.delegate.move.validation;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
+import static games.strategy.triplea.delegate.GameDataTestUtil.battleship;
+import static games.strategy.triplea.delegate.GameDataTestUtil.carrier;
+import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
+import static games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter.PLACEMENT_LIMIT;
+import static games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter.filterUnits;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.triplea.java.collections.CollectionUtils.countMatches;
+
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.AbstractDelegateTestCase;
+import games.strategy.triplea.delegate.Matches;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UnitStackingLimitTest extends AbstractDelegateTestCase {
+
+  @Test
+  void testUnitAttachmentStackingLimit() {
+    // we can place 4
+    List<Unit> fourTanks = armour(gameData).create(4, british);
+    assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk), is(fourTanks));
+
+    // we can't place 5 per the unit attachment's placementLimit
+    List<Unit> fiveTanks = armour(gameData).create(5, british);
+    assertThat(filterUnits(fiveTanks, PLACEMENT_LIMIT, british, uk), hasSize(4));
+
+    // only 2 can be placed if 2 are already there
+    uk.getUnitCollection().addAll(armour(gameData).create(2, british));
+    assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk), hasSize(2));
+
+    // but we can include other units that don't have stacking limits in the list
+    // note: still with the two tanks already in the uk
+    List<Unit> twoInfantryAndFourTanks = infantry(gameData).create(2, british);
+    twoInfantryAndFourTanks.addAll(fourTanks);
+    assertThat(twoInfantryAndFourTanks, hasSize(6));
+    var result = filterUnits(twoInfantryAndFourTanks, PLACEMENT_LIMIT, british, uk);
+    assertThat(result, hasSize(4));
+    assertThat(countMatches(result, Matches.unitIsOfType(infantry(gameData))), is(2));
+    assertThat(countMatches(result, Matches.unitIsOfType(armour(gameData))), is(2));
+  }
+
+  @Test
+  void testPlayerAttachmentStackingLimit() {
+    // we can place 3 battleships
+    List<Unit> units = battleship(gameData).create(3, british);
+    assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), is(units));
+
+    // but not 4
+    units = battleship(gameData).create(4, british);
+    assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), hasSize(3));
+
+    // we can also place 2 battleships and a carrier
+    units = battleship(gameData).create(2, british);
+    units.addAll(carrier(gameData).create(1, british));
+    assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), is(units));
+
+    // but not 2 battleships and 2 carriers
+    units.addAll(carrier(gameData).create(1, british));
+    var expected = units.subList(0, 3);
+    assertThat(expected, hasSize(3));
+    assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), is(expected));
+
+    // and that the filtered units returned are in order
+    Collections.shuffle(units);
+    expected = units.subList(0, 3);
+    assertThat(expected, hasSize(3));
+    assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), is(expected));
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
@@ -1,9 +1,5 @@
 package games.strategy.triplea.delegate.move.validation;
 
-import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
-import static games.strategy.triplea.delegate.GameDataTestUtil.battleship;
-import static games.strategy.triplea.delegate.GameDataTestUtil.carrier;
-import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
 import static games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter.PLACEMENT_LIMIT;
 import static games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter.filterUnits;
 import static org.hamcrest.CoreMatchers.is;
@@ -24,45 +20,51 @@ class UnitStackingLimitTest extends AbstractDelegateTestCase {
   @Test
   void testUnitAttachmentStackingLimit() {
     // we can place 4
-    List<Unit> fourTanks = armour(gameData).create(4, british);
+    List<Unit> fourTanks = armour.create(4, british);
     assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk), is(fourTanks));
 
     // we can't place 5 per the unit attachment's placementLimit
-    List<Unit> fiveTanks = armour(gameData).create(5, british);
+    List<Unit> fiveTanks = armour.create(5, british);
     assertThat(filterUnits(fiveTanks, PLACEMENT_LIMIT, british, uk), hasSize(4));
 
     // only 2 can be placed if 2 are already there
-    uk.getUnitCollection().addAll(armour(gameData).create(2, british));
+    uk.getUnitCollection().addAll(armour.create(2, british));
     assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk), hasSize(2));
 
     // but we can include other units that don't have stacking limits in the list
     // note: still with the two tanks already in the uk
-    List<Unit> twoInfantryAndFourTanks = infantry(gameData).create(2, british);
+    List<Unit> twoInfantryAndFourTanks = infantry.create(2, british);
     twoInfantryAndFourTanks.addAll(fourTanks);
     assertThat(twoInfantryAndFourTanks, hasSize(6));
     var result = filterUnits(twoInfantryAndFourTanks, PLACEMENT_LIMIT, british, uk);
     assertThat(result, hasSize(4));
-    assertThat(countMatches(result, Matches.unitIsOfType(infantry(gameData))), is(2));
-    assertThat(countMatches(result, Matches.unitIsOfType(armour(gameData))), is(2));
+    assertThat(countMatches(result, Matches.unitIsOfType(infantry)), is(2));
+    assertThat(countMatches(result, Matches.unitIsOfType(armour)), is(2));
+  }
+
+  @Test
+  void testClassicAaStackingLimit() {
+    List<Unit> twoAa = aaGun.create(2, british);
+
   }
 
   @Test
   void testPlayerAttachmentStackingLimit() {
     // we can place 3 battleships
-    List<Unit> units = battleship(gameData).create(3, british);
+    List<Unit> units = battleship.create(3, british);
     assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), is(units));
 
     // but not 4
-    units = battleship(gameData).create(4, british);
+    units = battleship.create(4, british);
     assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), hasSize(3));
 
     // we can also place 2 battleships and a carrier
-    units = battleship(gameData).create(2, british);
-    units.addAll(carrier(gameData).create(1, british));
+    units = battleship.create(2, british);
+    units.addAll(carrier.create(1, british));
     assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), is(units));
 
     // but not 2 battleships and 2 carriers
-    units.addAll(carrier(gameData).create(1, british));
+    units.addAll(carrier.create(1, british));
     var expected = units.subList(0, 3);
     assertThat(expected, hasSize(3));
     assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), is(expected));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
@@ -5,12 +5,12 @@ import static games.strategy.triplea.delegate.move.validation.UnitStackingLimitF
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.triplea.java.collections.CollectionUtils.countMatches;
 
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.AbstractDelegateTestCase;
 import games.strategy.triplea.delegate.Matches;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -44,8 +44,13 @@ class UnitStackingLimitTest extends AbstractDelegateTestCase {
 
   @Test
   void testClassicAaStackingLimit() {
-    List<Unit> twoAa = aaGun.create(2, british);
+    // No more aa guns to be placed in UK.
+    List<Unit> units = aaGun.create(2, british);
+    assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), empty());
 
+    // Remove the aa gun in UK, now one can be placed.
+    uk.getUnitCollection().removeIf(Matches.unitIsOfType(aaGun));
+    assertThat(filterUnits(units, PLACEMENT_LIMIT, british, uk), hasSize(1));
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
@@ -24,9 +24,13 @@ class UnitStackingLimitTest extends AbstractDelegateTestCase {
     assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk), is(fourTanks));
 
     // the same four tanks are returned, even if we pass some existing units.
-    assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk, infantry.create(2, british)), is(fourTanks));
+    assertThat(
+        filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk, infantry.create(2, british)),
+        is(fourTanks));
     // and only 2 are returned if we pass 2 existing tanks
-    assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk, armour.create(2, british)), hasSize(2));
+    assertThat(
+        filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk, armour.create(2, british)),
+        hasSize(2));
 
     // we can't place 5 per the unit attachment's placementLimit
     List<Unit> fiveTanks = armour.create(5, british);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitTest.java
@@ -23,6 +23,11 @@ class UnitStackingLimitTest extends AbstractDelegateTestCase {
     List<Unit> fourTanks = armour.create(4, british);
     assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk), is(fourTanks));
 
+    // the same four tanks are returned, even if we pass some existing units.
+    assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk, infantry.create(2, british)), is(fourTanks));
+    // and only 2 are returned if we pass 2 existing tanks
+    assertThat(filterUnits(fourTanks, PLACEMENT_LIMIT, british, uk, armour.create(2, british)), hasSize(2));
+
     // we can't place 5 per the unit attachment's placementLimit
     List<Unit> fiveTanks = armour.create(5, british);
     assertThat(filterUnits(fiveTanks, PLACEMENT_LIMIT, british, uk), hasSize(4));

--- a/game-app/game-core/src/test/resources/DelegateTest.xml
+++ b/game-app/game-core/src/test/resources/DelegateTest.xml
@@ -631,7 +631,7 @@
     <attachmentList>
         <attachment name="unitAttachment"
             attachTo="infantry"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="movement" value="1"/>
             <option name="transportCost" value="1"/>
@@ -640,17 +640,18 @@
         </attachment>
         <attachment name="unitAttachment"
             attachTo="armour"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="movement" value="2"/>
             <option name="transportCost" value="2"/>
             <option name="canBlitz" value="true"/>
             <option name="attack" value="3"/>
             <option name="defense" value="2"/>
+            <option name="placementLimit" value="owned" count="4"/>
         </attachment>
         <attachment name="unitAttachment"
             attachTo="fighter"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="movement" value="4"/>
             <option name="carrierCost" value="1"/>
@@ -660,7 +661,7 @@
         </attachment>
         <attachment name="unitAttachment"
             attachTo="bomber"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="movement" value="6"/>
             <option name="isAir" value="true"/>
@@ -670,7 +671,7 @@
         </attachment>
         <attachment name="unitAttachment"
             attachTo="transport"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="movement" value="2"/>
             <option name="isSea" value="true"/>
@@ -680,7 +681,7 @@
         </attachment>
         <attachment name="unitAttachment"
             attachTo="battleship"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="movement" value="2"/>
             <option name="isSea" value="true"/>
@@ -690,7 +691,7 @@
         </attachment>
         <attachment name="unitAttachment"
             attachTo="carrier"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="carrierCapacity" value="2"/>
             <option name="movement" value="2"/>
@@ -700,7 +701,7 @@
         </attachment>
         <attachment name="unitAttachment"
             attachTo="submarine"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="isSub" value="true"/>
             <option name="movement" value="2"/>
@@ -711,532 +712,251 @@
 
         <attachment name="unitAttachment"
             attachTo="factory"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="isFactory" value="true"/>
         </attachment>
         <attachment name="unitAttachment"
             attachTo="aaGun"
-            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            javaClass="UnitAttachment"
             type="unitType">
             <option name="isAA" value="true"/>
             <option name="transportCost" value="2"/>
             <option name="movement" value="1"/>
         </attachment>
 
-
-
-
-        <attachment name="territoryAttachment"
-            attachTo="United Kingdom"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory">
+        <attachment name="territoryAttachment" attachTo="United Kingdom" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="10"/>
             <option name="capital" value="British"/>
             <option name="originalFactory" value="true"/>
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Japan"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory">
+        <attachment name="territoryAttachment" attachTo="Japan" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="10"/>
             <option name="capital" value="Japanese"/>
             <option name="originalFactory" value="true"/>
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Afghanistan"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Afghanistan" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Alaska"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Alaska" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Algeria"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Algeria" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Anglo Sudan Egypt"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Anglo Sudan Egypt" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Angola"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Angola" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Argentina-Chile"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Argentina-Chile" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Australia"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Australia" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Borneo Celebes"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Borneo Celebes" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Brazil"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Brazil" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Caroline Islands"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Caucasus"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Caucasus" javaClass="TerritoryAttachment"  type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="China"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="China" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Columbia"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Columbia" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Congo"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Congo" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Cuba"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Cuba" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="East Canada"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="East Canada" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="East Europe"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="East Europe" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="East Indies"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="East Indies" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="East US"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="East US" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Eire"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Eire" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Evenki National Okrug"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Evenki National Okrug" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Finland Norway"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Finland Norway" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="French Equatorial Africa"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="French Equatorial Africa" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="French Indo China"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="French Indo China" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="French West Africa"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="French West Africa" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Germany"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Germany" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Gibraltar"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Gibraltar" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Hawaiian Islands"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Hawaiian Islands" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="India"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="India" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Italian East Africa"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Italian East Africa" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Karelia S.S.R."
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Karelia S.S.R." javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Kazakh S.S.R."
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Kazakh S.S.R." javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Kenya-Rhodesia"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Kenya-Rhodesia" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Kwangtung"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Kwangtung" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Libya"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Libya" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Madagascar"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Madagascar" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Manchuria"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Manchuria" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Mexico"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Mexico" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Midway"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Midway" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Mongolia"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Mongolia" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Mozambique"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Mozambique" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="New Guinea"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="New Guinea" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="New Zealand"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="New Zealand" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Novosibirsk"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Novosibirsk" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Okinawa"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Okinawa" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Panama"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Panama" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Persia"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Persia" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Peru"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Peru" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Philippines"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Philippines" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Rio del Oro"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Rio del Oro" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Russia"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Russia" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Saudi Arabia"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Saudi Arabia" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Sinkiang"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Sinkiang" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Solomon Islands"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Solomon Islands" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="South Africa"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="South Africa" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="South Europe"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="South Europe" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Soviet Far East"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Soviet Far East" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Spain"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Spain" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Sweden"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Sweden" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Switzerland"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Switzerland" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Syria Jordan"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Syria Jordan" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Turkey"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Turkey" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Ukraine S.S.R."
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Ukraine S.S.R." javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Wake Island"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Wake Island" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="West Canada"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="West Canada" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="West Europe"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="West Europe" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="West US"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="West US" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
-        <attachment name="territoryAttachment"
-            attachTo="Yakut S.S.R."
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory"
-        >
+        <attachment name="territoryAttachment" attachTo="Yakut S.S.R." javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
         </attachment>
 
-        <attachment name="territoryAttachment"
-            attachTo="Yunnan"
-            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-            type="territory">
+        <attachment name="territoryAttachment" attachTo="Yunnan" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="1"/>
         </attachment>
 
-<!-- Chinese Rules -->
-                <attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                    <option name="movementRestrictionTerritories" value="Yunnan:Manchuria:Kwangtung"/>
-                    <option name="movementRestrictionType" value="allowed"/>
-                    <option name="productionPerXTerritories" value="2"/>
-                    <option name="placementAnyTerritory" value="true"/>
-                    <option name="placementCapturedTerritory" value="true"/>
-                    <option name="placementPerTerritory" value="3"/>
-                </attachment>
+        <attachment name="playerAttachment" attachTo="British" javaClass="PlayerAttachment" type="player">
+            <option name="placementLimit" value="owned:battleship:carrier" count="3"/>
+        </attachment>
 
+        <!-- Chinese Rules -->
+        <attachment name="rulesAttachment" attachTo="Chinese" javaClass="RulesAttachment" type="player">
+            <option name="movementRestrictionTerritories" value="Yunnan:Manchuria:Kwangtung"/>
+            <option name="movementRestrictionType" value="allowed"/>
+            <option name="productionPerXTerritories" value="2"/>
+            <option name="placementAnyTerritory" value="true"/>
+            <option name="placementCapturedTerritory" value="true"/>
+            <option name="placementPerTerritory" value="3"/>
+        </attachment>
 
     </attachmentList>
     <initialize>
@@ -1283,7 +1003,6 @@
             <unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British"/>
             <unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British"/>
             <unitPlacement unitType="transport" territory="North Sea Zone" quantity="2" owner="British"/>
-            <unitPlacement unitType="battleship" territory="North Sea Zone" quantity="1" owner="British" />
             <unitPlacement unitType="infantry" territory="North Sea Zone" quantity="4" owner="British" />
             <unitPlacement unitType="factory" territory="West Canada" quantity="1" owner="British"/>
 

--- a/game-app/game-core/src/test/resources/DelegateTest.xml
+++ b/game-app/game-core/src/test/resources/DelegateTest.xml
@@ -688,6 +688,8 @@
             <option name="attack" value="4"/>
             <option name="defense" value="4"/>
             <option name="canBombard" value="true"/>
+            <!-- For PlaceDelegateTest.testStackingLimitFilteringHappensAfterPlacementRestrictions() -->
+            <option name="unitPlacementRestrictions" value="West Canada Sea Zone"/>
         </attachment>
         <attachment name="unitAttachment"
             attachTo="carrier"
@@ -1078,19 +1080,23 @@
     <propertyList>
 
         <!-- OPTIONAL PROPERTIES -->
-        <property name="Place in Any Territory" value="true" editable="false">
+        <property name="Place in Any Territory" value="true">
             <boolean/>
         </property>
 
-        <property name="Unit Placement Per Territory Restricted" value="true" editable="false">
+        <property name="Unit Placement Restrictions" value="true">
             <boolean/>
         </property>
 
-        <property name="neutralCharge" value="3" editable="false">
+        <property name="Unit Placement Per Territory Restricted" value="true">
+            <boolean/>
+        </property>
+
+        <property name="neutralCharge" value="3">
             <number min="0" max="9999999"/>
         </property>
 
-        <property name="Heavy Bomber Dice Rolls" value="3" editable="false">
+        <property name="Heavy Bomber Dice Rolls" value="3">
             <number min="1" max="10"/>
         </property>
 

--- a/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.experimental.UtilityClass;
@@ -36,6 +37,20 @@ public class CollectionUtils {
     checkNotNull(predicate);
 
     return (int) collection.stream().filter(predicate).count();
+  }
+
+  /**
+   * Returns the count of elements in the specified iterable that match the specified predicate.
+   *
+   * @param it The iterable whose elements are to be matched.
+   * @param predicate The predicate with which to test each element.
+   * @return The count of elements in the specified collection that match the specified predicate.
+   */
+  public static <T> int countMatches(final Iterable<T> it, final Predicate<T> predicate) {
+    checkNotNull(it);
+    checkNotNull(predicate);
+
+    return (int) StreamSupport.stream(it.spliterator(), false).filter(predicate).count();
   }
 
   /**
@@ -72,7 +87,7 @@ public class CollectionUtils {
     return collection.stream().filter(predicate).limit(max).collect(Collectors.toList());
   }
 
-  /** return a such that a exists in c1 and a exists in c2. always returns a new collection. */
+  /** return a such that a exists in c1 and a exists in c2. Always returns a new collection. */
   public static <T> List<T> intersection(
       final Collection<T> collection1, final Collection<T> collection2) {
     if (collection1 == null


### PR DESCRIPTION
## Change Summary & Additional Notes

With this change, these restrictions are checked before showing the dialog of which units to place in a territory.
This way, invalid placements will be omitted from the dialog already, rather than showing up and causing an error when selected.

Tested on the "1941 Global Command Decision" map, where all the factory types have a stacking limit of 1 per territory. Before the change, if you build them and try to place units in a territory with a factory already, the factory would show up in the dialog. With the change, it will be omitted. (On this map, the presence of the factory in the list of units to place would also show an increased max for how many units can be placed for non-factory units - e.g. being able to select 3 infantry to place in a territory that only allows 2.)

This change refactors the code to move the stacking limits logic to a new UnitStackingLimitFilter class, combining the logic that was previously split between two places behind a better API that allows simplification of all the call sites.
Additional test coverage is added, both for the new class and for the PlaceDelegate, the latter also covering the sequence of the different calls (i.e. that placement restrictions are checked before stacking limit filtering).

Additionally, one call site no longer needed to do the checks as it was already doing the validation indirectly through another function it was calling.

The cleanup removes several hundred lines of code, although many lines of test code are also added,

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Unit placement dialog will now filter out units that can't be placed due to stacking limits coming from the PlayerAttachment.<!--END_RELEASE_NOTE-->
