### PR TITLE
Build: remove explicit compose-up in github action

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,9 +15,5 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-      - uses: isbang/compose-action@v1.5.1
-        with:
-          compose-file: ".docker/docker-compose.yml"
       - name: Run Build Checks
-        run: ./verify --exclude-task composeUp
-
+        run: ./verify


### PR DESCRIPTION
Gradle script already will do a 'compose-up'

## Notes to reviewer

Not sure if this will work, if build fails we can just close.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->
