### PR TITLE
Allow tuv to be set to 0.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2516,7 +2516,12 @@ public class UnitAttachment extends DefaultAttachment {
     return Tuple.of(max, s[1].intern());
   }
 
-  private void setTuv(final String s) {
+  private void setTuv(final String s) throws GameParseException {
+    final int value = getInt(s);
+    if (value < -1) {
+      throw new GameParseException(
+              "tuv must be 0 positive (or -1, default, to calculate) " + thisErrorMsg());
+    }
     tuv = getInt(s);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2520,7 +2520,7 @@ public class UnitAttachment extends DefaultAttachment {
     final int value = getInt(s);
     if (value < -1) {
       throw new GameParseException(
-              "tuv must be 0 positive (or -1, default, to calculate) " + thisErrorMsg());
+          "tuv must be 0 positive (or -1, default, to calculate) " + thisErrorMsg());
     }
     tuv = getInt(s);
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvCostsCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvCostsCalculator.java
@@ -120,7 +120,7 @@ public class TuvCostsCalculator {
     // Add any units that have XML TUV even if they aren't purchasable
     for (final UnitType unitType : data.getUnitTypeList()) {
       final UnitAttachment ua = unitType.getUnitAttachment();
-      if (ua.getTuv() > 0) {
+      if (ua.getTuv() > -1) {
         costs.put(unitType, ua.getTuv());
       }
     }
@@ -131,7 +131,7 @@ public class TuvCostsCalculator {
   private static int getTotalTuv(
       final UnitType unitType, final IntegerMap<UnitType> costs, final Set<UnitType> alreadyAdded) {
     final UnitAttachment ua = unitType.getUnitAttachment();
-    if (ua.getTuv() > 0) {
+    if (ua.getTuv() > -1) {
       return ua.getTuv();
     }
     int tuv = costs.getInt(unitType);


### PR DESCRIPTION
This change allows tuv to be set to 0 and be used for calculations. Also, a check was added for the proper values.

## Change Summary & Additional Notes

tuv default setting is -1. There was no check for proper values. And when the tuv is calculated, the check was for greater than '0'. Please see [here](https://forums.triplea-game.org/topic/159/tuv-for-units-that-have-consumesunits-property/37?page=2), for the discussion with @Cernelius.

Note: PoS2 should be updated, showing the proper values.

Cheers... 


<!--RELEASE_NOTE-->CHANGE|Allows a zero (0) value to be valid when using the "tuv" option for unitAttachment.<!--END_RELEASE_NOTE-->
