### PR TITLE
Fix stacking limit logic for placement dialog.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.attachments.TerritoryAttachment;
@@ -14,7 +15,9 @@ import games.strategy.triplea.delegate.TechTracker;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.CollectionUtils;
@@ -28,6 +31,10 @@ import org.triplea.java.collections.IntegerMap;
  */
 @UtilityClass
 public class UnitUtils {
+
+  public static Set<UnitType> getUnitTypesFromUnitList(final Collection<Unit> units) {
+    return units.stream().map(Unit::getType).collect(Collectors.toSet());
+  }
 
   public static int getProductionPotentialOfTerritory(
       final Collection<Unit> unitsAtStartOfStepInTerritory,
@@ -151,7 +158,7 @@ public class UnitUtils {
             (Properties.getWW2V2(properties) || Properties.getWW2V3(properties)) ? 0 : 1;
       }
     }
-    // Increase production if have industrial technology
+    // Increase production if we have industrial technology
     if (territoryProduction
         >= techTracker.getMinimumTerritoryValueForProductionBonus(unit.getOwner())) {
       productionCapacity += techTracker.getProductionBonus(unit.getOwner(), unit.getType());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -18,6 +18,7 @@ import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.UnitUtils;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -257,10 +258,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public static UnitAttachment get(final UnitType type, final String nameOfAttachment) {
     return getAttachment(type, nameOfAttachment, UnitAttachment.class);
-  }
-
-  private static Collection<UnitType> getUnitTypesFromUnitList(final Collection<Unit> units) {
-    return units.stream().map(Unit::getType).collect(Collectors.toSet());
   }
 
   private TechTracker getTechTracker() {
@@ -1161,7 +1158,7 @@ public class UnitAttachment extends DefaultAttachment {
       final UnitTypeList unitTypeList) {
     final IntegerMap<Tuple<String, String>> map = new IntegerMap<>();
     final Collection<UnitType> canReceive =
-        getUnitTypesFromUnitList(
+        UnitUtils.getUnitTypesFromUnitList(
             CollectionUtils.getMatches(units, Matches.unitCanReceiveAbilityWhenWith()));
     for (final UnitType ut : canReceive) {
       final Collection<String> receives = ut.getUnitAttachment().getReceivesAbilityWhenWith();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -184,7 +184,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     if (error != null) {
       return new PlaceableUnits(error);
     }
-    // Here!
     final Collection<Unit> placeableUnits = getUnitsToBePlaced(to, units, player);
     final int maxUnits = getMaxUnitsToBePlaced(placeableUnits, to, player);
     return new PlaceableUnits(placeableUnits, maxUnits);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -992,6 +992,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     // Filter each type separately, since we don't want a max on one type to filter out all units of
     // another type, if the two types have a combined limit. UnitStackingLimitFilter doesn't do
     // that directly since other call sites (e.g. move validation) do need the combined filtering.
+    // But we need to do it this way here, since the result will be shown for choosing which units
+    // to build (where we want to show all the types that can be built).
     final var result = new ArrayList<Unit>();
     for (UnitType ut : UnitUtils.getUnitTypesFromUnitList(units)) {
       result.addAll(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -16,6 +16,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.UnitUtils;
 import games.strategy.triplea.attachments.AbstractUserActionAttachment;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.PlayerAttachment;
@@ -220,8 +221,7 @@ public final class Matches {
       Territory battleSite,
       int battleRound,
       Collection<Unit> enemyUnits) {
-    final Set<UnitType> enemyUnitTypes =
-        enemyUnits.stream().map(Unit::getType).collect(Collectors.toSet());
+    final Collection<UnitType> enemyUnitTypes = UnitUtils.getUnitTypesFromUnitList(enemyUnits);
     return u -> {
       final boolean landBattle = !battleSite.isWater();
       if (!landBattle && Matches.unitIsLand().test(u)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/TargetGroup.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/TargetGroup.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate.battle.steps.fire.general;
 import com.google.common.collect.Sets;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.UnitUtils;
 import games.strategy.triplea.delegate.Matches;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,10 +44,9 @@ class TargetGroup {
    */
   public static List<TargetGroup> newTargetGroups(
       final Collection<Unit> units, final Collection<Unit> enemyUnits) {
-    final Set<UnitType> unitTypes = units.stream().map(Unit::getType).collect(Collectors.toSet());
+    final Set<UnitType> unitTypes = UnitUtils.getUnitTypesFromUnitList(units);
     final boolean destroyerPresent = unitTypes.stream().anyMatch(Matches.unitTypeIsDestroyer());
-    final Set<UnitType> enemyUnitTypes =
-        enemyUnits.stream().map(Unit::getType).collect(Collectors.toSet());
+    final Set<UnitType> enemyUnitTypes = UnitUtils.getUnitTypesFromUnitList(enemyUnits);
     final List<TargetGroup> targetGroups = new ArrayList<>();
     for (final UnitType unitType : unitTypes) {
       final Set<UnitType> targets = findTargets(unitType, destroyerPresent, enemyUnitTypes);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -19,7 +18,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -8,7 +8,9 @@ import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBrid
 import static games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate.BidMode.NOT_BID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -17,6 +19,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -228,6 +231,17 @@ class PlaceDelegateTest extends AbstractDelegateTestCase {
     // but not 2 battleships and 2 carriers
     units.addAll(create(british, carrier, 1));
     assertError(delegate.canUnitsBePlaced(northSea, units, british));
+    // However, getPlaceableUnits() should return 2 of each, since that's what's for filtering the
+    // options given to the user.
+    assertThat(
+        delegate.getPlaceableUnits(units, northSea).getUnits(),
+        containsInAnyOrder(units.toArray()));
+    units.addAll(create(british, carrier, 5));
+    units.addAll(create(british, battleship, 7));
+    var result = delegate.getPlaceableUnits(units, northSea).getUnits();
+    assertThat(result, hasSize(6));
+    assertThat(CollectionUtils.getMatches(result, Matches.unitIsOfType(battleship)), hasSize(3));
+    assertThat(CollectionUtils.getMatches(result, Matches.unitIsOfType(carrier)), hasSize(3));
   }
 
   @Test
@@ -237,7 +251,7 @@ class PlaceDelegateTest extends AbstractDelegateTestCase {
     // Add a carrier to the sea zone.
     westCanadaSeaZone.getUnitCollection().addAll(create(british, carrier, 1));
 
-    // if we filter list of 2 battleships and 2 carriers, the 2 carriers should be selected.
+    // If we filter list of 2 battleships and 2 carriers, the 2 carriers should be selected.
     List<Unit> units = create(british, battleship, 2);
     units.addAll(create(british, carrier, 2));
     // First, we can't place all of them (expected).

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilterTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilterTest.java
@@ -55,7 +55,7 @@ class UnitStackingLimitFilterTest extends AbstractDelegateTestCase {
     assertThat(callFilterUnits(fourTanks, british, uk), hasSize(2));
 
     // but we can include other units that don't have stacking limits in the list
-    // note: still with the two tanks already in the uk
+    // note: still with the two tanks already in the UK
     List<Unit> twoInfantryAndFourTanks = infantry.create(2, british);
     twoInfantryAndFourTanks.addAll(fourTanks);
     assertThat(twoInfantryAndFourTanks, hasSize(6));

--- a/game-app/game-core/src/test/resources/DelegateTest.xml
+++ b/game-app/game-core/src/test/resources/DelegateTest.xml
@@ -964,6 +964,7 @@
 
         <attachment name="playerAttachment" attachTo="British" javaClass="PlayerAttachment" type="player">
             <option name="placementLimit" value="owned:battleship:carrier" count="3"/>
+            <option name="placementLimit" value="allied:factory:factory2" count="1"/>
             <option name="movementLimit" value="owned:infantry" count="7"/>
         </attachment>
 

--- a/game-app/game-core/src/test/resources/DelegateTest.xml
+++ b/game-app/game-core/src/test/resources/DelegateTest.xml
@@ -964,7 +964,6 @@
 
         <attachment name="playerAttachment" attachTo="British" javaClass="PlayerAttachment" type="player">
             <option name="placementLimit" value="owned:battleship:carrier" count="3"/>
-            <option name="placementLimit" value="allied:factory:factory2" count="1"/>
             <option name="movementLimit" value="owned:infantry" count="7"/>
         </attachment>
 


### PR DESCRIPTION
## Change Summary & Additional Notes

Fixes: https://github.com/triplea-game/triplea/issues/11994
(2.6 bug)

The logic to filter out which units should be shown in the place dialog was too aggressive and was resulting in filtering out a unit of type B when it shared a limit with a unit of type A. This change relaxes that logic specifically for the placement dialog case and adds test coverage.

Also moves a helper function to UnitUtils.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
