### PR TITLE
Fix runtime crash related to scrambling.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -99,7 +99,9 @@ public class AirBattle extends AbstractBattle {
   @Override
   public Change addAttackChange(
       final Route route, final Collection<Unit> units, final Map<Unit, Set<Unit>> targets) {
-    attackingUnits.addAll(units);
+    // Avoid duplicates. Note: This is needed as scrambling code calls addAirBattle(), but the
+    // battle may have already been created with the same attackers. They should not be added twice.
+    units.stream().filter(not(attackingUnits::contains)).forEach(attackingUnits::add);
     return ChangeFactory.EMPTY_CHANGE;
   }
 


### PR DESCRIPTION
## Change Summary & Additional Notes
The issue was caused by duplicate units being added to the battle.
What happened was that choosing units to scramble resulted in a call to BattleTracker.addBattle(), which found the existing air battle and then added units to it that were already there.
Fixes: https://github.com/triplea-game/triplea/issues/11927

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
