### PR TITLE
Build: split tests that need database from those that do not

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,33 @@ subprojects {
         }
     }
 
+    //  'test' runs only the tests that do _not_ need a database
     test {
-        useJUnitPlatform()
+        useJUnitPlatform() {
+            excludeTags 'RequiresDatabase'
+        }
     }
+
+    //  'testWithDatabase' runs only the tests that need a database
+    tasks.register('testWithDatabase', Test) {
+        description = 'Runs integration tests.'
+        group = 'verification'
+
+        dependsOn(":spitfire-server:database:flywayMigrateLobbyDb")
+        dependsOn(":spitfire-server:database:flywayMigrateErrorReportDb")
+
+        useJUnitPlatform() {
+            includeTags 'RequiresDatabase'
+        }
+    }
+
+    //  - 'testAll' runs all tests
+    task testAll {
+        dependsOn testWithDatabase
+        dependsOn test
+    }
+
+    //  - 'check' should run ALL validations, tests, spotlessChecks, everything..
+    check.dependsOn testAll
+
 }

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -46,6 +46,19 @@ IDEA should automatically find.  Look in 'run configurations' to launch the game
 ./game-app/run/check
 ```
 
+## Run Tests
+
+```
+./gradlew test
+```
+
+## Run Tests that need a running database
+
+```
+./gradlew testWithDatabase
+```
+
+
 ## Run Formatting
 
 We use 'google java format', be sure to install the plugin in your IDE to properly format
@@ -121,7 +134,7 @@ The deployment code is inside of the '[/infrastructure](./infrastructure)' folde
 We use [ansible](https://www.ansible.com/) to execute deployments.
 
 You can test out deployment code by first launching a virtual machine and then running a deployment
-against that virtual machine. See '[infrastructure/vagrant/REAMDE.md](./infrastructure/vagrant/REAMDE.md)'
+against that virtual machine. See '[infrastructure/vagrant/README.md](./infrastructure/vagrant/README.md)'
 for more information.
 
 # Pitfalls and Pain Points to be aware of

--- a/lib/test-common/src/main/java/org/triplea/test/common/RequiresDatabase.java
+++ b/lib/test-common/src/main/java/org/triplea/test/common/RequiresDatabase.java
@@ -1,0 +1,17 @@
+package org.triplea.test.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * 'RequiresDatabase' means a database needs to be running (presumably on docker) for the test to
+ * pass. Tests annotated with 'RequiresDatabase' will not run with 'gradle test' task but will
+ * instead run with the 'check', 'testAll' or 'testWithDatabase' tasks.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("RequiresDatabase")
+public @interface RequiresDatabase {}

--- a/servers/error-reporting/build.gradle
+++ b/servers/error-reporting/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     testImplementation "com.github.database-rider:rider-junit5:$databaseRiderVersion"
     testImplementation "io.dropwizard:dropwizard-testing:$dropwizardVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+    testImplementation project(':lib:test-common')
     testImplementation project(':servers:server-test-support')
     testImplementation project(':spitfire-server:database-test-support')
 }

--- a/servers/error-reporting/src/test/java/org/triplea/modules/error/reporting/ErrorReportControllerIntegrationTest.java
+++ b/servers/error-reporting/src/test/java/org/triplea/modules/error/reporting/ErrorReportControllerIntegrationTest.java
@@ -11,11 +11,10 @@ import org.triplea.http.client.error.report.CanUploadRequest;
 import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 import org.triplea.http.client.error.report.ErrorReportResponse;
+import org.triplea.test.common.RequiresDatabase;
 
 @ExtendWith(ErrorReportServerTestExtension.class)
-// @ExtendWith(SpitfireDatabaseTestSupport.class)
-// @ExtendWith(DBUnitExtension.class)
-// @DataSet(value = ControllerIntegrationTest.DATA_SETS, useSequenceFiltering = false)
+@RequiresDatabase
 class ErrorReportControllerIntegrationTest {
   private final ErrorReportClient client;
 

--- a/servers/error-reporting/src/test/java/org/triplea/modules/error/reporting/ErrorReportServerTestExtension.java
+++ b/servers/error-reporting/src/test/java/org/triplea/modules/error/reporting/ErrorReportServerTestExtension.java
@@ -3,6 +3,7 @@ package org.triplea.modules.error.reporting;
 import io.dropwizard.testing.DropwizardTestSupport;
 import org.triplea.server.error.reporting.ErrorReportingConfiguration;
 import org.triplea.server.error.reporting.ErrorReportingServer;
+import org.triplea.test.common.RequiresDatabase;
 import org.triplea.test.support.DropwizardServerExtension;
 
 /**
@@ -10,6 +11,7 @@ import org.triplea.test.support.DropwizardServerExtension;
  * extension will launch a drop wizard server when the test starts up. If a server is already
  * running at the start of a test, it will be re-used.
  */
+@RequiresDatabase
 public class ErrorReportServerTestExtension
     extends DropwizardServerExtension<ErrorReportingConfiguration> {
 

--- a/servers/error-reporting/src/test/java/org/triplea/modules/error/reporting/db/ErrorReportingDaoTest.java
+++ b/servers/error-reporting/src/test/java/org/triplea/modules/error/reporting/db/ErrorReportingDaoTest.java
@@ -18,10 +18,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.triplea.server.error.reporting.upload.ErrorReportingDao;
 import org.triplea.server.error.reporting.upload.InsertHistoryRecordParams;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @ExtendWith(ErrorReportingModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 final class ErrorReportingDaoTest {
   private final ErrorReportingDao errorReportingDao;
 

--- a/spitfire-server/dropwizard-server/src/test/java/org/triplea/spitfire/server/ControllerIntegrationTest.java
+++ b/spitfire-server/dropwizard-server/src/test/java/org/triplea/spitfire/server/ControllerIntegrationTest.java
@@ -18,11 +18,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.SystemIdLoader;
 import org.triplea.http.client.LobbyHttpClientConfig;
+import org.triplea.test.common.RequiresDatabase;
 
 @ExtendWith(SpitfireServerTestExtension.class)
 @ExtendWith(SpitfireDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
 @DataSet(value = ControllerIntegrationTest.DATA_SETS, useSequenceFiltering = false)
+@RequiresDatabase
 public abstract class ControllerIntegrationTest {
 
   @BeforeAll

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
@@ -14,10 +14,12 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class AccessLogDaoTest {
   private static final String EMPTY_ACCESS_LOG =
       "access_log/user_role.yml,access_log/lobby_user.yml";

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/api/key/GameHostingApiKeyDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/api/key/GameHostingApiKeyDaoTest.java
@@ -10,10 +10,12 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class GameHostingApiKeyDaoTest {
 
   private final GameHostingApiKeyDao gameHostApiKeyDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 import org.triplea.db.dao.user.role.UserRole;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(
     value =
@@ -24,6 +25,7 @@ import org.triplea.db.dao.user.role.UserRole;
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class PlayerApiKeyDaoTest {
 
   private static final int USER_ID = 50;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDaoTest.java
@@ -7,10 +7,12 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class LobbyChatHistoryDaoTest {
 
   private final LobbyChatHistoryDao lobbyChatHistoryDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/lobby/games/LobbyGameDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/lobby/games/LobbyGameDaoTest.java
@@ -11,10 +11,12 @@ import org.triplea.db.LobbyModuleDatabaseTestSupport;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.http.client.lobby.game.lobby.watcher.ChatMessageUpload;
 import org.triplea.http.client.lobby.game.lobby.watcher.LobbyGameListing;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class LobbyGameDaoTest {
   private final LobbyGameDao lobbyGameDao;
 

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/BadWordsDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/BadWordsDaoTest.java
@@ -15,11 +15,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(value = "bad_words/bad_word.yml", useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class BadWordsDaoTest {
   private static final List<String> expectedBadWords = List.of("aaa", "one", "two", "zzz");
 

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/ModeratorAuditHistoryDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/ModeratorAuditHistoryDaoTest.java
@@ -16,6 +16,7 @@ import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @DataSet(
@@ -26,6 +27,7 @@ import org.triplea.db.LobbyModuleDatabaseTestSupport;
     useSequenceFiltering = false)
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class ModeratorAuditHistoryDaoTest {
 
   private static final int MODERATOR_ID = 900000;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/ModeratorsDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/ModeratorsDaoTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 import org.triplea.db.dao.user.role.UserRole;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(
     value = "moderators/user_role.yml, moderators/lobby_user.yml, moderators/access_log.yml",
@@ -22,6 +23,7 @@ import org.triplea.db.dao.user.role.UserRole;
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class ModeratorsDaoTest {
 
   private static final int NOT_MODERATOR_ID = 100000;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/chat/history/GameChatHistoryDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/chat/history/GameChatHistoryDaoTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(
     value =
@@ -24,6 +25,7 @@ import org.triplea.db.LobbyModuleDatabaseTestSupport;
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class GameChatHistoryDaoTest {
   private static final String SIR_HOSTS_A_LOT = "sir_hosts_a_lot";
   private static final String SIR_HOSTS_A_LITTLE = "sir_hosts_a_little";

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/player/info/PlayerInfoForModeratorDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/player/info/PlayerInfoForModeratorDaoTest.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class PlayerInfoForModeratorDaoTest {
 
   private final PlayerInfoForModeratorDao playerInfoForModeratorDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/temp/password/TempPasswordDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/temp/password/TempPasswordDaoTest.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(
     value =
@@ -21,6 +22,7 @@ import org.triplea.db.LobbyModuleDatabaseTestSupport;
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class TempPasswordDaoTest {
 
   private static final String USERNAME = "username";

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/temp/password/TempPasswordHistoryDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/temp/password/TempPasswordHistoryDaoTest.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(
     cleanBefore = true,
@@ -15,6 +16,7 @@ import org.triplea.db.LobbyModuleDatabaseTestSupport;
     useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@RequiresDatabase
 class TempPasswordHistoryDaoTest {
 
   private static final String USERNAME = "username";

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/UserJdbiDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/UserJdbiDaoTest.java
@@ -14,11 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 import org.triplea.db.dao.user.role.UserRole;
 import org.triplea.db.dao.user.role.UserRoleLookup;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(value = "user/user_role.yml,user/lobby_user.yml", useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class UserJdbiDaoTest {
 
   private static final int USER_ID = 900000;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/ban/UserBanDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/ban/UserBanDaoTest.java
@@ -19,10 +19,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class UserBanDaoTest {
   private final UserBanDao userBanDao;
 

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/role/UserRoleDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/role/UserRoleDaoTest.java
@@ -9,11 +9,13 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(value = "user_role/initial.yml", useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class UserRoleDaoTest {
 
   private final UserRoleDao userRoleDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class UsernameBanDaoTest {
 
   private final UsernameBanDao usernameBanDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/modules/user/account/login/LobbyLoginMessageDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/modules/user/account/login/LobbyLoginMessageDaoTest.java
@@ -9,10 +9,12 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class LobbyLoginMessageDaoTest {
 
   private final LobbyLoginMessageDao lobbyLoginMessageDao;

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
@@ -14,11 +14,13 @@ import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.maps.MapsModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @AllArgsConstructor
 @DataSet(value = "map_index.yml", useSequenceFiltering = false)
 @ExtendWith(MapsModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class MapIndexDaoTest {
 
   private final MapIndexDao mapIndexDao;

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
@@ -11,10 +11,12 @@ import java.time.ZoneOffset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.maps.MapsModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(value = "map_index.yml,map_tag_value.yml", useSequenceFiltering = false)
 @ExtendWith(MapsModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
+@RequiresDatabase
 class MapListingDaoTest {
 
   private final MapListingDao mapListingDao;

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/tags/MapTagsDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/tags/MapTagsDaoTest.java
@@ -13,11 +13,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.maps.MapsModuleDatabaseTestSupport;
+import org.triplea.test.common.RequiresDatabase;
 
 @DataSet(value = "map_index.yml,map_tag_value.yml", useSequenceFiltering = false)
 @ExtendWith(MapsModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
 @AllArgsConstructor
+@RequiresDatabase
 class MapTagsDaoTest {
 
   private final MapTagsDao mapTagsDao;


### PR DESCRIPTION
Update adds a tag to tests that need a database. We then split the build such that 'test' no longer runs these tests, and './gradlew testWithDatabase' does.

This allows for './gradlew test' to no longer depend on any running docker containers & faster game-headed development.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->
