### PR TITLE
Fix transportedBy not cleared after a convoy capture.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import org.triplea.java.ObjectUtils;
@@ -101,19 +102,28 @@ abstract class AbstractBattle implements IBattle {
   }
 
   void clearTransportedBy(final IDelegateBridge bridge) {
-    // Clear the transported_by for successfully off loaded units
+    // This battle may be a dependent battle for an amphibious landing. In such a case, the
+    // TRANSPORTED_BY property hasn't yet been cleared for any landing units (even if they've
+    // already been put in the new territory), since technically they haven't really landed until
+    // the battle has been won. This code is responsible for clearing this property for those units.
+    // Note: We find transports from among all attacker's units in the territory (and not just those
+    // that are attacking) because some may not actually be participating in the combat (e.g. if an
+    // empty convoy zone was taken over by another ship first).
+    final Predicate<Unit> attackerTransports =
+        Matches.unitIsOwnedBy(attacker).and(Matches.unitIsSeaTransport());
     final Collection<Unit> transports =
-        CollectionUtils.getMatches(attackingUnits, Matches.unitIsSeaTransport());
+        CollectionUtils.getMatches(getTerritory().getUnits(), attackerTransports);
     if (!transports.isEmpty()) {
-      final CompositeChange change = new CompositeChange();
       final Collection<Unit> dependents = getTransportDependents(transports);
-      if (!dependents.isEmpty()) {
-        for (final Unit unit : dependents) {
-          // clear the loaded by ONLY for Combat unloads. NonCombat unloads are handled elsewhere.
-          if (Matches.unitWasUnloadedThisTurn().test(unit)) {
-            change.add(ChangeFactory.unitPropertyChange(unit, null, Unit.TRANSPORTED_BY));
-          }
-        }
+      // Clear TRANSPORTED_BY only for combat unloads. Non-combat unloads are handled by
+      // markTransportsMovement().
+      final Collection<Unit> dependentsUnloadedThisTurn =
+          CollectionUtils.getMatches(dependents, Matches.unitWasUnloadedThisTurn());
+      final CompositeChange change = new CompositeChange();
+      for (final Unit unit : dependentsUnloadedThisTurn) {
+        change.add(ChangeFactory.unitPropertyChange(unit, null, Unit.TRANSPORTED_BY));
+      }
+      if (!change.isEmpty()) {
         bridge.addChange(change);
       }
     }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -55,7 +55,7 @@ public final class GameDataTestUtil {
   /**
    * Get the italian PlayerId for the given GameData object.
    *
-   * @return A italian PlayerId.
+   * @return An italian PlayerId.
    */
   public static GamePlayer italians(final GameState data) {
     return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_ITALIANS);
@@ -77,7 +77,7 @@ public final class GameDataTestUtil {
   /**
    * Get the american PlayerId for the given GameData object.
    *
-   * @return A american PlayerId.
+   * @return An american PlayerId.
    */
   public static GamePlayer americans(final GameState data) {
     return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_AMERICANS);
@@ -393,7 +393,7 @@ public final class GameDataTestUtil {
     return (BidPlaceDelegate) data.getDelegate("placeBid");
   }
 
-  static void load(final Collection<Unit> units, final Route route) {
+  public static void load(final Collection<Unit> units, final Route route) {
     Preconditions.checkArgument(!units.isEmpty());
     final MoveDelegate moveDelegate = moveDelegate(route.getStart().getData());
     final Collection<Unit> transports =

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/FinishedBattleTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/FinishedBattleTest.java
@@ -1,0 +1,75 @@
+package games.strategy.triplea.delegate.battle;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
+import static games.strategy.triplea.delegate.GameDataTestUtil.battleship;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.MoveDelegate;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.triplea.java.collections.CollectionUtils;
+
+public class FinishedBattleTest extends AbstractClientSettingTestCase {
+  final GameData pos2GameData = TestMapGameData.PACT_OF_STEEL_2.getGameData();
+  final Territory sz2 = territory("2 Sea Zone", pos2GameData);
+  final Territory sz3 = territory("3 Sea Zone", pos2GameData);
+  final Territory norway = territory("Norway", pos2GameData);
+  final Territory uk = territory("United Kingdom", pos2GameData);
+
+  @Test
+  void testTransportedByClearedAfterDependentBattle() {
+    assertEquals("Germans", sz3.getOwner().getName());
+    // Clear all units in Norway since we just want to land uncontested there.
+    norway.getUnitCollection().clear();
+
+    Unit battleship = getSingleUnit(sz2, battleship(pos2GameData));
+    Unit transport = getSingleUnit(sz2, transport(pos2GameData));
+    Unit tank = getSingleUnit(uk, armour(pos2GameData));
+
+    GamePlayer british = GameDataTestUtil.british(pos2GameData);
+    IDelegateBridge bridge = newDelegateBridge(british);
+
+    advanceToStep(bridge, "CombatMove");
+    MoveDelegate moveDelegate = GameDataTestUtil.moveDelegate(pos2GameData);
+    moveDelegate.setDelegateBridgeAndPlayer(bridge);
+    moveDelegate.start();
+    // First, move the battleship to sz3 to capture the convoy zone.
+    GameDataTestUtil.move(List.of(battleship), new Route(sz2, sz3));
+    // Then, load a transport and land a tank in Norway.
+    GameDataTestUtil.load(List.of(tank), new Route(uk, sz2));
+    GameDataTestUtil.move(List.of(transport, tank), new Route(sz2, sz3));
+    GameDataTestUtil.move(List.of(tank), new Route(sz3, norway));
+    moveDelegate.end();
+    // TRANSPORTED_BY is still set, since there's a dependent battle.
+    assertEquals(transport, tank.getTransportedBy());
+
+    advanceToStep(bridge, "Combat");
+    BattleDelegate battleDelegate = GameDataTestUtil.battleDelegate(pos2GameData);
+    battleDelegate.setDelegateBridgeAndPlayer(bridge);
+    battleDelegate.start();
+    // TRANSPORTED_BY should now be cleared since the dependent battle has been resolved.
+    assertEquals(null, tank.getTransportedBy());
+  }
+
+  private Unit getSingleUnit(Territory t, UnitType type) {
+    Collection<Unit> units = CollectionUtils.getMatches(t.getUnits(), Matches.unitIsOfType(type));
+    assertEquals(1, units.size());
+    return CollectionUtils.getAny(units);
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/FinishedBattleTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/FinishedBattleTest.java
@@ -38,12 +38,12 @@ public class FinishedBattleTest extends AbstractClientSettingTestCase {
     // Clear all units in Norway since we just want to land uncontested there.
     norway.getUnitCollection().clear();
 
-    Unit battleship = getSingleUnit(sz2, battleship(pos2GameData));
-    Unit transport = getSingleUnit(sz2, transport(pos2GameData));
-    Unit tank = getSingleUnit(uk, armour(pos2GameData));
+    final Unit battleship = getSingleUnit(sz2, battleship(pos2GameData));
+    final Unit transport = getSingleUnit(sz2, transport(pos2GameData));
+    final Unit tank = getSingleUnit(uk, armour(pos2GameData));
 
-    GamePlayer british = GameDataTestUtil.british(pos2GameData);
-    IDelegateBridge bridge = newDelegateBridge(british);
+    final GamePlayer british = GameDataTestUtil.british(pos2GameData);
+    final IDelegateBridge bridge = newDelegateBridge(british);
 
     advanceToStep(bridge, "CombatMove");
     MoveDelegate moveDelegate = GameDataTestUtil.moveDelegate(pos2GameData);


### PR DESCRIPTION
## Change Summary & Additional Notes
This fixes https://github.com/triplea-game/triplea/issues/12013, which was caused by units still having a stale `transportedBy` property set under some circumstances. This would happen when there's an uncontested convoy zone capture before a landing and where the transport didn't participate in the convoy zone capture.
This is a pre-2.6 bug.

Note: The issue resulting from this bug with air transports will only be fixed for new games, as existing save games will have the bad state already carried over from past turns.

Includes a unit test that reproduces the scenario.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Error when trying to air transport units that were previously unloaded with a regular transport under certain circumstances<!--END_RELEASE_NOTE-->
