### PR TITLE
Remove some no-op code.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -403,7 +403,7 @@ public class MovePerformer implements Serializable {
       }
       dependentAirTransportableUnits.put(entry.getKey(), dependents);
     }
-    
+
     // load the transports
     if (route.isLoad() || paratroopsLanding) {
       // mark transports as having transported

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -403,15 +403,7 @@ public class MovePerformer implements Serializable {
       }
       dependentAirTransportableUnits.put(entry.getKey(), dependents);
     }
-
-    // If paratroops moved normally (within their normal movement) remove their dependency to the
-    // airTransports
-    // So they can all continue to move normally
-    if (!paratroopsLanding && !dependentAirTransportableUnits.isEmpty()) {
-      final Collection<Unit> airTransports =
-          CollectionUtils.getMatches(arrived, Matches.unitIsAirTransport());
-      airTransports.addAll(dependentAirTransportableUnits.keySet());
-    }
+    
     // load the transports
     if (route.isLoad() || paratroopsLanding) {
       // mark transports as having transported


### PR DESCRIPTION
## Change Summary & Additional Notes
This code became no-op code with https://github.com/triplea-game/triplea/pull/10304, which removed the MovePanel.clearDependents() call.

With that call removed, the whole if block can go away.

No functional changes.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
