### PR TITLE
Fix another case of cannot find step name error.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -823,11 +823,7 @@ public class MustFightBattle extends DependentBattle
   }
 
   public Optional<String> findStepNameForFiringUnits(Collection<Unit> firingUnits) {
-    System.err.println("Checking:" + firingUnits);
     for (final var entry : Optional.ofNullable(stepFiringUnits).orElse(Map.of()).entrySet()) {
-      System.err.println(entry.getKey() + " / " + entry.getValue());
-      System.err.println(
-          " --> " + CollectionUtils.getAny(entry.getValue()).getUnitAttachment().getCanNotTarget());
       if (entry.getValue().containsAll(firingUnits)) {
         return Optional.of(entry.getKey());
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -823,7 +823,11 @@ public class MustFightBattle extends DependentBattle
   }
 
   public Optional<String> findStepNameForFiringUnits(Collection<Unit> firingUnits) {
+    System.err.println("Checking:" + firingUnits);
     for (final var entry : Optional.ofNullable(stepFiringUnits).orElse(Map.of()).entrySet()) {
+      System.err.println(entry.getKey() + " / " + entry.getValue());
+      System.err.println(
+          " --> " + CollectionUtils.getAny(entry.getValue()).getUnitAttachment().getCanNotTarget());
       if (entry.getValue().containsAll(firingUnits)) {
         return Optional.of(entry.getKey());
       }
@@ -1284,7 +1288,7 @@ public class MustFightBattle extends DependentBattle
   }
 
   /**
-   * Returns only the relevant non-combatant units present in the specified collection.
+   * Returns only the relevant combatant units present in the specified collection.
    *
    * @return a collection containing all the combatants in units non-combatants include such things
    *     as factories, aa guns, land units in a water battle.

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -245,7 +245,7 @@ public class MustFightBattle extends DependentBattle
     // mark units with no movement for all but air
     Collection<Unit> nonAir = CollectionUtils.getMatches(attackingUnits, Matches.unitIsNotAir());
     // we don't want to change the movement of transported land units if this is a sea battle
-    // so restrict non air to remove land units
+    // so restrict non-air to remove land units
     if (battleSite.isWater()) {
       nonAir = CollectionUtils.getMatches(nonAir, Matches.unitIsNotLand());
     }
@@ -705,7 +705,7 @@ public class MustFightBattle extends DependentBattle
         List.of());
     display.listBattleSteps(battleId, stepStrings);
     if (!headless) {
-      // take the casualties with least movement first
+      // take the casualties with the least movement first
       CasualtySortingUtil.sortPreBattle(attackingUnits);
       CasualtySortingUtil.sortPreBattle(defendingUnits);
       SoundUtils.playBattleType(attacker, attackingUnits, defendingUnits, bridge);
@@ -844,9 +844,9 @@ public class MustFightBattle extends DependentBattle
         || Properties.getRetreatingUnitsRemainInPlace(gameData.getProperties())) {
       return Set.of(battleSite);
     }
-    // its possible that a sub retreated to a territory we came from, if so we can no longer retreat
-    // there
-    // or if we are moving out of a territory containing enemy units, we cannot retreat back there
+    // it's possible that a sub retreated to a territory we came from, if so we can no longer
+    // retreat there or if we are moving out of a territory containing enemy units, we cannot
+    // retreat back there
     final Predicate<Unit> enemyUnitsThatPreventRetreat =
         PredicateBuilder.of(Matches.enemyUnit(attacker))
             .and(Matches.unitIsNotInfrastructure())
@@ -1260,7 +1260,7 @@ public class MustFightBattle extends DependentBattle
   }
 
   /**
-   * Removes non combatants from the requested battle side and returns them
+   * Removes non-combatants from the requested battle side and returns them.
    *
    * @return the removed units
    */

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -205,7 +205,7 @@ public class MockGameData {
       lenient().when(unitType.getData()).thenReturn(gameData);
       unitTypeList.addUnitType(unitType);
     }
-    when(gameData.getUnitTypeList()).thenReturn(unitTypeList);
+    lenient().when(gameData.getUnitTypeList()).thenReturn(unitTypeList);
     return this;
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes
Fixes: https://github.com/triplea-game/triplea/issues/12022
This was caused by land units loaded on transports getting considered for canNotTarget step name splitting logic, when they shouldn't have been given they wouldn't participate in the combat.

The fix is actually very similar to https://github.com/triplea-game/triplea/pull/11773, except that one was applying the logic only to attackers. This change extends the logic to defenders.

A test is included.
Note: This is a 2.6 bug, since it's in the refactored combat code that was done in 2.6.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
