### PR TITLE
Dev Build: add servers to docker compose, automatically start services with gradlew run

### DIFF
--- a/.docker/compose-up.sh
+++ b/.docker/compose-up.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./gradlew shadowJar
+docker compose -f .docker/docker-compose.yml --ansi never -p triplea up

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,5 +1,29 @@
+# This docker-compose file depends on './gradlew shadowJar'
+#
+# Launches all of the background servers used by TripleA.
+# The main entrypoint to those services is NGINX which
+# is listening on localhost:80
+#
 version: '3'
 services:
+  lobby:
+    build:
+      context: ../spitfire-server/dropwizard-server/
+      dockerfile: Dockerfile
+    environment:
+      - DATABASE_USER=lobby_user
+      - DATABASE_PASSWORD=lobby
+      - DB_URL=database:5432/lobby_db
+    depends_on:
+      - database
+  game-support-server:
+    build:
+      context: ../servers/game-support/server/
+      dockerfile: Dockerfile
+    environment:
+      - DB_URL=database:5432/error_report
+    depends_on:
+      - database
   database:
     image: postgres:10
     environment:
@@ -10,7 +34,16 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/01-init.sql
     ports:
       - "5432:5432"
+    healthcheck:
+      test: echo 'select 1' | psql -h localhost -U postgres  | grep -q '1 row'
+      interval: 3s
+      retries: 10
+      timeout: 3s
   nginx:
     image: nginx:stable-alpine-perl
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     ports:
       - "80:80"
+    links:
+      - game-support-server

--- a/.docker/nginx/default.conf
+++ b/.docker/nginx/default.conf
@@ -1,0 +1,48 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name localhost;
+
+    location / {
+      proxy_pass              http://lobby:8080;
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+      proxy_read_timeout  90;
+    }
+
+    location /game-connection/ws {
+      proxy_pass              http://lobby:8080;
+      proxy_http_version      1.1;
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+
+    location /player-connection/ws {
+      proxy_pass              http://lobby:8080;
+      proxy_http_version      1.1;
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+
+
+    location /game-support {
+      proxy_pass              http://game-support-server:8080;
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+      proxy_read_timeout  90;
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -227,7 +227,14 @@ subprojects {
     //  - 'check' should run ALL validations, tests, spotlessChecks, everything..
     check.dependsOn testAll
 
+    // composeUp is the same as running => docker compose -f .docker/full-stack.yml --ansi never -p triplea up
+    // composeBuild is the same as running => docker compose -f .docker/full-stack.yml --ansi never -p triplea build
     dockerCompose {
+        projectName = 'triplea'
         useComposeFiles = ['.docker/docker-compose.yml' ]
     }
+
+    // compose builds need WAR files for packaging, so we must run the corresponding package (shadowJar) tasks
+    composeBuild.dependsOn ":servers:game-support:server:shadowJar"
+    composeBuild.dependsOn ":spitfire-server:dropwizard-server:shadowJar"
 }

--- a/game-app/game-headed/build.gradle
+++ b/game-app/game-headed/build.gradle
@@ -63,6 +63,9 @@ task downloadAssets {
 
 run {
     dependsOn downloadAssets
+    dependsOn rootProject.composeUp
+    dependsOn(":spitfire-server:database:flywayMigrateLobbyDb")
+    dependsOn(":spitfire-server:database:flywayMigrateErrorReportDb")
 }
 
 runShadow {

--- a/lib/feign-common/src/main/java/org/triplea/http/client/HttpClient.java
+++ b/lib/feign-common/src/main/java/org/triplea/http/client/HttpClient.java
@@ -16,6 +16,8 @@ import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+
+import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/servers/game-support/server/Dockerfile
+++ b/servers/game-support/server/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:11-jre-slim-buster
+
+EXPOSE 8080
+ADD configuration.yml /
+ADD build/libs/game-support-server.jar /
+CMD java -jar game-support-server.jar server /configuration.yml

--- a/servers/game-support/server/build.gradle
+++ b/servers/game-support/server/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
-archivesBaseName = "$group-$name"
+archivesBaseName = "game-support-server"
 mainClassName = 'org.triplea.server.error.reporting.ErrorReportingServer'
 ext {
     releasesDir = file("$buildDir/releases")

--- a/servers/game-support/server/configuration.yml
+++ b/servers/game-support/server/configuration.yml
@@ -50,7 +50,7 @@ logging:
 server:
   applicationConnectors:
     - type: http
-      port: ${HTTP_PORT:-8090}
+      port: ${HTTP_PORT:-8080}
       # useForwardedHeaders is important for when behind a reverse proxy (NGINX)
       # Without this 'getRemoteAddr' will return the IP of the reverse proxy server.
       # By default when building locally useForwardedPorts should be 'false', but

--- a/servers/server-lib/build.gradle
+++ b/servers/server-lib/build.gradle
@@ -1,11 +1,3 @@
-plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
-}
-
-shadowJar {
-    archiveClassifier.set ''
-}
-
 dependencies {
     implementation "com.liveperson:dropwizard-websockets:$dropwizardWebsocketsVersion"
     implementation "io.dropwizard:dropwizard-auth:$dropwizardVersion"

--- a/spitfire-server/dropwizard-server/Dockerfile
+++ b/spitfire-server/dropwizard-server/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:11-jre-slim-buster
+
+EXPOSE 8080
+ADD configuration.yml /
+ADD build/libs/triplea-dropwizard-server.jar /
+CMD java -jar triplea-dropwizard-server.jar server /configuration.yml

--- a/spitfire-server/dropwizard-server/build.gradle
+++ b/spitfire-server/dropwizard-server/build.gradle
@@ -9,8 +9,6 @@ ext {
     releasesDir = file("$buildDir/releases")
 }
 
-run.dependsOn rootProject.composeUp
-
 jar {
     manifest {
         attributes 'Main-Class': mainClassName


### PR DESCRIPTION

After this update, `./gradlew run` will automatically invoke composeUp to start all services. The locally running game client can then connect to the locally running lobby at "http://locahost"  (port 80).

This will send lobby login request to the locally running nginx which will then route the request to the lobby. This usage with nginx mirrors the production setup, and also simplifies localy configuration. Instead of having to configure the URL of every local service, we can configure that once in the nginx config and send all requests to the same 'locahost:80'

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer

Still need to update developer documentation. Planning to do that somewhat shortly (probably not as part of this PR, but soon :crossed_fingers: ).