### PR TITLE
Use continuous resize for game window split panes.

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -418,6 +418,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     gameCenterPanel =
         new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mapAndChatPanel, rightHandSidePanel);
     gameCenterPanel.setOneTouchExpandable(true);
+    gameCenterPanel.setContinuousLayout(true);
     gameCenterPanel.setDividerSize(8);
     gameCenterPanel.setResizeWeight(1.0);
     gameMainPanel.add(gameCenterPanel, BorderLayout.CENTER);
@@ -1928,6 +1929,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
           final JSplitPane split = new JSplitPane();
           split.setOneTouchExpandable(true);
           split.setDividerSize(8);
+          split.setContinuousLayout(true);
           historyPanel = new HistoryPanel(clonedGameData, historyDetailPanel, popup, uiContext);
           split.setLeftComponent(historyPanel);
           split.setRightComponent(gameCenterPanel);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1928,8 +1928,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
               });
           final JSplitPane split = new JSplitPane();
           split.setOneTouchExpandable(true);
-          split.setDividerSize(8);
           split.setContinuousLayout(true);
+          split.setDividerSize(8);
           historyPanel = new HistoryPanel(clonedGameData, historyDetailPanel, popup, uiContext);
           split.setLeftComponent(historyPanel);
           split.setRightComponent(gameCenterPanel);


### PR DESCRIPTION
## Change Summary & Additional Notes

Continuous resizing is better UX and also workarounds a bug (?) with non-continuous resizing on macOS where the split pane can get stuck.


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|When resizing the left and right split panes on the game view, the content will now update right away.<!--END_RELEASE_NOTE-->
