### PR TITLE
Bump wiremock to 2.35.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ subprojects {
         sonatypeGoodiesPrefsVersion = '2.3.6'
         substanceVersion = '4.5.0'
         wireMockJunit5Version = '1.3.1'
-        wireMockVersion = '2.27.2'
+        wireMockVersion = '2.35.1'
         xchartVersion = '3.8.5'
         xmlUnitCore = '2.9.1'
         xmlUnitMatchers = '2.9.1'

--- a/http-clients/error-reporting-client/build.gradle
+++ b/http-clients/error-reporting-client/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     implementation project(":http-clients:http-client-lib")
     implementation project(":lib:java-extras")
     testImplementation "ru.lanwen.wiremock:wiremock-junit5:$wireMockJunit5Version"
-    testImplementation "com.github.tomakehurst:wiremock:$wireMockVersion"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:$wireMockVersion"
     testImplementation project(":lib:test-common")
 }

--- a/http-clients/feign-common/build.gradle
+++ b/http-clients/feign-common/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation project(":game-app:domain-data")
     implementation project(":lib:java-extras")
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
-    testImplementation "com.github.tomakehurst:wiremock:$wireMockVersion"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:$wireMockVersion"
     testImplementation "ru.lanwen.wiremock:wiremock-junit5:$wireMockJunit5Version"
     testImplementation project(":lib:test-common")
 }

--- a/http-clients/github-client/build.gradle
+++ b/http-clients/github-client/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     implementation project(":http-clients:feign-common")
     implementation project(":lib:java-extras")
     testImplementation "ru.lanwen.wiremock:wiremock-junit5:$wireMockJunit5Version"
-    testImplementation "com.github.tomakehurst:wiremock-jre8:$  wireMockVersion"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:$wireMockVersion"
     testImplementation project(":lib:test-common")
 }

--- a/http-clients/github-client/build.gradle
+++ b/http-clients/github-client/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     implementation project(":http-clients:feign-common")
     implementation project(":lib:java-extras")
     testImplementation "ru.lanwen.wiremock:wiremock-junit5:$wireMockJunit5Version"
-    testImplementation "com.github.tomakehurst:wiremock:$wireMockVersion"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:$  wireMockVersion"
     testImplementation project(":lib:test-common")
 }

--- a/http-clients/lobby-client/build.gradle
+++ b/http-clients/lobby-client/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation project(":lib:java-extras")
     implementation project(":lib:websocket-client")
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
-    testImplementation "com.github.tomakehurst:wiremock:$wireMockVersion"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:$wireMockVersion"
     testImplementation "com.google.code.gson:gson:$gsonVersion"
     testImplementation "ru.lanwen.wiremock:wiremock-junit5:$wireMockJunit5Version"
     testImplementation project(":lib:test-common")


### PR DESCRIPTION
This seems to be the latest security release from the 2.x line.

Also switches to wiremock-jre8 since the updated 2.x version is only published under that name.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
