### PR TITLE
Switch defaultGameUri to an actual Uri like 2.5.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -87,7 +87,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
       ClientSetting.defaultGameUri.resetValue();
     } else {
       ClientSetting.defaultGameName.setValue(gameData.getGameName());
-      ClientSetting.defaultGameUri.setValue(xmlFile.toAbsolutePath().toString());
+      ClientSetting.defaultGameUri.setValue(xmlFile.toUri().toString());
     }
     ClientSetting.flush();
   }
@@ -213,9 +213,8 @@ public class GameSelectorModel extends Observable implements GameSelector {
       final Path gameFile = pathFromGameUri(gameUri);
 
       // starts with check is because we don't want to load a game file by default that is not
-      // within
-      // the map folders. (ie: if a previous version of triplea was using running a game within its
-      // root folder, we shouldn't open it)
+      // within the map folders. (ie: if a previous version of triplea was using running a game
+      // within its root folder, we shouldn't open it)
       return Files.exists(gameFile)
           && gameFile.startsWith(ClientFileSystemHelper.getUserRootFolder());
     } catch (final IllegalArgumentException e) {


### PR DESCRIPTION
## Change Summary & Additional Notes
This reverts a change to the format of the pref that was introduced in 2.6. The change seems unnecessary and just causes compatibility errors between 2.5 and 2.6.

Fixes the 2.5 error that's caused by 2.6: https://github.com/triplea-game/triplea/issues/11728

Looks like the behavior change was introduced by: https://github.com/triplea-game/triplea/pull/9034

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
