### PR TITLE
PR Template: update header text to be 'notes to reviewer'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
-## Change Summary & Additional Notes
-
 <!--
-- If multiple commits, summarize what has changed
-- Mention any manual testing done.
-- If there are UI updates, please include before & after screenshots
+Please add any notes for the reviewers in the section below.
+  Things to include:
+     - If this PR has multiple commits, summarize what has changed
+     - Mention any manual testing done.
+     - If there are UI updates, please include before & after screenshots
 -->
+
+## Notes to Reviewer


### PR DESCRIPTION
## Notes to reviewer

The "notes to reviewer" text seems a bit better compared to "Change Summary & Additional Notes"

For single-commit PRs, there is already a change summary present between the commit title & comment which are auto-filled in by the PR. For these kinds of PRs, a section titled "change summary" redundant.  At worst, this can be confusing and lead to a practice where less details are put in the commit comment and more detail are put in the "change summary".

Thus, "notes to reviewer" seems better as it is more explicit that these are comments intended only for the reviewers & not the commit history. 

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->
