### PR TITLE
Simplify, move variable from 'MapsClient.java' to where it is used

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -21,6 +21,8 @@ import org.triplea.util.Services;
 @Slf4j
 public final class ClientFileSystemHelper {
   public static final String USER_ROOT_FOLDER_NAME = "triplea";
+
+  @VisibleForTesting static final String MAPS_FOLDER_NAME = "downloadedMaps";
   private static Path codeSourceLocation;
 
   private ClientFileSystemHelper() {}
@@ -111,7 +113,7 @@ public final class ClientFileSystemHelper {
   @VisibleForTesting
   static Path getUserMapsFolder(final Supplier<Path> userHomeRootFolderSupplier) {
     final Path defaultDownloadedMapsFolder =
-        userHomeRootFolderSupplier.get().resolve(MapsClient.MAPS_FOLDER_NAME);
+        userHomeRootFolderSupplier.get().resolve(MAPS_FOLDER_NAME);
 
     // make sure folder override location is valid, if not notify user and reset it.
     final Optional<Path> path = ClientSetting.mapFolderOverride.getValue();

--- a/game-app/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -13,7 +13,6 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.game.ApplicationContext;
-import org.triplea.http.client.maps.listing.MapsClient;
 import org.triplea.io.FileUtils;
 import org.triplea.util.Services;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.triplea.http.client.maps.listing.MapsClient;
 import org.triplea.java.ThreadRunner;
 
 /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -149,10 +149,6 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
           UnitsDrawer.UnitFlagDrawMode.class,
           "UNIT_FLAG_DRAW_MODE",
           UnitsDrawer.UnitFlagDrawMode.NONE);
-  public static final ClientSetting<Path> userMapsFolderPath =
-      new PathClientSetting(
-          "USER_MAPS_FOLDER_PATH",
-          ClientFileSystemHelper.getUserRootFolder().resolve(MapsClient.MAPS_FOLDER_NAME));
   public static final ClientSetting<Integer> wheelScrollAmount =
       new IntegerClientSetting("WHEEL_SCROLL_AMOUNT", 60);
   public static final ClientSetting<String> playerName =

--- a/game-app/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -18,7 +18,7 @@ final class ClientFileSystemHelperTest {
       final Path result =
           ClientFileSystemHelper.getUserMapsFolder(() -> Path.of("/path/to/current"));
 
-      assertThat(result, is(Path.of("/path", "to", "current", MapsClient.MAPS_FOLDER_NAME)));
+      assertThat(result, is(Path.of("/path", "to", "current", ClientFileSystemHelper.MAPS_FOLDER_NAME)));
     }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -7,7 +7,6 @@ import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.triplea.http.client.maps.listing.MapsClient;
 
 @SuppressWarnings("InnerClassMayBeStatic")
 final class ClientFileSystemHelperTest {
@@ -18,7 +17,8 @@ final class ClientFileSystemHelperTest {
       final Path result =
           ClientFileSystemHelper.getUserMapsFolder(() -> Path.of("/path/to/current"));
 
-      assertThat(result, is(Path.of("/path", "to", "current", ClientFileSystemHelper.MAPS_FOLDER_NAME)));
+      assertThat(
+          result, is(Path.of("/path", "to", "current", ClientFileSystemHelper.MAPS_FOLDER_NAME)));
     }
   }
 }

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
@@ -12,7 +12,6 @@ import org.triplea.http.client.lobby.AuthenticationHeaders;
  */
 public interface MapsClient {
   String MAPS_LISTING_PATH = "/maps/listing";
-  String MAPS_FOLDER_NAME = "downloadedMaps";
 
   static MapsClient newClient(URI mapsServerUri) {
     return HttpClient.newClient(


### PR DESCRIPTION
The variable moved did not belong in MapsClient.java (not used there at all), on of its other usages could be deleted. This simplification moves the variable to where it is used.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
