### PR TITLE
Fix another cause of "Could not find step name"

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Value;
@@ -119,4 +120,6 @@ public interface BattleState {
   @RemoveOnNextMajorRelease
   @Deprecated
   List<String> getStepStrings();
+
+  Optional<String> findStepNameForFiringUnits(Collection<Unit> firingUnits);
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -814,7 +814,7 @@ public class MustFightBattle extends DependentBattle
       stepStrings.add(stepName);
       if (details.getStep() instanceof SelectCasualties) {
         SelectCasualties step = (SelectCasualties) details.getStep();
-        // Note: We don't copy the list since the steps will be destroyed.
+        // Note: No need to copy since `step` is a temp that won't outlive this call.
         stepFiringUnits.put(stepName, step.getFiringGroup().getFiringUnits());
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -28,6 +28,7 @@ import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveGeneralRetr
 import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveSubsRetreat;
 import games.strategy.triplea.delegate.battle.steps.retreat.sub.SubmergeSubsVsOnlyAirStep;
 import java.util.List;
+import lombok.Value;
 
 /**
  * This is used to break up the battle into separate atomic pieces. If there is a network error, or
@@ -80,10 +81,16 @@ public interface BattleStep extends IExecutable {
     FIRE_ROUND_REMOVE_CASUALTIES,
   }
 
+  @Value
+  class StepDetails {
+    String name;
+    BattleStep step;
+  }
+
   /**
    * @return a list of names that will be shown in the UI.
    */
-  List<String> getNames();
+  List<StepDetails> getAllStepDetails();
 
   /**
    * @return The order in which this step should be called

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -15,10 +15,10 @@ public class BattleSteps implements BattleStepStrings {
   final BattleState battleState;
   final BattleActions battleActions;
 
-  public List<String> get() {
+  public List<BattleStep.StepDetails> get() {
     return BattleStep.getAll(battleState, battleActions).stream()
         .sorted(Comparator.comparing(BattleStep::getOrder))
-        .flatMap(step -> step.getNames().stream())
+        .flatMap(step -> step.getAllStepDetails().stream())
         .collect(Collectors.toList());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -47,7 +47,7 @@ public class CheckGeneralBattleEnd implements BattleStep {
   }
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return List.of();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
@@ -16,7 +16,7 @@ public class CheckStalemateBattleEnd extends CheckGeneralBattleEnd {
   }
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return List.of();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearAaCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearAaCasualties.java
@@ -17,7 +17,7 @@ public class ClearAaCasualties implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return List.of();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearBombardmentCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearBombardmentCasualties.java
@@ -20,9 +20,9 @@ public class ClearBombardmentCasualties implements BattleStep {
   private final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return canBombardmentOccur() && clearCasualties()
-        ? List.of(REMOVE_BOMBARDMENT_CASUALTIES)
+        ? List.of(new StepDetails(REMOVE_BOMBARDMENT_CASUALTIES, this))
         : List.of();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearGeneralCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearGeneralCasualties.java
@@ -19,8 +19,8 @@ public class ClearGeneralCasualties implements BattleStep {
   private final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
-    return List.of(REMOVE_CASUALTIES);
+  public List<StepDetails> getAllStepDetails() {
+    return List.of(new StepDetails(REMOVE_CASUALTIES, this));
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopers.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopers.java
@@ -28,8 +28,10 @@ public class LandParatroopers implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
-    return new TransportsAndParatroopers().hasParatroopers() ? List.of(LAND_PARATROOPS) : List.of();
+  public List<StepDetails> getAllStepDetails() {
+    return new TransportsAndParatroopers().hasParatroopers()
+        ? List.of(new StepDetails(LAND_PARATROOPS, this))
+        : List.of();
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeft.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeft.java
@@ -27,7 +27,7 @@ public class MarkNoMovementLeft implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return List.of();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatants.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatants.java
@@ -28,7 +28,7 @@ public class RemoveNonCombatants implements BattleStep {
   }
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return List.of();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnits.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnits.java
@@ -33,13 +33,13 @@ public class RemoveUnprotectedUnits implements BattleStep {
   private final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     if (battleState.getBattleSite().isWater()
         && Properties.getTransportCasualtiesRestricted(battleState.getGameData().getProperties())
         && (battleState.filterUnits(ALIVE, OFFENSE).stream().anyMatch(Matches.unitIsSeaTransport())
             || battleState.filterUnits(ALIVE, DEFENSE).stream()
                 .anyMatch(Matches.unitIsSeaTransport()))) {
-      return List.of(REMOVE_UNESCORTED_TRANSPORTS);
+      return List.of(new StepDetails(REMOVE_UNESCORTED_TRANSPORTS, this));
     }
     return List.of();
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnitsGeneral.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnitsGeneral.java
@@ -11,7 +11,7 @@ public class RemoveUnprotectedUnitsGeneral extends RemoveUnprotectedUnits {
   }
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return List.of();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/suicide/RemoveFirstStrikeSuicide.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/suicide/RemoveFirstStrikeSuicide.java
@@ -16,7 +16,7 @@ public class RemoveFirstStrikeSuicide extends RemoveUnits {
   }
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return List.of();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/suicide/RemoveGeneralSuicide.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/suicide/RemoveGeneralSuicide.java
@@ -15,7 +15,7 @@ public class RemoveGeneralSuicide extends RemoveUnits {
   }
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return List.of();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MarkCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MarkCasualties.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.triplea.java.ChangeOnNextMajorRelease;
@@ -49,8 +50,8 @@ public class MarkCasualties implements BattleStep {
   private final MustFightBattle.ReturnFire returnFire;
 
   @Override
-  public List<String> getNames() {
-    return List.of(getName());
+  public List<StepDetails> getAllStepDetails() {
+    return List.of(new StepDetails(getName(), this));
   }
 
   private String getName() {
@@ -159,6 +160,15 @@ public class MarkCasualties implements BattleStep {
       final String name) {
     if (battleState.getStepStrings().contains(name)) {
       return name;
+    }
+    // Try to find the original step name for these firing units at the time the step names shown in
+    // the UI were produced. It can happen that such a step no longer exists in the stack due to the
+    // units having changed due to previous steps, however the UI still has the original strings and
+    // we need to map to one of the ones shown. Match based on firing units.
+    Optional<String> stepName =
+        battleState.findStepNameForFiringUnits(firingGroup.getFiringUnits());
+    if (stepName.isPresent()) {
+      return stepName.get();
     }
 
     // this is from a save game and so must use the old step name

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardment.java
@@ -41,11 +41,11 @@ public class NavalBombardment implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return !valid()
         ? List.of()
         : getSteps().stream()
-            .flatMap(step -> step.getNames().stream())
+            .flatMap(step -> step.getAllStepDetails().stream())
             .collect(Collectors.toList());
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollDiceStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollDiceStep.java
@@ -32,8 +32,8 @@ public class RollDiceStep implements BattleStep {
   private final BiFunction<IDelegateBridge, RollDiceStep, DiceRoll> rollDice;
 
   @Override
-  public List<String> getNames() {
-    return List.of(getName());
+  public List<StepDetails> getAllStepDetails() {
+    return List.of(new StepDetails(getName(), this));
   }
 
   private String getName() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectCasualties.java
@@ -37,8 +37,8 @@ public class SelectCasualties implements BattleStep {
   private final BiFunction<IDelegateBridge, SelectCasualties, CasualtyDetails> selectCasualties;
 
   @Override
-  public List<String> getNames() {
-    return List.of(getName());
+  public List<StepDetails> getAllStepDetails() {
+    return List.of(new StepDetails(getName(), this));
   }
 
   private String getName() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
@@ -34,9 +34,9 @@ public abstract class AaFireAndCasualtyStep implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return getSteps().stream()
-        .flatMap(step -> step.getNames().stream())
+        .flatMap(step -> step.getAllStepDetails().stream())
         .collect(Collectors.toList());
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
@@ -20,8 +20,8 @@ public class AirAttackVsNonSubsStep extends AirVsNonSubsStep {
   }
 
   @Override
-  public List<String> getNames() {
-    return valid() ? List.of(AIR_ATTACK_NON_SUBS) : List.of();
+  public List<StepDetails> getAllStepDetails() {
+    return valid() ? List.of(new StepDetails(AIR_ATTACK_NON_SUBS, this)) : List.of();
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
@@ -20,8 +20,8 @@ public class AirDefendVsNonSubsStep extends AirVsNonSubsStep {
   }
 
   @Override
-  public List<String> getNames() {
-    return valid() ? List.of(AIR_DEFEND_NON_SUBS) : List.of();
+  public List<StepDetails> getAllStepDetails() {
+    return valid() ? List.of(new StepDetails(AIR_DEFEND_NON_SUBS, this)) : List.of();
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualties.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -70,12 +69,11 @@ public class ClearFirstStrikeCasualties implements BattleStep {
   }
 
   @Override
-  public List<String> getNames() {
-    final List<String> steps = new ArrayList<>();
+  public List<StepDetails> getAllStepDetails() {
     if (offenseHasSneakAttack() || defenseHasSneakAttack()) {
-      steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
+      return List.of(new StepDetails(REMOVE_SNEAK_ATTACK_CASUALTIES, this));
     }
-    return steps;
+    return List.of();
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/DefensiveFirstStrike.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/DefensiveFirstStrike.java
@@ -82,11 +82,11 @@ public class DefensiveFirstStrike implements BattleStep {
   }
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return this.state == State.NOT_APPLICABLE
         ? List.of()
         : getSteps().stream()
-            .flatMap(step -> step.getNames().stream())
+            .flatMap(step -> step.getAllStepDetails().stream())
             .collect(Collectors.toList());
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/OffensiveFirstStrike.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/OffensiveFirstStrike.java
@@ -80,11 +80,11 @@ public class OffensiveFirstStrike implements BattleStep {
   }
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return this.state == State.NOT_APPLICABLE
         ? List.of()
         : getSteps().stream()
-            .flatMap(step -> step.getNames().stream())
+            .flatMap(step -> step.getAllStepDetails().stream())
             .collect(Collectors.toList());
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/DefensiveGeneral.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/DefensiveGeneral.java
@@ -34,9 +34,9 @@ public class DefensiveGeneral implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return getSteps().stream()
-        .flatMap(step -> step.getNames().stream())
+        .flatMap(step -> step.getAllStepDetails().stream())
         .collect(Collectors.toList());
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/OffensiveGeneral.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/OffensiveGeneral.java
@@ -34,9 +34,9 @@ public class OffensiveGeneral implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     return getSteps().stream()
-        .flatMap(step -> step.getNames().stream())
+        .flatMap(step -> step.getAllStepDetails().stream())
         .collect(Collectors.toList());
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -37,7 +37,7 @@ public class DefensiveSubsRetreat implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     // even though the #execute method checks for destroyers, we don't do it here
     // because this is called at the beginning of the round and any destroyer that exists
     // might die before the #execute is called
@@ -45,7 +45,7 @@ public class DefensiveSubsRetreat implements BattleStep {
       return List.of();
     }
 
-    return List.of(getName());
+    return List.of(new StepDetails(getName(), this));
   }
 
   private String getName() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
@@ -36,8 +36,8 @@ public class OffensiveGeneralRetreat implements BattleStep {
   private final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
-    return isRetreatPossible() ? List.of(getName()) : List.of();
+  public List<StepDetails> getAllStepDetails() {
+    return isRetreatPossible() ? List.of(new StepDetails(getName(), this)) : List.of();
   }
 
   private boolean isRetreatPossible() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
@@ -33,7 +33,7 @@ public class OffensiveSubsRetreat implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
+  public List<StepDetails> getAllStepDetails() {
     // even though the #execute method checks for destroyers, we don't do it here
     // because this is called at the beginning of the round and any destroyer that exists
     // might die before the #execute is called
@@ -41,7 +41,7 @@ public class OffensiveSubsRetreat implements BattleStep {
       return List.of();
     }
 
-    return List.of(getName());
+    return List.of(new StepDetails(getName(), this));
   }
 
   private String getName() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
@@ -32,8 +32,8 @@ public class SubmergeSubsVsOnlyAirStep implements BattleStep {
   protected final BattleActions battleActions;
 
   @Override
-  public List<String> getNames() {
-    return valid() ? List.of(SUBMERGE_SUBS_VS_AIR_ONLY) : List.of();
+  public List<StepDetails> getAllStepDetails() {
+    return valid() ? List.of(new StepDetails(SUBMERGE_SUBS_VS_AIR_ONLY, this)) : List.of();
   }
 
   @Override

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -176,6 +177,11 @@ public class FakeBattleState implements BattleState {
   @Override
   public List<String> getStepStrings() {
     return List.of();
+  }
+
+  @Override
+  public Optional<String> findStepNameForFiringUnits(final Collection<Unit> firingUnits) {
+    return Optional.empty();
   }
 
   public static FakeBattleState.FakeBattleStateBuilder givenBattleStateBuilder(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
@@ -1,10 +1,14 @@
 package games.strategy.triplea.delegate.battle;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
+import static games.strategy.triplea.delegate.GameDataTestUtil.artillery;
 import static games.strategy.triplea.delegate.GameDataTestUtil.battleDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.britain;
 import static games.strategy.triplea.delegate.GameDataTestUtil.britishArtillery;
 import static games.strategy.triplea.delegate.GameDataTestUtil.britishInfantry;
+import static games.strategy.triplea.delegate.GameDataTestUtil.chinese;
+import static games.strategy.triplea.delegate.GameDataTestUtil.fighter;
+import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
 import static games.strategy.triplea.delegate.GameDataTestUtil.japan;
 import static games.strategy.triplea.delegate.GameDataTestUtil.japaneseInfantry;
 import static games.strategy.triplea.delegate.GameDataTestUtil.move;
@@ -19,17 +23,23 @@ import static games.strategy.triplea.delegate.MockDelegateBridge.withDiceValues;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.display.IDisplay;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
@@ -93,10 +103,7 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
   @Test
   void testCasualtyDefendersProvideSupport() throws Exception {
     final GameData gameData = TestMapGameData.TWW.getGameData();
-    IEditableProperty<Boolean> lowLuck =
-        (IEditableProperty<Boolean>)
-            gameData.getProperties().getEditablePropertiesByName().get(Constants.LOW_LUCK);
-    lowLuck.setValue(false);
+    setPropertyValue(gameData, Constants.LOW_LUCK, false);
 
     // Add a support rule to make british artillery provide an extra die to british infantry.
     var supportAttachment =
@@ -135,6 +142,82 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
     battle.fight(bridge);
     // Attackers killed the two defenders, while defenders failed to hit anything.
     assertThat(burma.getUnits(), containsInAnyOrder(attackers.toArray()));
+  }
+
+  @Test
+  void testStepNamesChangeDuringCombat() {
+    final GameData gameData = TestMapGameData.VICTORY_TEST.getGameData();
+    setPropertyValue(gameData, Constants.LOW_LUCK, false);
+    setPropertyValue(gameData, Constants.LL_AA_ONLY, false);
+
+    // Set up a chinese attack with infantry + fighter against a japanese infantry + artillery.
+    // The units on the test map have been modified as follows:
+    //   fighter has an offensive "AA" attack that can hit an artillery only.
+    //   artillery has canNotTarget="fighter"
+    //
+    // We're testing the scenario where casualty steps will change after initial step names are
+    // generated. Initially, since defenders can target different units, there will be multiple
+    // casualty steps for attackers corresponding to the defending units dice roll steps.
+    // But then, when an artillery will die due to offensive AA and not get a counterattack, the
+    // casualty steps will become a single one. We're testing that this won't hit an error.
+    // The error itself ("Could not find step name:") would typically happen in the UI code via
+    // TripleADisplay, but this test can only validate that all invocations of notifyDice() pass
+    // a valid step name (that exists in the MustFightBattle's stepNames list).
+
+    final Territory china = territory("China", gameData);
+    removeFrom(china, china.getUnits());
+    addTo(china, infantry(gameData).create(1, chinese(gameData)));
+    addTo(china, fighter(gameData).create(1, chinese(gameData)));
+    // We'll need 3 fuel to move the fighter...
+    final Resource fuel = gameData.getResourceList().getResource("Fuel");
+    chinese(gameData).getResources().addResource(fuel, 3);
+
+    final Territory indoChina = territory("French Indochina", gameData);
+    removeFrom(indoChina, indoChina.getUnits());
+    addTo(indoChina, infantry(gameData).create(1, japan(gameData)));
+    addTo(indoChina, artillery(gameData).create(1, japan(gameData)));
+
+    final Collection<Unit> attackers = List.copyOf(china.getUnits());
+    final IDelegateBridge bridge =
+        performCombatMove(chinese(gameData), attackers, new Route(china, indoChina));
+
+    final IBattle battle =
+        AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(indoChina);
+    assertNotNull(battle);
+
+    whenGetRandom(bridge)
+        // First, there's an offensive AA roll by the fighter (hit).
+        .thenAnswer(withDiceValues(1))
+        // Then regular combat rolls, one by fighter and another by infantry.
+        .thenAnswer(withDiceValues(1, 1))
+        // Then the casualty infantry rolls.
+        .thenAnswer(withDiceValues(6));
+
+    // Ensure that all step names passed to notifyDice() exist in the battle's stepStrings.
+    // This verifies what the real TripleADisplay's notifyDice() does (since it tries to select a
+    // step in the UI created from stepStrings).
+    // This verifies the MustFightBattle.findStepNameForFiringUnits() logic (and its caller) is able
+    // to find the appropriate step even when the set of step names changes mid-battle.
+    IDisplay display = bridge.getDisplayChannelBroadcaster();
+    doAnswer(
+            invocation -> {
+              String stepName = invocation.getArgument(1);
+              List<String> stepNames = ((MustFightBattle) battle).getStepStrings();
+              assertThat(stepName, in(stepNames));
+              return null;
+            })
+        .when(display)
+        .notifyDice(any(), anyString());
+
+    battle.fight(bridge);
+    assertThat(indoChina.getUnits(), containsInAnyOrder(attackers.toArray()));
+  }
+
+  private static <T> void setPropertyValue(GameData gameData, String propertyName, T value) {
+    IEditableProperty<T> property =
+        (IEditableProperty<T>)
+            gameData.getProperties().getEditablePropertiesByName().get(propertyName);
+    property.setValue(value);
   }
 
   private IDelegateBridge performCombatMove(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -309,7 +309,10 @@ public class BattleStepsTest {
         .battleActions(battleActions)
         .battleState(battleState)
         .build()
-        .get();
+        .get()
+        .stream()
+        .map(BattleStep.StepDetails::getName)
+        .collect(Collectors.toList());
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopersTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopersTest.java
@@ -42,7 +42,7 @@ class LandParatroopersTest {
     final BattleState battleState = givenBattleStateBuilder().battleRound(2).build();
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
-    assertThat(landParatroopers.getNames(), is(empty()));
+    assertThat(landParatroopers.getAllStepDetails(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
     verify(delegateBridge, never()).addChange(any(Change.class));
@@ -54,7 +54,7 @@ class LandParatroopersTest {
         givenBattleStateBuilder().battleRound(1).battleSite(givenSeaBattleSite()).build();
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
-    assertThat(landParatroopers.getNames(), is(empty()));
+    assertThat(landParatroopers.getAllStepDetails(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
     verify(delegateBridge, never()).addChange(any(Change.class));
@@ -70,7 +70,7 @@ class LandParatroopersTest {
         givenBattleStateBuilder().battleRound(1).attacker(attacker).build();
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
-    assertThat(landParatroopers.getNames(), is(empty()));
+    assertThat(landParatroopers.getAllStepDetails(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
     verify(delegateBridge, never()).addChange(any(Change.class));
@@ -101,7 +101,7 @@ class LandParatroopersTest {
 
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
-    assertThat(landParatroopers.getNames(), is(empty()));
+    assertThat(landParatroopers.getAllStepDetails(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
     verify(delegateBridge, never()).addChange(any(Change.class));
@@ -133,7 +133,7 @@ class LandParatroopersTest {
 
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
-    assertThat(landParatroopers.getNames(), hasSize(1));
+    assertThat(landParatroopers.getAllStepDetails(), hasSize(1));
 
     landParatroopers.execute(executionStack, delegateBridge);
     verify(delegateBridge).addChange(any(Change.class));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnitsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnitsTest.java
@@ -55,7 +55,7 @@ class RemoveUnprotectedUnitsTest {
       final BattleState battleState = givenBattleStateBuilder().battleSite(battleSite).build();
       final RemoveUnprotectedUnits removeUnprotectedUnits =
           new RemoveUnprotectedUnits(battleState, battleActions);
-      assertThat(removeUnprotectedUnits.getNames(), is(empty()));
+      assertThat(removeUnprotectedUnits.getAllStepDetails(), is(empty()));
     }
 
     @Test
@@ -66,7 +66,7 @@ class RemoveUnprotectedUnitsTest {
           givenBattleStateBuilder().battleSite(battleSite).gameData(gameData).build();
       final RemoveUnprotectedUnits removeUnprotectedUnits =
           new RemoveUnprotectedUnits(battleState, battleActions);
-      assertThat(removeUnprotectedUnits.getNames(), is(empty()));
+      assertThat(removeUnprotectedUnits.getAllStepDetails(), is(empty()));
     }
 
     @Test
@@ -82,7 +82,7 @@ class RemoveUnprotectedUnitsTest {
               .build();
       final RemoveUnprotectedUnits removeUnprotectedUnits =
           new RemoveUnprotectedUnits(battleState, battleActions);
-      assertThat(removeUnprotectedUnits.getNames(), is(empty()));
+      assertThat(removeUnprotectedUnits.getAllStepDetails(), is(empty()));
     }
 
     @Test
@@ -97,7 +97,7 @@ class RemoveUnprotectedUnitsTest {
               .build();
       final RemoveUnprotectedUnits removeUnprotectedUnits =
           new RemoveUnprotectedUnits(battleState, battleActions);
-      assertThat(removeUnprotectedUnits.getNames(), hasSize(1));
+      assertThat(removeUnprotectedUnits.getAllStepDetails(), hasSize(1));
     }
 
     @Test
@@ -112,7 +112,7 @@ class RemoveUnprotectedUnitsTest {
               .build();
       final RemoveUnprotectedUnits removeUnprotectedUnits =
           new RemoveUnprotectedUnits(battleState, battleActions);
-      assertThat(removeUnprotectedUnits.getNames(), hasSize(1));
+      assertThat(removeUnprotectedUnits.getAllStepDetails(), hasSize(1));
     }
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundStepsFactoryTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundStepsFactoryTest.java
@@ -57,7 +57,9 @@ class FireRoundStepsFactoryTest {
   }
 
   private List<String> getStepNames(final List<BattleStep> steps) {
-    return steps.stream().flatMap(step -> step.getNames().stream()).collect(Collectors.toList());
+    return steps.stream()
+        .flatMap(step -> step.getAllStepDetails().stream())
+        .collect(Collectors.toList());
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundStepsFactoryTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundStepsFactoryTest.java
@@ -59,6 +59,7 @@ class FireRoundStepsFactoryTest {
   private List<String> getStepNames(final List<BattleStep> steps) {
     return steps.stream()
         .flatMap(step -> step.getAllStepDetails().stream())
+        .map(BattleStep.StepDetails::getName)
         .collect(Collectors.toList());
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardmentTest.java
@@ -57,7 +57,7 @@ class NavalBombardmentTest {
             .build();
 
     final NavalBombardment navalBombardment = new NavalBombardment(battleState, battleActions);
-    assertThat(navalBombardment.getNames(), hasSize(3));
+    assertThat(navalBombardment.getAllStepDetails(), hasSize(3));
 
     navalBombardment.execute(executionStack, delegateBridge);
     verify(executionStack, times(3)).push(any());
@@ -72,7 +72,7 @@ class NavalBombardmentTest {
             .battleRound(2)
             .build();
     final NavalBombardment navalBombardment = new NavalBombardment(battleState, battleActions);
-    assertThat(navalBombardment.getNames(), is(empty()));
+    assertThat(navalBombardment.getAllStepDetails(), is(empty()));
     navalBombardment.execute(executionStack, delegateBridge);
     verify(executionStack, never()).push(any());
   }
@@ -86,7 +86,7 @@ class NavalBombardmentTest {
             .battleRound(1)
             .build();
     final NavalBombardment navalBombardment = new NavalBombardment(battleState, battleActions);
-    assertThat(navalBombardment.getNames(), is(empty()));
+    assertThat(navalBombardment.getAllStepDetails(), is(empty()));
     navalBombardment.execute(executionStack, delegateBridge);
     verify(executionStack, never()).push(any());
   }
@@ -101,7 +101,7 @@ class NavalBombardmentTest {
             .battleSite(givenSeaBattleSite())
             .build();
     final NavalBombardment navalBombardment = new NavalBombardment(battleState, battleActions);
-    assertThat(navalBombardment.getNames(), is(empty()));
+    assertThat(navalBombardment.getAllStepDetails(), is(empty()));
     navalBombardment.execute(executionStack, delegateBridge);
     verify(executionStack, never()).push(any());
   }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -54,14 +54,14 @@ class DefensiveAaFireTest {
               .defendingUnits(List.of(aaUnit))
               .build();
       final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-      assertThat(defensiveAaFire.getNames(), hasSize(3));
+      assertThat(defensiveAaFire.getAllStepDetails(), hasSize(3));
     }
 
     @Test
     void hasNoNamesIfNoAaIsAvailable() {
       final BattleState battleState = givenBattleStateBuilder().defendingUnits(List.of()).build();
       final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-      assertThat(defensiveAaFire.getNames(), is(empty()));
+      assertThat(defensiveAaFire.getAllStepDetails(), is(empty()));
     }
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -54,14 +54,14 @@ class OffensiveAaFireTest {
               .defendingUnits(List.of(targetUnit))
               .build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-      assertThat(offensiveAaFire.getNames(), hasSize(3));
+      assertThat(offensiveAaFire.getAllStepDetails(), hasSize(3));
     }
 
     @Test
     void hasNoNamesIfNoAaIsAvailable() {
       final BattleState battleState = givenBattleStateBuilder().attackingUnits(List.of()).build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-      assertThat(offensiveAaFire.getNames(), is(empty()));
+      assertThat(offensiveAaFire.getAllStepDetails(), is(empty()));
     }
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
@@ -26,7 +26,7 @@ class AirAttackVsNonSubsStepTest {
   @MethodSource
   void stepName(final String displayName, final BattleState battleState, final boolean expected) {
     final AirAttackVsNonSubsStep airAttackVsNonSubsStep = new AirAttackVsNonSubsStep(battleState);
-    assertThat(airAttackVsNonSubsStep.getNames(), hasSize(expected ? 1 : 0));
+    assertThat(airAttackVsNonSubsStep.getAllStepDetails(), hasSize(expected ? 1 : 0));
   }
 
   static List<Arguments> stepName() {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
@@ -26,7 +26,7 @@ class AirDefendVsNonSubsStepTest {
   @MethodSource
   void stepName(final String displayName, final BattleState battleState, final boolean expected) {
     final AirDefendVsNonSubsStep airDefendVsNonSubsStep = new AirDefendVsNonSubsStep(battleState);
-    assertThat(airDefendVsNonSubsStep.getNames(), hasSize(expected ? 1 : 0));
+    assertThat(airDefendVsNonSubsStep.getAllStepDetails(), hasSize(expected ? 1 : 0));
   }
 
   static List<Arguments> stepName() {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualtiesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualtiesTest.java
@@ -39,7 +39,7 @@ class ClearFirstStrikeCasualtiesTest {
     final ClearFirstStrikeCasualties clearFirstStrikeCasualties =
         new ClearFirstStrikeCasualties(battleState, battleActions);
 
-    assertThat(clearFirstStrikeCasualties.getNames(), hasSize(sides.isEmpty() ? 0 : 1));
+    assertThat(clearFirstStrikeCasualties.getAllStepDetails(), hasSize(sides.isEmpty() ? 0 : 1));
 
     clearFirstStrikeCasualties.execute(executionStack, delegateBridge);
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/DefensiveFirstStrikeTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/DefensiveFirstStrikeTest.java
@@ -40,7 +40,7 @@ class DefensiveFirstStrikeTest {
 
     final DefensiveFirstStrike defensiveFirstStrike =
         new DefensiveFirstStrike(battleState, battleActions);
-    assertThat(defensiveFirstStrike.getNames(), is(empty()));
+    assertThat(defensiveFirstStrike.getAllStepDetails(), is(empty()));
 
     defensiveFirstStrike.execute(executionStack, delegateBridge);
     verify(executionStack, never()).push(any());
@@ -54,7 +54,7 @@ class DefensiveFirstStrikeTest {
 
     final DefensiveFirstStrike defensiveFirstStrike =
         new DefensiveFirstStrike(battleState, battleActions);
-    assertThat(defensiveFirstStrike.getNames(), hasSize(3));
+    assertThat(defensiveFirstStrike.getAllStepDetails(), hasSize(3));
     assertThat(defensiveFirstStrike.getOrder(), is(stepOrder));
 
     defensiveFirstStrike.execute(executionStack, delegateBridge);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/OffensiveFirstStrikeTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/OffensiveFirstStrikeTest.java
@@ -41,7 +41,7 @@ class OffensiveFirstStrikeTest {
 
     final OffensiveFirstStrike offensiveFirstStrike =
         new OffensiveFirstStrike(battleState, battleActions);
-    assertThat(offensiveFirstStrike.getNames(), is(empty()));
+    assertThat(offensiveFirstStrike.getAllStepDetails(), is(empty()));
 
     offensiveFirstStrike.execute(executionStack, delegateBridge);
     verify(executionStack, never()).push(any());
@@ -57,7 +57,7 @@ class OffensiveFirstStrikeTest {
 
     final OffensiveFirstStrike offensiveFirstStrike =
         new OffensiveFirstStrike(battleState, battleActions);
-    assertThat(offensiveFirstStrike.getNames(), hasSize(3));
+    assertThat(offensiveFirstStrike.getAllStepDetails(), hasSize(3));
     assertThat(offensiveFirstStrike.getOrder(), is(stepOrder));
 
     offensiveFirstStrike.execute(executionStack, delegateBridge);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/DefensiveGeneralTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/DefensiveGeneralTest.java
@@ -37,7 +37,7 @@ class DefensiveGeneralTest {
               .gameData(gameData)
               .build();
       final DefensiveGeneral defensiveGeneral = new DefensiveGeneral(battleState, battleActions);
-      assertThat(defensiveGeneral.getNames(), hasSize(3));
+      assertThat(defensiveGeneral.getAllStepDetails(), hasSize(3));
     }
 
     @Test
@@ -51,7 +51,7 @@ class DefensiveGeneralTest {
               .gameData(gameData)
               .build();
       final DefensiveGeneral defensiveGeneral = new DefensiveGeneral(battleState, battleActions);
-      assertThat(defensiveGeneral.getNames(), is(empty()));
+      assertThat(defensiveGeneral.getAllStepDetails(), is(empty()));
     }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/OffensiveGeneralTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/OffensiveGeneralTest.java
@@ -34,7 +34,7 @@ class OffensiveGeneralTest {
               .defendingUnits(List.of(givenAnyUnit()))
               .build();
       final OffensiveGeneral offensiveGeneral = new OffensiveGeneral(battleState, battleActions);
-      assertThat(offensiveGeneral.getNames(), hasSize(3));
+      assertThat(offensiveGeneral.getAllStepDetails(), hasSize(3));
     }
 
     @Test
@@ -46,7 +46,7 @@ class OffensiveGeneralTest {
               .defendingUnits(List.of(givenAnyUnit()))
               .build();
       final OffensiveGeneral offensiveGeneral = new OffensiveGeneral(battleState, battleActions);
-      assertThat(offensiveGeneral.getNames(), is(empty()));
+      assertThat(offensiveGeneral.getAllStepDetails(), is(empty()));
     }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
@@ -71,7 +71,7 @@ class DefensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final DefensiveSubsRetreat defensiveSubsRetreat =
         new DefensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(defensiveSubsRetreat.getNames(), hasSize(1));
+    assertThat(defensiveSubsRetreat.getAllStepDetails(), hasSize(1));
   }
 
   @Test
@@ -84,7 +84,7 @@ class DefensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final DefensiveSubsRetreat defensiveSubsRetreat =
         new DefensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(defensiveSubsRetreat.getNames(), hasSize(1));
+    assertThat(defensiveSubsRetreat.getAllStepDetails(), hasSize(1));
   }
 
   @Test
@@ -99,7 +99,7 @@ class DefensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final DefensiveSubsRetreat defensiveSubsRetreat =
         new DefensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(defensiveSubsRetreat.getNames(), hasSize(1));
+    assertThat(defensiveSubsRetreat.getAllStepDetails(), hasSize(1));
   }
 
   @Test
@@ -113,7 +113,7 @@ class DefensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final DefensiveSubsRetreat defensiveSubsRetreat =
         new DefensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(defensiveSubsRetreat.getNames(), hasSize(1));
+    assertThat(defensiveSubsRetreat.getAllStepDetails(), hasSize(1));
   }
 
   @Test
@@ -123,7 +123,7 @@ class DefensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final DefensiveSubsRetreat defensiveSubsRetreat =
         new DefensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(defensiveSubsRetreat.getNames(), is(empty()));
+    assertThat(defensiveSubsRetreat.getAllStepDetails(), is(empty()));
   }
 
   @Nested

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreatTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreatTest.java
@@ -70,7 +70,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), is(empty()));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), is(empty()));
         final UnitAttachment unitAttachment =
             (UnitAttachment) unit.getType().getAttachment(UNIT_ATTACHMENT_NAME);
         // ensure it didn't even try to check if there are planes
@@ -89,7 +89,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), hasSize(1));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), hasSize(1));
         final UnitAttachment unitAttachment =
             (UnitAttachment) unit.getType().getAttachment(UNIT_ATTACHMENT_NAME);
         verify(unitAttachment).getIsAir();
@@ -111,7 +111,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), hasSize(1));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), hasSize(1));
       }
 
       @Test
@@ -126,7 +126,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), hasSize(1));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), hasSize(1));
       }
 
       @Test
@@ -140,7 +140,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), is(empty()));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), is(empty()));
       }
 
       @Test
@@ -159,7 +159,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), is(empty()));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), is(empty()));
       }
     }
 
@@ -179,7 +179,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), hasSize(1));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), hasSize(1));
       }
 
       @Test
@@ -194,7 +194,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), is(empty()));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), is(empty()));
       }
 
       @Test
@@ -209,7 +209,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), is(empty()));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), is(empty()));
         // ensure that it doesn't even check for amphibious units
         verify(amphibiousUnit, never()).getWasAmphibious();
       }
@@ -227,7 +227,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
       final OffensiveGeneralRetreat offensiveGeneralRetreat =
           new OffensiveGeneralRetreat(battleState, battleActions);
-      assertThat(offensiveGeneralRetreat.getNames(), hasSize(1));
+      assertThat(offensiveGeneralRetreat.getAllStepDetails(), hasSize(1));
     }
 
     @Nested
@@ -243,7 +243,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), is(empty()));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), is(empty()));
       }
 
       @Test
@@ -256,7 +256,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), hasSize(1));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), hasSize(1));
       }
 
       @Test
@@ -270,7 +270,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), is(empty()));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), is(empty()));
       }
 
       @Test
@@ -284,7 +284,7 @@ class OffensiveGeneralRetreatTest extends AbstractClientSettingTestCase {
 
         final OffensiveGeneralRetreat offensiveGeneralRetreat =
             new OffensiveGeneralRetreat(battleState, battleActions);
-        assertThat(offensiveGeneralRetreat.getNames(), hasSize(1));
+        assertThat(offensiveGeneralRetreat.getAllStepDetails(), hasSize(1));
       }
     }
   }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
@@ -71,7 +71,7 @@ public class OffensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(offensiveSubsRetreat.getNames(), hasSize(1));
+    assertThat(offensiveSubsRetreat.getAllStepDetails(), hasSize(1));
   }
 
   @Test
@@ -85,7 +85,7 @@ public class OffensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(offensiveSubsRetreat.getNames(), hasSize(1));
+    assertThat(offensiveSubsRetreat.getAllStepDetails(), hasSize(1));
   }
 
   @Test
@@ -100,7 +100,7 @@ public class OffensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(offensiveSubsRetreat.getNames(), hasSize(1));
+    assertThat(offensiveSubsRetreat.getAllStepDetails(), hasSize(1));
   }
 
   @Test
@@ -116,7 +116,7 @@ public class OffensiveSubsRetreatTest extends AbstractClientSettingTestCase {
 
     assertThat(
         "The destroyer could be killed during the AA phase which would allow the sub to retreat.",
-        offensiveSubsRetreat.getNames(),
+        offensiveSubsRetreat.getAllStepDetails(),
         hasSize(1));
   }
 
@@ -131,7 +131,7 @@ public class OffensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(offensiveSubsRetreat.getNames(), is(empty()));
+    assertThat(offensiveSubsRetreat.getAllStepDetails(), is(empty()));
   }
 
   @Test
@@ -150,7 +150,7 @@ public class OffensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(offensiveSubsRetreat.getNames(), is(empty()));
+    assertThat(offensiveSubsRetreat.getAllStepDetails(), is(empty()));
   }
 
   @Test
@@ -163,7 +163,7 @@ public class OffensiveSubsRetreatTest extends AbstractClientSettingTestCase {
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(offensiveSubsRetreat.getNames(), is(empty()));
+    assertThat(offensiveSubsRetreat.getAllStepDetails(), is(empty()));
   }
 
   static Unit givenRealUnitCanEvade(final GameData gameData, final GamePlayer player) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
@@ -50,7 +50,7 @@ class SubmergeSubsVsOnlyAirStepTest extends AbstractClientSettingTestCase {
   void stepName(final String displayName, final BattleState battleState, final boolean expected) {
     final SubmergeSubsVsOnlyAirStep submergeSubsVsOnlyAirStep =
         new SubmergeSubsVsOnlyAirStep(battleState, battleActions);
-    assertThat(submergeSubsVsOnlyAirStep.getNames(), hasSize(expected ? 1 : 0));
+    assertThat(submergeSubsVsOnlyAirStep.getAllStepDetails(), hasSize(expected ? 1 : 0));
   }
 
   static List<Arguments> stepName() {

--- a/game-app/game-core/src/test/resources/victory_test.xml
+++ b/game-app/game-core/src/test/resources/victory_test.xml
@@ -1486,6 +1486,9 @@
                                 A unit which can not perform amphibious assaults may instead disembark during non-combat
                                 can be set to "all", or "none", or a list of some transports. if this option is not present, it defaults to "all" -->
                          <option name="canInvadeOnlyFrom" value="transport:jp_transport:air_transport:super_carrier"/>
+
+                         <!-- For MustFightBattleTest.testStepNamesChangeDuringCombat -->
+                         <option name="canNotTarget" value="fighter" />
                 </attachment>
 
                 <!-- Armour -->
@@ -1532,6 +1535,11 @@
                          <option name="airAttack" value="2"/>
                          <option name="fuelCost" value="Fuel" count="1"/>
                          <option name="fuelFlatCost" value="Fuel" count="2"/>
+
+                        <!-- For MustFightBattleTest.testStepNamesChangeDuringCombat -->
+                        <option name="isAAforCombatOnly" value="true"/>
+                        <option name="offensiveAttackAA" value="1"/>
+                        <option name="targetsAA" value="artillery"/>
                 </attachment>
 
                 <attachment name="unitAttachment" attachTo="jp_fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">


### PR DESCRIPTION
## Change Summary & Additional Notes
The error would happen when there are multiple casualty steps at first, but when we get to that point in combat, some of those get removed (due units dying and not having a counterattack) and we may end up with a generic casualty step. To fix this, we keep track of which firing units each casualty step had and match based on those.

Adds a test for the fix that's confirmed to fail without it.

Note: This is fixing a 2.6 bug, so no release notes.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
