### PR TITLE
Fix delay between "Calculating Data" and unit dialog shown.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/GameNotesMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/GameNotesMenu.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.ui.menubar.help;
 
 import games.strategy.engine.framework.ui.GameNotesView;
+import java.awt.Dimension;
 import java.nio.file.Path;
 import javax.swing.Action;
 import javax.swing.JComponent;
@@ -24,18 +25,12 @@ class GameNotesMenu {
                   final JDialog dialog =
                       InformationDialog.createDialog(
                           notesPanel(gameNotes, mapLocation), gameNotesTitle);
-                  if (dialog.getWidth() < 400) {
-                    dialog.setSize(400, dialog.getHeight());
-                  }
-                  if (dialog.getHeight() < 300) {
-                    dialog.setSize(dialog.getWidth(), 300);
-                  }
-                  if (dialog.getWidth() > 800) {
-                    dialog.setSize(800, dialog.getHeight());
-                  }
-                  if (dialog.getHeight() > 600) {
-                    dialog.setSize(dialog.getWidth(), 600);
-                  }
+                  Dimension size = dialog.getSize();
+                  size.width = Math.min(size.width, 400);
+                  size.height = Math.min(size.height, 300);
+                  size.width = Math.max(size.width, 800);
+                  size.height = Math.max(size.height, 600);
+                  dialog.setSize(size);
                   dialog.setVisible(true);
                 }));
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitHelpMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitHelpMenu.java
@@ -5,6 +5,7 @@ import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import games.strategy.triplea.ui.UiContext;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
+import javax.swing.JDialog;
 import javax.swing.JEditorPane;
 import javax.swing.JScrollPane;
 import lombok.experimental.UtilityClass;
@@ -20,19 +21,21 @@ class UnitHelpMenu {
     return SwingAction.of(
         unitHelpTitle,
         e -> {
-          final Result<String> result =
+          final Result<JDialog> result =
               Interruptibles.awaitResult(
                   () ->
                       BackgroundTaskRunner.runInBackgroundAndReturn(
                           "Calculating Data",
-                          () -> UnitStatsTable.getUnitStatsTable(gameData, uiContext)));
-          final JEditorPane editorPane =
-              new JEditorPane("text/html", result.result.orElse("Failed to calculate Data"));
-          editorPane.setEditable(false);
-          editorPane.setCaretPosition(0);
-          final JScrollPane scroll = new JScrollPane(editorPane);
-          scroll.setBorder(BorderFactory.createEmptyBorder());
-          InformationDialog.createDialog(scroll, unitHelpTitle).setVisible(true);
+                          () -> {
+                            String text = UnitStatsTable.getUnitStatsTable(gameData, uiContext);
+                            JEditorPane editorPane = new JEditorPane("text/html", text);
+                            editorPane.setEditable(false);
+                            editorPane.setCaretPosition(0);
+                            JScrollPane scroll = new JScrollPane(editorPane);
+                            scroll.setBorder(BorderFactory.createEmptyBorder());
+                            return InformationDialog.createDialog(scroll, unitHelpTitle);
+                          }));
+          result.result.orElseThrow().setVisible(true);
         });
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes

Previously, there would be a long delay after the "Calculating Data" dialog was closed but before the unit dialog got opened.
This fixes it by making the dialog constructor and packing happen in the background too.

Also some code cleanup.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
