### PR TITLE
isAI to check AI controlled players.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -55,8 +55,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   private int techCount = -1;
   // condition for having specific relationships
   private @Nullable List<String> relationship = null;
-  // condition for checking ai player
-  private Boolean isAIPlayers = null;
+  // condition for checking AI player
+  private Boolean isAI = null;
   // condition for being at war
   private @Nullable Set<GamePlayer> atWarPlayers = null;
   private int atWarCount = -1;
@@ -491,20 +491,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     unitPresence = null;
   }
 
-  private void setIsAIPlayers(final String s) {
-    isAIPlayers = (s == null) ? null : getBool(s);
+  private void setIsAI(final String s) {
+    isAI = (s == null) ? null : getBool(s);
   }
 
-  private void setIsAIPlayers(final Boolean s) {
-    isAIPlayers = s;
+  private void setIsAI(final Boolean s) {
+    isAI = s;
   }
 
-  public Boolean getIsAIPlayers() {
-    return isAIPlayers;
+  public Boolean getIsAI() {
+    return isAI;
   }
 
-  private void resetIsAIPlayers() {
-    isAIPlayers = null;
+  private void resetIsAI() {
+    isAI = null;
   }
 
   private int getAtWarCount() {
@@ -753,9 +753,9 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       }
       objectiveMet = checkDirectOwnership(listedTerritories, players);
     }
-    // check for ai controlled player
-    if (objectiveMet && getIsAIPlayers() != null) {
-      objectiveMet = checkIsAIPlayers(players);
+    // check for AI controlled player
+    if (objectiveMet && getIsAI() != null) {
+      objectiveMet = checkIsAI(players);
     }
     // get attached to player
     final GamePlayer playerAttachedTo = (GamePlayer) getAttachedTo();
@@ -1025,11 +1025,10 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     return numberMet >= getTerritoryCount();
   }
 
-  private boolean checkIsAIPlayers(final List<GamePlayer> players) {
+  private boolean checkIsAI(final List<GamePlayer> players) {
     boolean bcheck = true;
     for (GamePlayer player : players) {
-      // need to retain true/false
-      bcheck = (bcheck && (getIsAIPlayers() == player.isAi()));
+      bcheck = (bcheck && (getIsAI() == player.isAi()));
     }
     return bcheck;
   }
@@ -1090,12 +1089,12 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
             this::setRelationship,
             this::getRelationship,
             this::resetRelationship);
-      case "isAIPlayers":
+      case "isAI":
         return MutableProperty.of(
-            this::setIsAIPlayers,
-            this::setIsAIPlayers,
-            this::getIsAIPlayers,
-            this::resetIsAIPlayers);
+            this::setIsAI,
+            this::setIsAI,
+            this::getIsAI,
+            this::resetIsAI);
       case "atWarPlayers":
         return MutableProperty.of(
             this::setAtWarPlayers,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -56,7 +56,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   // condition for having specific relationships
   private @Nullable List<String> relationship = null;
   // condition for checking ai player
-  private boolean checkAIPlayers = false;
+  private Boolean isAIPlayers = null;
   // condition for being at war
   private @Nullable Set<GamePlayer> atWarPlayers = null;
   private int atWarCount = -1;
@@ -491,20 +491,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     unitPresence = null;
   }
 
-  private void setCheckAIPlayers(final String s) {
-    checkAIPlayers = getBool(s);
+  private void setIsAIPlayers(final String s) {
+    isAIPlayers = (s == null) ? null : getBool(s);
   }
 
-  private void setCheckAIPlayers(final Boolean s) {
-    checkAIPlayers = s;
+  private void setIsAIPlayers(final Boolean s) {
+    isAIPlayers = s;
   }
 
-  public boolean getCheckAIPlayers() {
-    return checkAIPlayers;
+  public Boolean getIsAIPlayers() {
+    return isAIPlayers;
   }
 
-  private void resetCheckAIPlayers() {
-    checkAIPlayers = false;
+  private void resetIsAIPlayers() {
+    isAIPlayers = null;
   }
 
   private int getAtWarCount() {
@@ -754,8 +754,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       objectiveMet = checkDirectOwnership(listedTerritories, players);
     }
     // check for ai controlled player
-    if (objectiveMet && getCheckAIPlayers()) {
-      objectiveMet = checkCheckAIPlayers(players);
+    if (objectiveMet && getIsAIPlayers() != null) {
+      objectiveMet = checkIsAIPlayers(players);
     }
     // get attached to player
     final GamePlayer playerAttachedTo = (GamePlayer) getAttachedTo();
@@ -1025,10 +1025,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     return numberMet >= getTerritoryCount();
   }
 
-  private boolean checkCheckAIPlayers(final List<GamePlayer> players) {
+  private boolean checkIsAIPlayers(final List<GamePlayer> players) {
     boolean bcheck = true;
     for (GamePlayer player : players) {
-      bcheck = (bcheck && player.isAi());
+      // need to retain true/false
+      bcheck = (bcheck && (getIsAIPlayers() == player.isAi()));
     }
     return bcheck;
   }
@@ -1089,12 +1090,12 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
             this::setRelationship,
             this::getRelationship,
             this::resetRelationship);
-      case "checkAIPlayer":
+      case "isAIPlayers":
         return MutableProperty.of(
-            this::setCheckAIPlayers,
-            this::setCheckAIPlayers,
-            this::getCheckAIPlayers,
-            this::resetCheckAIPlayers);
+            this::setIsAIPlayers,
+            this::setIsAIPlayers,
+            this::getIsAIPlayers,
+            this::resetIsAIPlayers);
       case "atWarPlayers":
         return MutableProperty.of(
             this::setAtWarPlayers,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
-
 import org.jetbrains.annotations.VisibleForTesting;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.CollectionUtils;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -1090,11 +1090,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
             this::getRelationship,
             this::resetRelationship);
       case "isAI":
-        return MutableProperty.of(
-            this::setIsAI,
-            this::setIsAI,
-            this::getIsAI,
-            this::resetIsAI);
+        return MutableProperty.of(this::setIsAI, this::setIsAI, this::getIsAI, this::resetIsAI);
       case "atWarPlayers":
         return MutableProperty.of(
             this::setAtWarPlayers,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -55,6 +55,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   private int techCount = -1;
   // condition for having specific relationships
   private @Nullable List<String> relationship = null;
+  // condition for checking ai player
+  private boolean checkAIPlayers = false;
   // condition for being at war
   private @Nullable Set<GamePlayer> atWarPlayers = null;
   private int atWarCount = -1;
@@ -489,6 +491,22 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     unitPresence = null;
   }
 
+  private void setCheckAIPlayers(final String s) {
+    checkAIPlayers = getBool(s);
+  }
+
+  private void setCheckAIPlayers(final Boolean s) {
+    checkAIPlayers = s;
+  }
+
+  public boolean getCheckAIPlayers() {
+    return checkAIPlayers;
+  }
+
+  private void resetCheckAIPlayers() {
+    checkAIPlayers = false;
+  }
+
   private int getAtWarCount() {
     return atWarCount;
   }
@@ -735,11 +753,17 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       }
       objectiveMet = checkDirectOwnership(listedTerritories, players);
     }
+    // check for ai controlled player
+    if (objectiveMet && getCheckAIPlayers()) {
+      objectiveMet = checkCheckAIPlayers(players);
+    }
     // get attached to player
     final GamePlayer playerAttachedTo = (GamePlayer) getAttachedTo();
+    // check for players at war
     if (objectiveMet && !getAtWarPlayers().isEmpty()) {
       objectiveMet = checkAtWar(playerAttachedTo, getAtWarPlayers(), getAtWarCount());
     }
+    // check for techs
     if (objectiveMet && !getTechs().isEmpty()) {
       objectiveMet = checkTechs(playerAttachedTo, data.getTechnologyFrontier());
     }
@@ -1001,6 +1025,14 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     return numberMet >= getTerritoryCount();
   }
 
+  private boolean checkCheckAIPlayers(final List<GamePlayer> players) {
+    boolean bcheck = true;
+    for (GamePlayer player : players) {
+      bcheck = (bcheck && player.isAi());
+    }
+    return bcheck;
+  }
+
   private boolean checkAtWar(
       final GamePlayer player, final Set<GamePlayer> enemies, final int count) {
     int found = CollectionUtils.countMatches(enemies, player::isAtWar);
@@ -1057,6 +1089,12 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
             this::setRelationship,
             this::getRelationship,
             this::resetRelationship);
+      case "checkAIPlayer":
+        return MutableProperty.of(
+            this::setCheckAIPlayers,
+            this::setCheckAIPlayers,
+            this::getCheckAIPlayers,
+            this::resetCheckAIPlayers);
       case "atWarPlayers":
         return MutableProperty.of(
             this::setAtWarPlayers,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -56,7 +56,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   // condition for having specific relationships
   private @Nullable List<String> relationship = null;
   // condition for checking AI player
-  private Boolean isAI = null;
+  private @Nullable Boolean isAI = null;
   // condition for being at war
   private @Nullable Set<GamePlayer> atWarPlayers = null;
   private int atWarCount = -1;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -37,6 +37,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
+
+import org.jetbrains.annotations.VisibleForTesting;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
@@ -491,7 +493,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     unitPresence = null;
   }
 
-  private void setIsAI(final String s) {
+  @VisibleForTesting
+  public void setIsAI(final String s) {
     isAI = (s == null) ? null : getBool(s);
   }
 
@@ -1025,7 +1028,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     return numberMet >= getTerritoryCount();
   }
 
-  private boolean checkIsAI(final List<GamePlayer> players) {
+  @VisibleForTesting
+  public boolean checkIsAI(final List<GamePlayer> players) {
     boolean bcheck = true;
     for (GamePlayer player : players) {
       bcheck = (bcheck && (getIsAI() == player.isAi()));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/RulesAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/RulesAttachmentTest.java
@@ -1,0 +1,87 @@
+package games.strategy.triplea.attachments;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.PlayerList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RulesAttachmentTest {
+
+  @Mock private PlayerList playerList;
+
+  private final GameData gameData = mock(GameData.class);
+
+  private final RulesAttachment attachment = new RulesAttachment("Test attachment", null, gameData);
+
+  @Mock private GamePlayer player1;
+  @Mock private GamePlayer player2;
+  @Mock private GamePlayer player3;
+  @Mock private GamePlayer player4;
+
+  @BeforeEach
+  void setUp() {
+    when(gameData.getPlayerList()).thenReturn(playerList);
+  }
+
+  /* Testing stored getIsAI values with setIsAI */
+  @Test
+  void isAITest() {
+    attachment.setIsAI("true");
+    assertTrue(attachment.getIsAI());
+    attachment.setIsAI("false");
+    assertFalse(attachment.getIsAI());
+  }
+
+  /* Testing returned values for checkGetIsAI */
+  @Test
+  void checkGetIsAITest() {
+    lenient().when(player1.isAi()).thenReturn(false);
+    lenient().when(player2.isAi()).thenReturn(true);
+    lenient().when(player3.isAi()).thenReturn(true);
+    lenient().when(player4.isAi()).thenReturn(false);
+
+    /* Testing with 1 non AI player */
+    final List<GamePlayer> players1 = List.of(player1);
+    attachment.setIsAI("true");
+    assertFalse(attachment.checkIsAI(players1));
+    attachment.setIsAI("false");
+    assertTrue(attachment.checkIsAI(players1));
+    /* Testing with 1 AI player */
+    final List<GamePlayer> players2 = List.of(player2);
+    attachment.setIsAI("true");
+    assertTrue(attachment.checkIsAI(players2));
+    attachment.setIsAI("false");
+    assertFalse(attachment.checkIsAI(players2));
+    /* Testing with 1 non AI player and 1 AI player */
+    final List<GamePlayer> players12 = List.of(player1, player2);
+    attachment.setIsAI("true");
+    assertFalse(attachment.checkIsAI(players12));
+    attachment.setIsAI("false");
+    assertFalse(attachment.checkIsAI(players12));
+    /* Testing with 2 AI players */
+    final List<GamePlayer> players23 = List.of(player2, player3);
+    attachment.setIsAI("true");
+    assertTrue(attachment.checkIsAI(players23));
+    attachment.setIsAI("false");
+    assertFalse(attachment.checkIsAI(players23));
+    /* Testing with 2 non AI players */
+    final List<GamePlayer> players14 = List.of(player1, player4);
+    attachment.setIsAI("true");
+    assertFalse(attachment.checkIsAI(players14));
+    attachment.setIsAI("false");
+    assertTrue(attachment.checkIsAI(players14));
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/RulesAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/RulesAttachmentTest.java
@@ -10,7 +10,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.PlayerList;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
isAI added to RulesAttachment to allow for checking of AI controlled players.

## Change Summary & Additional Notes
Changing isAIPlayers to isAI

isAI              values: true/false, check if the player is AI controlled. Can be used with the players option.
 
## Release Note

<!--RELEASE_NOTE-->NEW|isAI to check for AI controlled players.<!--END_RELEASE_NOTE-->
