### PR TITLE
Fix "Attackers and defenders collections must be distinct".

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -235,7 +235,6 @@ class ProNonCombatMoveAi {
 
     Map<Territory, ProTerritory> moveMap = territoryManager.getDefendOptions().getTerritoryMap();
     Map<Unit, Set<Territory>> unitMoveMap = territoryManager.getDefendOptions().getUnitMoveMap();
-    List<ProTransport> transportMapList = territoryManager.getDefendOptions().getTransportList();
 
     // Add all units that can't move (to be consumed, allied units, 0 move units, etc)
     for (final Territory t : moveMap.keySet()) {
@@ -252,26 +251,13 @@ class ProNonCombatMoveAi {
     // Add all units that only have 1 move option and can't be transported
     for (final Iterator<Unit> it = unitMoveMap.keySet().iterator(); it.hasNext(); ) {
       final Unit u = it.next();
-      if (unitMoveMap.get(u).size() == 1) {
-        final Territory onlyTerritory = CollectionUtils.getAny(unitMoveMap.get(u));
-        if (onlyTerritory.equals(unitTerritoryMap.get(u))) {
-          boolean canBeTransported = false;
-          for (final ProTransport pad : transportMapList) {
-            for (final Territory t : pad.getTransportMap().keySet()) {
-              if (pad.getTransportMap().get(t).contains(onlyTerritory)) {
-                canBeTransported = true;
-              }
-            }
-            for (final Territory t : pad.getSeaTransportMap().keySet()) {
-              if (pad.getSeaTransportMap().get(t).contains(onlyTerritory)) {
-                canBeTransported = true;
-              }
-            }
-          }
-          if (!canBeTransported) {
-            moveMap.get(onlyTerritory).addCantMoveUnit(u);
-            it.remove();
-          }
+      final Set<Territory> territories = unitMoveMap.get(u);
+      if (territories.size() == 1) {
+        final Territory onlyTerritory = CollectionUtils.getAny(territories);
+        if (onlyTerritory.equals(unitTerritoryMap.get(u))
+            && !canBePotentiallyBeTransported(onlyTerritory)) {
+          moveMap.get(onlyTerritory).addCantMoveUnit(u);
+          it.remove();
         }
       }
     }
@@ -323,6 +309,24 @@ class ProNonCombatMoveAi {
       }
     }
     return infraUnitMoveMap;
+  }
+
+  private boolean canBePotentiallyBeTransported(Territory unitTerritory) {
+    final List<ProTransport> transportMapList =
+        territoryManager.getDefendOptions().getTransportList();
+    for (final ProTransport pad : transportMapList) {
+      for (final Territory t : pad.getTransportMap().keySet()) {
+        if (pad.getTransportMap().get(t).contains(unitTerritory)) {
+          return true;
+        }
+      }
+      for (final Territory t : pad.getSeaTransportMap().keySet()) {
+        if (pad.getSeaTransportMap().get(t).contains(unitTerritory)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private List<Territory> moveOneDefenderToLandTerritoriesBorderingEnemy() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -255,7 +255,7 @@ class ProNonCombatMoveAi {
       if (territories.size() == 1) {
         final Territory onlyTerritory = CollectionUtils.getAny(territories);
         if (onlyTerritory.equals(unitTerritoryMap.get(u))
-            && !canBePotentiallyBeTransported(onlyTerritory)) {
+            && !canPotentiallyBeTransported(onlyTerritory)) {
           moveMap.get(onlyTerritory).addCantMoveUnit(u);
           it.remove();
         }
@@ -311,7 +311,7 @@ class ProNonCombatMoveAi {
     return infraUnitMoveMap;
   }
 
-  private boolean canBePotentiallyBeTransported(Territory unitTerritory) {
+  private boolean canPotentiallyBeTransported(Territory unitTerritory) {
     final List<ProTransport> transportMapList =
         territoryManager.getDefendOptions().getTransportList();
     for (final ProTransport pad : transportMapList) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -52,7 +52,7 @@ public class ProTerritory {
   private ProBattleResult battleResult;
 
   // Non-combat move variables
-  private final List<Unit> cantMoveUnits;
+  private final Set<Unit> cantMoveUnits;
   private List<Unit> maxEnemyUnits;
   private Set<Unit> maxEnemyBombardUnits;
   private ProBattleResult minBattleResult;
@@ -89,7 +89,7 @@ public class ProTerritory {
     currentlyWins = false;
     battleResult = null;
 
-    cantMoveUnits = new ArrayList<>();
+    cantMoveUnits = new HashSet<>();
     maxEnemyUnits = new ArrayList<>();
     maxEnemyBombardUnits = new HashSet<>();
     minBattleResult = new ProBattleResult();
@@ -126,7 +126,7 @@ public class ProTerritory {
     currentlyWins = patd.isCurrentlyWins();
     battleResult = patd.getBattleResult();
 
-    cantMoveUnits = new ArrayList<>(patd.getCantMoveUnits());
+    cantMoveUnits = new HashSet<>(patd.getCantMoveUnits());
     maxEnemyUnits = new ArrayList<>(patd.getMaxEnemyUnits());
     maxEnemyBombardUnits = new HashSet<>(patd.getMaxEnemyBombardUnits());
     minBattleResult = patd.getMinBattleResult();
@@ -332,8 +332,8 @@ public class ProTerritory {
     return sb.toString();
   }
 
-  public List<Unit> getCantMoveUnits() {
-    return Collections.unmodifiableList(cantMoveUnits);
+  public Collection<Unit> getCantMoveUnits() {
+    return Collections.unmodifiableCollection(cantMoveUnits);
   }
 
   public void addCantMoveUnit(final Unit unit) {


### PR DESCRIPTION
## Change Summary & Additional Notes
This was caused by cantMoveUnits containing duplicates in some cases. Changed to a Set to prevent that.

Also cleans up some logic.
Fixes: https://github.com/triplea-game/triplea/issues/11851

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
