### PR TITLE
Build: Remove 'check' task when building game-installers

### DIFF
--- a/.github/workflows/upload-game-installers.yml
+++ b/.github/workflows/upload-game-installers.yml
@@ -25,8 +25,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-      - name: Run Build Checks
-        run: ./game-app/run/check
       - name: Build Installers
         run: ./game-app/run/package
         env:


### PR DESCRIPTION
We already run './gradlew check' against merges to master and any PR. Thus, the check as pre-requisite for building game installers is redundant.

This update opens up a possibility that a 'check' could fail after merging to master & we still build game installer artifacts. In this case we will still get notification that the main branch build has failed. Such a situation should be rare enough that the simplicity in not having to configure our branch tests twice, is worth the trade-off.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->
