### PR TITLE
Fix game statistics.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -4,6 +4,8 @@ import com.google.common.collect.HashBasedTable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Resource;
+import games.strategy.engine.framework.GameDataManager;
+import games.strategy.engine.framework.GameDataUtils;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Round;
 import games.strategy.triplea.ui.mapdata.MapData;
@@ -13,14 +15,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.swing.tree.TreeNode;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Analyzes a game's history and aggregates interesting statistics in a {@link Statistics} object.
  */
 @Slf4j
-@RequiredArgsConstructor
 public class StatisticsAggregator {
   private static final Map<OverTimeStatisticType, IStat> defaultStatisticsMapping =
       Map.of(
@@ -31,6 +31,18 @@ public class StatisticsAggregator {
   private final Statistics underConstruction = new Statistics();
   private final GameData game;
   private final MapData mapData;
+
+  public StatisticsAggregator(GameData gameData, MapData map) {
+    this.game = cloneGameData(gameData);
+    this.mapData = map;
+  }
+
+  private static GameData cloneGameData(GameData gameData) {
+    final var cloneOptions = GameDataManager.Options.builder().withHistory(true).build();
+    final GameData clone = GameDataUtils.cloneGameData(gameData, cloneOptions).orElse(null);
+    clone.getHistory().enableSeeking(null);
+    return clone;
+  }
 
   private static Map<OverTimeStatisticType, IStat> createOverTimeStatisticsMapping(
       final List<Resource> resources) {

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -303,12 +303,12 @@ final class GameMenu extends JMenu {
   private void addStatistics() {
     add(
         SwingAction.of(
-            "Game statistics",
+            "Game Statistics",
             e ->
                 JOptionPane.showMessageDialog(
                     frame,
                     new StatisticsDialog(gameData, uiContext.getMapData()),
-                    "Game statistics",
+                    "Game Statistics",
                     JOptionPane.INFORMATION_MESSAGE)));
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes

This was broken in 2.6 due to game history refactoring that required seeking to be enabled.
With this change, we clone the game data so that getting statistics doesn't actually require seeking the live game's history.

Also, changes the name of the menu item to be consistent with the others.

Fixes: https://github.com/triplea-game/triplea/issues/11872

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
