### PR TITLE
Show up to 2 decimals for percents in battle calc.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -677,7 +677,7 @@ class BattleCalculatorPanel extends JPanel {
   }
 
   private static String formatPercentage(final double percentage) {
-    return new DecimalFormat("#%").format(percentage);
+    return new DecimalFormat("#%.##").format(percentage);
   }
 
   private static String formatValue(final double value) {


### PR DESCRIPTION
## Change Summary & Additional Notes

The extra precision is only shown when significant (which may require a different sim count than the default of 200).

As requested here: https://github.com/triplea-game/triplea/issues/11962

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->NEW|Up to two decimal digits after the decimal point are now shown for percentages in the battle calculator.<!--END_RELEASE_NOTE-->
