### PR TITLE
Use BFS class for GameMap.getDistance().

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import games.strategy.engine.data.util.BreadthFirstSearch;
 import games.strategy.triplea.delegate.Matches;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -375,37 +376,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     if (t1.equals(t2)) {
       return 0;
     }
-    return getDistance(0, new HashSet<>(), Set.of(t1), t2, routeCond);
-  }
-
-  /**
-   * Guaranteed that frontier doesn't contain target. Territories on the frontier are not target.
-   * They represent the extent of paths already searched. Territories in searched have already been
-   * on the frontier.
-   */
-  private int getDistance(
-      final int distance,
-      final Set<Territory> searched,
-      final Set<Territory> frontier,
-      final Territory target,
-      final BiPredicate<Territory, Territory> routeCond) {
-
-    // add the frontier to the searched
-    searched.addAll(frontier);
-    // find the new frontier
-
-    final Set<Territory> newFrontier =
-        frontier.stream()
-            .flatMap(f -> getNeighbors(f, routeCond).stream())
-            .collect(Collectors.toSet());
-    if (newFrontier.contains(target)) {
-      return distance + 1;
-    }
-    newFrontier.removeAll(searched);
-    if (newFrontier.isEmpty()) {
-      return -1;
-    }
-    return getDistance(distance + 1, searched, newFrontier, target, routeCond);
+    var territoryFinder = new BreadthFirstSearch.TerritoryFinder(t2);
+    new BreadthFirstSearch(List.of(t1), routeCond).traverse(territoryFinder);
+    return territoryFinder.getDistanceFound();
   }
 
   public IntegerMap<Territory> getDistance(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2405,24 +2405,21 @@ class ProNonCombatMoveAi {
     MutableObject<Territory> destination = new MutableObject<>();
     BreadthFirstSearch bfs = new BreadthFirstSearch(from, canMoveThrough);
     bfs.traverse(
-        new BreadthFirstSearch.Visitor() {
-          @Override
-          public boolean visit(Territory t, int distance) {
-            // If it's a desired final destination, see if we can move towards it.
-            if (finalDestinationTest.test(t)) {
-              Route r = data.getMap().getRouteForUnit(from, t, canMoveThrough, unit, player);
-              while (r != null && r.hasSteps()) {
-                final ProTerritory proDestination = proData.getProTerritory(moveMap, r.getEnd());
-                if (proDestination.isCanHold() && validateMove.test(r)) {
-                  destination.setValue(r.getEnd());
-                  // End the search.
-                  return false;
-                }
-                r = new Route(from, r.getMiddleSteps());
+        (t, distance) -> {
+          // If it's a desired final destination, see if we can move towards it.
+          if (finalDestinationTest.test(t)) {
+            Route r = data.getMap().getRouteForUnit(from, t, canMoveThrough, unit, player);
+            while (r != null && r.hasSteps()) {
+              final ProTerritory proDestination = proData.getProTerritory(moveMap, r.getEnd());
+              if (proDestination.isCanHold() && validateMove.test(r)) {
+                destination.setValue(r.getEnd());
+                // End the search.
+                return false;
               }
+              r = new Route(from, r.getMiddleSteps());
             }
-            return true;
           }
+          return true;
         });
     // If nothing chosen and we can't hold the current territory, try to move somewhere safe.
     if (destination.getValue() == null && !moveMap.get(from).isCanHold()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -187,13 +187,10 @@ public final class ProTerritoryValueUtils {
         final int[] landMassSize = new int[1];
         new BreadthFirstSearch(t, cond)
             .traverse(
-                new BreadthFirstSearch.Visitor() {
-                  @Override
-                  public boolean visit(Territory territory, int distance) {
-                    visited.add(territory);
-                    landMassSize[0]++;
-                    return true;
-                  }
+                (territory, distance) -> {
+                  visited.add(territory);
+                  landMassSize[0]++;
+                  return true;
                 });
         if (landMassSize[0] > maxLandMassSize) {
           maxLandMassSize = landMassSize[0];
@@ -462,7 +459,7 @@ public final class ProTerritoryValueUtils {
               }
 
               public boolean shouldContinueSearch() {
-                return currentDistance < MIN_FACTORY_CHECK_DISTANCE || found.isEmpty();
+                return currentDistance <= MIN_FACTORY_CHECK_DISTANCE || found.isEmpty();
               }
             });
     return found;

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/GameMapTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/GameMapTest.java
@@ -1,0 +1,35 @@
+package games.strategy.engine.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import games.strategy.triplea.xml.TestMapGameData;
+import org.junit.jupiter.api.Test;
+
+public class GameMapTest {
+  private final GameData gameData = TestMapGameData.REVISED.getGameData();
+  private final Territory caucasus = gameData.getMap().getTerritory("Caucasus");
+  private final Territory germany = gameData.getMap().getTerritory("Germany");
+  private final Territory russia = gameData.getMap().getTerritory("Russia");
+  private final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+
+  private int getLandDistance(Territory from, Territory to) {
+    return gameData.getMap().getLandDistance(from, to);
+  }
+
+  @Test
+  void testLandDistance() {
+    assertThat(getLandDistance(caucasus, russia), is(1));
+    assertThat(getLandDistance(caucasus, germany), is(3));
+  }
+
+  @Test
+  void testLandDistanceNotFound() {
+    assertThat(getLandDistance(caucasus, uk), is(-1));
+  }
+
+  @Test
+  void testLandDistanceSameTerritory() {
+    assertThat(getLandDistance(caucasus, caucasus), is(0));
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/MapTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/MapTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,6 +99,7 @@ class MapTest {
     map.addConnection(bd, cd);
     map.addConnection(cd, dd);
     nowhere = new Territory("nowhere", false, gameData);
+    when(gameData.getMap()).thenReturn(map);
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/util/BreadthFirstSearchTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/util/BreadthFirstSearchTest.java
@@ -1,0 +1,43 @@
+package games.strategy.engine.data.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.xml.TestMapGameData;
+import org.junit.jupiter.api.Test;
+
+public class BreadthFirstSearchTest {
+  private final GameData gameData = TestMapGameData.REVISED.getGameData();
+  private final Territory caucasus = gameData.getMap().getTerritory("Caucasus");
+  private final Territory germany = gameData.getMap().getTerritory("Germany");
+  private final Territory russia = gameData.getMap().getTerritory("Russia");
+  private final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+
+  private int getLandDistance(Territory from, Territory to) {
+    var territoryFinder = new BreadthFirstSearch.TerritoryFinder(to);
+    new BreadthFirstSearch(from, Matches.territoryIsLand()).traverse(territoryFinder);
+    return territoryFinder.getDistanceFound();
+  }
+
+  @Test
+  void testLandDistance() {
+    assertThat(getLandDistance(caucasus, russia), is(1));
+    assertThat(getLandDistance(caucasus, germany), is(3));
+  }
+
+  @Test
+  void testLandDistanceNotFound() {
+    assertThat(getLandDistance(caucasus, uk), is(-1));
+  }
+
+  @Test
+  void testLandDistanceSameTerritory() {
+    // Note: This is testing the limitation described in the API doc.
+    // This is a test for the low-level helper class, but the high level API, which is tested by
+    // GameMapTest.testLandDistanceSameTerritory() returns the expected result of 0.
+    assertThat(getLandDistance(caucasus, caucasus), is(-1));
+  }
+}


### PR DESCRIPTION
## Change Summary & Additional Notes

No functional changes.

The new implementation is a lot faster than the previous recursive one, which had a lot of overhead from creating a ton of temporary collections and doing a lot of recursive calls.
For a given game with FastAI, I observed ProTerritoryValueUtils.findTerritoryValues() (which spends a lot of time calling getDistance()) going from taking ~15% of the CPU to ~9%.

I tested that this is outputting the same results as the old implementation by having the engine run both and compare the values and ran several full rounds of all-AI games on different maps.

This PR also enhances the API of BreadthFirstSearch by supporting a BiPredicate condition and adds a helper visitor impl for finding a territory and returning its distance. Also, fixes an off-by-1 bug in the class for distance (and updates the one existing caller that was using the previous distance value).

Includes tests.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
