### PR TITLE
Fix JOptionPane scrollpane sizing logic.

### DIFF
--- a/lib/swing-lib/src/main/java/org/triplea/swing/EventThreadJOptionPane.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/EventThreadJOptionPane.java
@@ -136,7 +136,7 @@ public final class EventThreadJOptionPane {
     scroll.setBorder(BorderFactory.createEmptyBorder());
     scroll.addAncestorListener(
         new AncestorListener() {
-          private int getScrollbarSize() {
+          private int getScrollWidth() {
             Object scrollWidth = UIManager.get("ScrollBar.width");
             if (scrollWidth instanceof Integer) {
               return (Integer) scrollWidth;
@@ -149,10 +149,10 @@ public final class EventThreadJOptionPane {
             Rectangle maxBounds =
                 GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
             Rectangle r = event.getAncestor().getBounds();
-            boolean vScroll = (r.width > maxBounds.width);
-            boolean hScroll = (r.height > maxBounds.height);
-            r.width = Math.min(r.width + (hScroll ? getScrollbarSize() : 0), maxBounds.width);
-            r.height = Math.min(r.height + (vScroll ? getScrollbarSize() : 0), maxBounds.height);
+            boolean vertScroll = (r.width > maxBounds.width);
+            boolean horizScroll = (r.height > maxBounds.height);
+            r.width = Math.min(r.width + (horizScroll ? getScrollWidth() : 0), maxBounds.width);
+            r.height = Math.min(r.height + (vertScroll ? getScrollWidth() : 0), maxBounds.height);
             event.getAncestor().setBounds(r);
           }
 

--- a/lib/swing-lib/src/main/java/org/triplea/swing/EventThreadJOptionPane.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/EventThreadJOptionPane.java
@@ -4,8 +4,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Toolkit;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -19,6 +19,9 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.AncestorListener;
 import lombok.AllArgsConstructor;
 import org.triplea.java.concurrency.CountDownLatchHandler;
 
@@ -131,21 +134,34 @@ public final class EventThreadJOptionPane {
     final JLabel label = new JLabel(message);
     final JScrollPane scroll = new JScrollPane(label);
     scroll.setBorder(BorderFactory.createEmptyBorder());
-    final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
-    final int availWidth = screenResolution.width - 40;
-    final int availHeight = screenResolution.height - 140;
-    // add 25 for scrollbars
-    final int newWidth =
-        (scroll.getPreferredSize().width > availWidth
-            ? availWidth
-            : (scroll.getPreferredSize().width
-                + (scroll.getPreferredSize().height > availHeight ? 25 : 0)));
-    final int newHeight =
-        (scroll.getPreferredSize().height > availHeight
-            ? availHeight
-            : (scroll.getPreferredSize().height
-                + (scroll.getPreferredSize().width > availWidth ? 25 : 0)));
-    scroll.setPreferredSize(new Dimension(newWidth, newHeight));
+    scroll.addAncestorListener(
+        new AncestorListener() {
+          private int getScrollbarSize() {
+            Object scrollWidth = UIManager.get("ScrollBar.width");
+            if (scrollWidth instanceof Integer) {
+              return (Integer) scrollWidth;
+            }
+            return 25;
+          }
+
+          @Override
+          public void ancestorAdded(final AncestorEvent event) {
+            Rectangle maxBounds =
+                GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+            Rectangle r = event.getAncestor().getBounds();
+            boolean vScroll = (r.width > maxBounds.width);
+            boolean hScroll = (r.height > maxBounds.height);
+            r.width = Math.min(r.width + (hScroll ? getScrollbarSize() : 0), maxBounds.width);
+            r.height = Math.min(r.height + (vScroll ? getScrollbarSize() : 0), maxBounds.height);
+            event.getAncestor().setBounds(r);
+          }
+
+          @Override
+          public void ancestorRemoved(final AncestorEvent event) {}
+
+          @Override
+          public void ancestorMoved(final AncestorEvent event) {}
+        });
     return scroll;
   }
 


### PR DESCRIPTION
## Change Summary & Additional Notes
Do the sizing on the actual window, rather than the scrollpane with magic constant, so that all the other components of the window are taken into account. Use the correct ways to get available window size and scrollbar widths.

Fixes too large windows being shown on macOS at least when the dock and menubar are visible.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Resizing of notification windows that don't fit on the screen will now correctly fit the screen.<!--END_RELEASE_NOTE-->
