### PR TITLE
Speed up unit help.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
@@ -10,7 +10,6 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.image.UnitImageFactory.ImageKey;
-import games.strategy.triplea.ui.TooltipProperties;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.UnitCategory;
 import java.awt.Color;
@@ -271,7 +270,8 @@ class OrderOfLossesInputPanel extends JPanel {
             "<html>"
                 + category.getType().getName()
                 + ":  "
-                + new TooltipProperties(uiContext)
+                + uiContext
+                    .getTooltipProperties()
                     .getTooltip(category.getType(), category.getOwner())
                 + "</html>";
         final ImageIcon img = uiContext.getUnitImageFactory().getIcon(ImageKey.of(category));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
@@ -5,7 +5,6 @@ import static games.strategy.triplea.image.UnitImageFactory.ImageKey;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.ui.TooltipProperties;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.ui.ScrollableTextField;
@@ -38,7 +37,7 @@ public class UnitPanel extends JPanel {
             + ":  "
             + costs.getInt(category.getType())
             + " cost, <br /> &nbsp;&nbsp;&nbsp;&nbsp; "
-            + new TooltipProperties(uiContext).getTooltip(category.getType(), category.getOwner())
+            + uiContext.getTooltipProperties().getTooltip(category.getType(), category.getOwner())
             + "</html>";
     setCount(category.getUnits().size());
     setLayout(new GridBagLayout());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -129,7 +129,7 @@ public final class MapUnitTooltipManager implements ActionListener {
             count == 1 ? "" : (count + " "),
             StringUtils.capitalize(unitType.getName()),
             player.getName());
-    return firstLine + new TooltipProperties(uiContext).getTooltip(unitType, player);
+    return firstLine + uiContext.getTooltipProperties().getTooltip(unitType, player);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -337,7 +337,7 @@ class ProductionPanel extends JPanel {
           tooltip
               .append(type.getName())
               .append(": ")
-              .append(new TooltipProperties(uiContext).getTooltip(type, player));
+              .append(uiContext.getTooltipProperties().getTooltip(type, player));
           name.setText(type.getName());
           if (attach.getConsumesUnits().totalValues() == 1) {
             name.setForeground(Color.CYAN);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -70,6 +70,7 @@ public class UiContext {
   @Getter private final TileImageFactory tileImageFactory = new TileImageFactory();
   @Getter private UnitImageFactory unitImageFactory;
   @Getter private final ResourceImageFactory resourceImageFactory = new ResourceImageFactory();
+  @Getter private final TooltipProperties tooltipProperties;
 
   @Getter
   private final TerritoryEffectImageFactory territoryEffectImageFactory =
@@ -152,6 +153,7 @@ public class UiContext {
         log.error("Failed to create cursor from: " + cursorUrl, e);
       }
     }
+    tooltipProperties = new TooltipProperties(this);
   }
 
   public JLabel newUnitImageLabel(final ImageKey imageKey) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitStatsTable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitStatsTable.java
@@ -11,7 +11,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.image.UnitImageFactory.ImageKey;
-import games.strategy.triplea.ui.TooltipProperties;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
@@ -72,7 +71,7 @@ public class UnitStatsTable {
               .append(costs.get(player).get(ut).toStringForHtml())
               .append("</td>")
               .append("<td>")
-              .append(new TooltipProperties(uiContext).getTooltip(ut, player))
+              .append(uiContext.getTooltipProperties().getTooltip(ut, player))
               .append("</td></tr>");
         }
       }

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -199,7 +199,7 @@ public class TerritoryDetailPanel extends JPanel {
           "<html>"
               + item.getType().getName()
               + ": "
-              + new TooltipProperties(uiContext).getTooltip(item.getType(), currentPlayer)
+              + uiContext.getTooltipProperties().getTooltip(item.getType(), currentPlayer)
               + "</html>";
       label.setToolTipText(toolTipText);
       panel.add(label);


### PR DESCRIPTION
## Change Summary & Additional Notes

Previously, it was constructing a TooltipProperties object for every unit shown, which resulted in a read of the properties file.
Now, we just keep a single TooltipProperties object on the uiContext, so the file is only ever read once.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
