### PR TITLE
Automatically format when 'verify' script is run

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,4 +16,7 @@ jobs:
           distribution: temurin
           java-version: 11
       - name: Run Build Checks
-        run: ./verify
+        # We skip 'spotlessApply' such that only 'spotlessCheck' will run to validate formatting.
+        # This is a good setup for a CI server, meanwhile if a developer runs 'verify', they
+        # will have the 'spotlessApply' task run and it will automatically format the code.
+        run: ./verify --exclude-task spotlessApply

--- a/verify
+++ b/verify
@@ -49,6 +49,6 @@ set -o pipefail
 set -eu
 
 checkDependency "docker" || installDocker
-"$scriptDir/gradlew" check $@
+"$scriptDir/gradlew" spotlessApply check $@
 "$scriptDir/.build/find-unused-dbunit-datasets"
 "$scriptDir/.build/code-convention-checks/check-custom-style" spitfire-server


### PR DESCRIPTION
This update changes the 'verify' script to also
run 'spotlessApply'. This automatically fixes any
formatting issues.

Meanwhile, we also update the CI build to skip the 'spotlessApply' task. This means if a developer
runs 'verify', they will automatically get formatting fixes; but if a branch with formatting problems is pushed it would fail the build.

For context, the `verify` script is run by CI to run all build verifications (AKA: checks, tests). This same script can be run by a developer as-is on their system to test their local branch.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
