### PR TITLE
Make CollectionUtils guarantee mutable return value.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -395,7 +395,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
         final Predicate<Unit> givesBonusUnit =
             Matches.alliedUnit(player).and(Matches.unitCanGiveBonusMovementToThisUnit(u));
         final Collection<Unit> givesBonusUnits =
-            new ArrayList<>(CollectionUtils.getMatches(t.getUnits(), givesBonusUnit));
+            CollectionUtils.getMatches(t.getUnits(), givesBonusUnit);
         if (Matches.unitIsSea().test(u)) {
           final Predicate<Unit> givesBonusUnitLand = givesBonusUnit.and(Matches.unitIsLand());
           final Set<Territory> neighbors =

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -289,7 +289,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
   }
 
   @Test
-  void testCantBlitzNuetral() {
+  void testCantBlitzNeutral() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 2);
     final Route route = new Route(equatorialAfrica, westAfrica, algeria);
@@ -710,19 +710,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     // move carriers to ensure they can't go anywhere
     route = new Route(congoSeaZone, westAfricaSea, northAtlantic);
     Collection<Unit> units =
-        new ArrayList<>(
             CollectionUtils.getMatches(
                 gameData.getMap().getTerritory(congoSeaZone.toString()).getUnits(),
-                Matches.unitIsCarrier()));
+                Matches.unitIsCarrier());
     results = delegate.move(units, route);
     assertValid(results);
     // move carriers to ensure they can't go anywhere
     route = new Route(redSea, eastMediteranean, blackSea);
-    units =
-        new ArrayList<>(
-            CollectionUtils.getMatches(
+    units = CollectionUtils.getMatches(
                 gameData.getMap().getTerritory(redSea.toString()).getUnits(),
-                Matches.unitIsCarrier()));
+                Matches.unitIsCarrier());
     results = delegate.move(units, route);
     assertValid(results);
     // make sure the place cant use it to land
@@ -989,8 +986,6 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     // Get the defending land units that and their number
     retreatingLandUnits.addAll(
         karelia.getUnitCollection().getMatches(Matches.isUnitAllied(british)));
-    final List<Unit> defendingLandUnits = new ArrayList<>();
-    final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inBalticSeaZone =
         gameData.getBattleDelegate().getBattleTracker().getPendingBattle(balticSeaZone);
@@ -1025,10 +1020,8 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final OffensiveGeneralRetreat offensiveGeneralRetreat =
         new OffensiveGeneralRetreat((BattleState) inBalticSeaZone, (BattleActions) inBalticSeaZone);
     offensiveGeneralRetreat.execute(mock(ExecutionStack.class), bridge);
-    // Get the total number of units that should be left
-    final int postCountInt = preCountInt - retreatingLandSizeInt;
     // Compare the number of units in Finland to begin with the number after retreating
-    assertEquals(defendingLandSizeInt, postCountInt);
+    assertEquals(preCountInt, retreatingLandSizeInt);
   }
 
   @Test
@@ -1052,11 +1045,8 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final List<Unit> retreatingLandUnits =
         new ArrayList<>(karelia.getUnitCollection().getMatches(Matches.isUnitAllied(russians)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
-    // Get the defending land units that and their number
-    final List<Unit> defendingLandUnits = new ArrayList<>();
     retreatingLandUnits.addAll(
         karelia.getUnitCollection().getMatches(Matches.isUnitAllied(british)));
-    final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inBalticSeaZone =
         gameData.getBattleDelegate().getBattleTracker().getPendingBattle(balticSeaZone);
@@ -1091,10 +1081,8 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final OffensiveGeneralRetreat offensiveGeneralRetreat =
         new OffensiveGeneralRetreat((BattleState) inBalticSeaZone, (BattleActions) inBalticSeaZone);
     offensiveGeneralRetreat.execute(mock(ExecutionStack.class), bridge);
-    // Get the total number of units that should be left
-    final int postCountInt = preCountInt - retreatingLandSizeInt;
     // Compare the number of units in Finland to begin with the number after retreating
-    assertEquals(defendingLandSizeInt, postCountInt);
+    assertEquals(preCountInt, retreatingLandSizeInt);
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -710,16 +710,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     // move carriers to ensure they can't go anywhere
     route = new Route(congoSeaZone, westAfricaSea, northAtlantic);
     Collection<Unit> units =
-            CollectionUtils.getMatches(
-                gameData.getMap().getTerritory(congoSeaZone.toString()).getUnits(),
-                Matches.unitIsCarrier());
+        CollectionUtils.getMatches(
+            gameData.getMap().getTerritory(congoSeaZone.toString()).getUnits(),
+            Matches.unitIsCarrier());
     results = delegate.move(units, route);
     assertValid(results);
     // move carriers to ensure they can't go anywhere
     route = new Route(redSea, eastMediteranean, blackSea);
-    units = CollectionUtils.getMatches(
-                gameData.getMap().getTerritory(redSea.toString()).getUnits(),
-                Matches.unitIsCarrier());
+    units =
+        CollectionUtils.getMatches(
+            gameData.getMap().getTerritory(redSea.toString()).getUnits(), Matches.unitIsCarrier());
     results = delegate.move(units, route);
     assertValid(results);
     // make sure the place cant use it to land

--- a/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
@@ -57,7 +57,7 @@ public class CollectionUtils {
   /**
    * Returns all elements in the specified collection that match the specified predicate.
    *
-   * Returns a mutable list with distinct storage from `collection`.
+   * <p>Returns a mutable list with distinct storage from `collection`.
    *
    * @param collection The collection whose elements are to be matched.
    * @param predicate The predicate with which to test each element.
@@ -75,7 +75,7 @@ public class CollectionUtils {
    * Returns the elements in the specified collection, up to the specified limit, that match the
    * specified predicate.
    *
-   * Returns a mutable list with distinct storage from `collection`.
+   * <p>Returns a mutable list with distinct storage from `collection`.
    *
    * @param collection The collection whose elements are to be matched.
    * @param max The maximum number of elements in the returned collection.
@@ -95,7 +95,7 @@ public class CollectionUtils {
   /**
    * Returns a such that a exists in c1 and a exists in c2. Always returns a new collection.
    *
-   * Returns a mutable list with distinct storage from `collection`.
+   * <p>Returns a mutable list with distinct storage from `collection`.
    */
   public static <T> List<T> intersection(
       final Collection<T> collection1, final Collection<T> collection2) {
@@ -113,7 +113,7 @@ public class CollectionUtils {
   /**
    * Returns a such that a exists in c1 but not in c2. Always returns a new collection.
    *
-   * Returns a mutable list with distinct storage from `collection`.
+   * <p>Returns a mutable list with distinct storage from `collection`.
    */
   public static <T> List<T> difference(
       final Collection<T> collection1, final Collection<T> collection2) {
@@ -148,7 +148,7 @@ public class CollectionUtils {
    * Creates a sorted, mutable collection containing the specified elements that will maintain its
    * sort order according to the specified comparator as elements are added or removed.
    *
-   * Returns a mutable collection with distinct storage from `elements`.
+   * <p>Returns a mutable collection with distinct storage from `elements`.
    */
   public static <T> Collection<T> createSortedCollection(
       final Collection<T> elements, final @Nullable Comparator<T> comparator) {

--- a/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
@@ -56,6 +57,8 @@ public class CollectionUtils {
   /**
    * Returns all elements in the specified collection that match the specified predicate.
    *
+   * Returns a mutable list with distinct storage from `collection`.
+   *
    * @param collection The collection whose elements are to be matched.
    * @param predicate The predicate with which to test each element.
    * @return A collection of all elements that match the specified predicate.
@@ -65,12 +68,14 @@ public class CollectionUtils {
     checkNotNull(collection);
     checkNotNull(predicate);
 
-    return collection.stream().filter(predicate).collect(Collectors.toList());
+    return collection.stream().filter(predicate).collect(toArrayList());
   }
 
   /**
    * Returns the elements in the specified collection, up to the specified limit, that match the
    * specified predicate.
+   *
+   * Returns a mutable list with distinct storage from `collection`.
    *
    * @param collection The collection whose elements are to be matched.
    * @param max The maximum number of elements in the returned collection.
@@ -84,10 +89,14 @@ public class CollectionUtils {
     checkArgument(max >= 0, "max must not be negative");
     checkNotNull(predicate);
 
-    return collection.stream().filter(predicate).limit(max).collect(Collectors.toList());
+    return collection.stream().filter(predicate).limit(max).collect(toArrayList());
   }
 
-  /** return a such that a exists in c1 and a exists in c2. Always returns a new collection. */
+  /**
+   * Returns a such that a exists in c1 and a exists in c2. Always returns a new collection.
+   *
+   * Returns a mutable list with distinct storage from `collection`.
+   */
   public static <T> List<T> intersection(
       final Collection<T> collection1, final Collection<T> collection2) {
     if (collection1 == null
@@ -98,10 +107,14 @@ public class CollectionUtils {
     }
     final Collection<T> c2 =
         (collection2 instanceof Set) ? collection2 : ImmutableSet.copyOf(collection2);
-    return collection1.stream().distinct().filter(c2::contains).collect(Collectors.toList());
+    return collection1.stream().distinct().filter(c2::contains).collect(toArrayList());
   }
 
-  /** Returns a such that a exists in c1 but not in c2. Always returns a new collection. */
+  /**
+   * Returns a such that a exists in c1 but not in c2. Always returns a new collection.
+   *
+   * Returns a mutable list with distinct storage from `collection`.
+   */
   public static <T> List<T> difference(
       final Collection<T> collection1, final Collection<T> collection2) {
     if (collection1 == null || collection1.isEmpty()) {
@@ -113,7 +126,7 @@ public class CollectionUtils {
 
     final Collection<T> c2 =
         (collection2 instanceof Set) ? collection2 : ImmutableSet.copyOf(collection2);
-    return collection1.stream().distinct().filter(not(c2::contains)).collect(Collectors.toList());
+    return collection1.stream().distinct().filter(not(c2::contains)).collect(toArrayList());
   }
 
   /**
@@ -134,6 +147,8 @@ public class CollectionUtils {
   /**
    * Creates a sorted, mutable collection containing the specified elements that will maintain its
    * sort order according to the specified comparator as elements are added or removed.
+   *
+   * Returns a mutable collection with distinct storage from `elements`.
    */
   public static <T> Collection<T> createSortedCollection(
       final Collection<T> elements, final @Nullable Comparator<T> comparator) {
@@ -144,5 +159,10 @@ public class CollectionUtils {
 
   public static <T> T getAny(final Iterable<T> elements) {
     return elements.iterator().next();
+  }
+
+  /** Like Collectors.toList() but guarantees that the returned object is a mutable ArrayList. */
+  public static <T> Collector<T, ?, List<T>> toArrayList() {
+    return Collectors.toCollection(ArrayList::new);
   }
 }

--- a/lib/java-extras/src/test/java/org/triplea/java/collections/CollectionUtilsTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/java/collections/CollectionUtilsTest.java
@@ -1,7 +1,10 @@
 package org.triplea.java.collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.triplea.java.collections.CollectionUtils.countMatches;
@@ -9,6 +12,7 @@ import static org.triplea.java.collections.CollectionUtils.getMatches;
 import static org.triplea.java.collections.CollectionUtils.getNMatches;
 import static org.triplea.java.collections.CollectionUtils.haveEqualSizeAndEquivalentElements;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
@@ -44,6 +48,26 @@ final class CollectionUtilsTest {
       assertEquals(List.of(), getMatches(input, NEVER), "none match");
       assertEquals(List.of(-1, 1), getMatches(input, IS_ZERO.negate()), "some match");
       assertEquals(List.of(-1, 0, 1), getMatches(input, ALWAYS), "all match");
+    }
+
+    @Test
+    void returnsDistinctInstanceWithDifferenceStorage() {
+      final Collection<Integer> input = new ArrayList<>(List.of(-1, 0, 1));
+      final List<Integer> result = getMatches(input, ALWAYS);
+      assertThat(result, equalTo(input));
+      assertThat(result, not(sameInstance(input)));
+      // Modifying input shouldn't change result.
+      input.add(5);
+      assertThat(result, not(equalTo(input)));
+    }
+
+    @Test
+    void returnsMutableInstance() {
+      final Collection<Integer> input = List.of(-1, 0, 1);
+      final List<Integer> result = getMatches(input, IS_ZERO.negate());
+      assertThat(result, equalTo(List.of(-1, 1)));
+      result.add(5);
+      assertThat(result, equalTo(List.of(-1, 1, 5)));
     }
   }
 


### PR DESCRIPTION
## Change Summary & Additional Notes

Previously, they used Collectors.toList() which did not provide any such guarantee in its API docs, but behind-the-scenes was implemented as returning a mutable collection.

As such, there's likely triplea code that depends on that implementation detail. This change makes that implementation detail an API guarantee.

Also cleans up a couple code places that were copying the result and a few other clean ups.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
