### PR TITLE
Compose-up script: add bash '-e' flag

### DIFF
--- a/.docker/compose-up.sh
+++ b/.docker/compose-up.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+set -e
+
 ./gradlew shadowJar
 docker compose -f .docker/docker-compose.yml --ansi never -p triplea up


### PR DESCRIPTION
The '-e' flag will allow for the script to halt
if the first command fails, rather than continue
to what is an otherwise doomed 'compose-up' command.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
