### PR TITLE
Fix 2.6 regression with mini map territory scaling.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
@@ -60,7 +60,37 @@ public class SmallMapImageManager {
     if (t.isWater()) {
       return;
     }
+    // create a large image for the territory
     final Rectangle bounds = new Rectangle(mapData.getBoundingRect(t.getName()));
+    final Image largeImage = createLargeImage(t, bounds, mapData);
+
+    // scale it down
+    final double ratioX = view.getRatioX();
+    final double ratioY = view.getRatioY();
+    int thumbWidth = (int) (bounds.width * ratioX);
+    int thumbHeight = (int) (bounds.height * ratioY);
+    // the images won't overlap perfectly after being scaled, make them a little bigger to
+    // re-balance that
+    thumbWidth += 3;
+    thumbHeight += 3;
+    final int thumbsX = (int) (bounds.x * ratioX) - 1;
+    final int thumbsY = (int) (bounds.y * ratioY) - 1;
+    // create the thumb image
+    final Image thumbImage = Util.newImage(thumbWidth, thumbHeight, true);
+    {
+      final Graphics g = thumbImage.getGraphics();
+      g.drawImage(largeImage, 0, 0, thumbWidth, thumbHeight, null);
+      g.dispose();
+    }
+    {
+      final Graphics g = offscreen.getGraphics();
+      // draw it on our offscreen
+      g.drawImage(thumbImage, thumbsX, thumbsY, thumbWidth, thumbHeight, null);
+      g.dispose();
+    }
+  }
+
+  private Image createLargeImage(Territory t, Rectangle bounds, MapData mapData) {
     // create a large image for the territory
     final Image largeImage = Util.newImage(bounds.width, bounds.height, true);
     // make it transparent
@@ -82,35 +112,10 @@ public class SmallMapImageManager {
           RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
       g.setRenderingHint(
           RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
-      final LandTerritoryDrawable drawable = new LandTerritoryDrawable(t.getName());
-      drawable.draw(bounds, data, g, mapData, mapData.getSmallMapTerritorySaturation());
+      final LandTerritoryDrawable drawable = new LandTerritoryDrawable(t);
+      drawable.draw(bounds, g, mapData, mapData.getSmallMapTerritorySaturation());
       g.dispose();
     }
-
-    // scale it down
-    final double ratioX = view.getRatioX();
-    final double ratioY = view.getRatioX();
-    int thumbWidth = (int) (bounds.width * ratioX);
-    int thumbHeight = (int) (bounds.height * ratioY);
-    // make the image a little bigger
-    // the images wont overlap perfectly after being scaled, make them a little bigger to re-balance
-    // that
-    thumbWidth += 3;
-    thumbHeight += 3;
-    final int thumbsX = (int) (bounds.x * ratioX) - 1;
-    final int thumbsY = (int) (bounds.y * ratioY) - 1;
-    // create the thumb image
-    final Image thumbImage = Util.newImage(thumbWidth, thumbHeight, true);
-    {
-      final Graphics g = thumbImage.getGraphics();
-      g.drawImage(largeImage, 0, 0, thumbWidth, thumbHeight, null);
-      g.dispose();
-    }
-    {
-      final Graphics g = offscreen.getGraphics();
-      // draw it on our offscreen
-      g.drawImage(thumbImage, thumbsX, thumbsY, thumbWidth, thumbHeight, null);
-      g.dispose();
-    }
+    return largeImage;
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -253,7 +253,7 @@ public class TileManager {
     drawing.add(new BattleDrawable(territory.getName()));
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     if (!territory.isWater()) {
-      drawing.add(new LandTerritoryDrawable(territory.getName()));
+      drawing.add(new LandTerritoryDrawable(territory));
     } else {
       if (ta != null) {
         // Kamikaze Zones
@@ -482,7 +482,7 @@ public class TileManager {
   }
 
   /**
-   * Returns the rectangle within which all of the specified units will be drawn stacked or {@code
+   * Returns the rectangle within which all the specified units will be drawn stacked or {@code
    * null} if no such rectangle exists. Because the units are assumed to be drawn stacked, the
    * returned rectangle will always have a size equal to the standard unit image size.
    */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
@@ -1,25 +1,22 @@
 package games.strategy.triplea.ui.screen.drawable;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.ui.mapdata.MapData;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import lombok.AllArgsConstructor;
 
 /**
  * Draws a black outline around the associated territory and draws a solid color over the territory
- * interior. The color is based on the territory owner and whether or not the territory is
- * impassable. Intended only for use with land territories.
+ * interior. The color is based on the territory owner and whether the territory is impassable.
+ * Intended only for use with land territories.
  */
+@AllArgsConstructor
 public class LandTerritoryDrawable extends TerritoryDrawable {
-  private final String territoryName;
-
-  public LandTerritoryDrawable(final String territoryName) {
-    this.territoryName = territoryName;
-  }
+  private final Territory territory;
 
   @Override
   public void draw(
@@ -27,17 +24,15 @@ public class LandTerritoryDrawable extends TerritoryDrawable {
       final GameData data,
       final Graphics2D graphics,
       final MapData mapData) {
-    draw(bounds, data, graphics, mapData, 1.0f);
+    draw(bounds, graphics, mapData, 1.0f);
   }
 
   /** Determine territory color and set saturation to then draw the territory. */
   public void draw(
       final Rectangle bounds,
-      final GameState data,
       final Graphics2D graphics,
       final MapData mapData,
       final float saturation) {
-    final Territory territory = data.getMap().getTerritory(territoryName);
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
 
     final Color territoryColor =


### PR DESCRIPTION
A refactoring used getRatioX() instead of getRatioY().

Also some related code and comment clean ups.

Fixes https://github.com/triplea-game/triplea/issues/12117.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
