### PR TITLE
Dev Builds: update nginx config for maps server redirect

### DIFF
--- a/.docker/nginx/default.conf
+++ b/.docker/nginx/default.conf
@@ -45,4 +45,13 @@ server {
       proxy_set_header        X-Forwarded-Proto $scheme;
       proxy_read_timeout  90;
     }
+
+    location /maps {
+      proxy_pass              http://maps-server:8080;
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+      proxy_read_timeout  90;
+    }
 }


### PR DESCRIPTION
Adds mapping for the nginx launched by docker compose to redirect /maps requests to a 'maps-server' (will update docker-compose in a future update to launch that server)

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
