### PR TITLE
Fix whenHitPointsDamagedChangesInto allowing move.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/history/change/HistoryChangeFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/change/HistoryChangeFactory.java
@@ -13,8 +13,10 @@ import org.triplea.java.collections.IntegerMap;
 public class HistoryChangeFactory {
 
   public TransformDamagedUnitsHistoryChange transformDamagedUnits(
-      final Territory location, final Collection<Unit> damagedUnits) {
-    return new TransformDamagedUnitsHistoryChange(location, damagedUnits);
+      final Territory location,
+      final Collection<Unit> damagedUnits,
+      final boolean markNoMovementOnNewUnits) {
+    return new TransformDamagedUnitsHistoryChange(location, damagedUnits, markNoMovementOnNewUnits);
   }
 
   public RemoveUnitsHistoryChange removeUnitsFromTerritory(

--- a/game-app/game-core/src/main/java/games/strategy/engine/history/change/units/RemoveUnitsHistoryChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/change/units/RemoveUnitsHistoryChange.java
@@ -62,7 +62,7 @@ public class RemoveUnitsHistoryChange implements HistoryChange {
         });
 
     transformDamagedUnitsHistoryChange =
-        new TransformDamagedUnitsHistoryChange(location, killedUnits);
+        new TransformDamagedUnitsHistoryChange(location, killedUnits, false);
 
     killedUnits.forEach(unit -> unit.setHits(originalHits.getInt(unit)));
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/history/change/units/TransformDamagedUnitsHistoryChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/change/units/TransformDamagedUnitsHistoryChange.java
@@ -40,9 +40,14 @@ public class TransformDamagedUnitsHistoryChange implements HistoryChange {
 
   CompositeChange attributeChanges = new CompositeChange();
 
+  final boolean markNoMovementOnNewUnits;
+
   public TransformDamagedUnitsHistoryChange(
-      final Territory location, final Collection<Unit> damagedUnits) {
+      final Territory location,
+      final Collection<Unit> damagedUnits,
+      final boolean markNoMovementOnNewUnits) {
     this.location = location;
+    this.markNoMovementOnNewUnits = markNoMovementOnNewUnits;
 
     // check if each of the damaged units are supposed to change when they take damage
     // if it is supposed to change, create the new unit and translate attributes from the old unit
@@ -68,11 +73,15 @@ public class TransformDamagedUnitsHistoryChange implements HistoryChange {
       return;
     }
 
-    this.change.add(
+    final CompositeChange compositeChange =
         new CompositeChange(
             ChangeFactory.addUnits(location, getNewUnits()),
             ChangeFactory.removeUnits(location, getOldUnits()),
-            attributeChanges));
+            attributeChanges);
+    if (markNoMovementOnNewUnits) {
+      compositeChange.add(ChangeFactory.markNoMovementChange(getNewUnits()));
+    }
+    this.change.add(compositeChange);
 
     bridge.addChange(this.change);
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -527,7 +527,6 @@ public class MustFightBattle extends DependentBattle
       final Collection<Unit> unitsKilledDuringRound,
       final IDelegateBridge bridge,
       final Side side) {
-
     final List<Unit> unitsThatMightTransform =
         CollectionUtils.getMatches(
             units,
@@ -536,7 +535,8 @@ public class MustFightBattle extends DependentBattle
         CollectionUtils.getMatches(
             unitsKilledDuringRound, Matches.unitAtMaxHitPointDamageChangesInto()));
     final TransformDamagedUnitsHistoryChange transformDamagedUnitsHistoryChange =
-        HistoryChangeFactory.transformDamagedUnits(battleSite, unitsThatMightTransform);
+        HistoryChangeFactory.transformDamagedUnits(battleSite, unitsThatMightTransform, true);
+
     transformDamagedUnitsHistoryChange.perform(bridge);
 
     cleanupKilledUnits(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -125,6 +125,7 @@ public class CasualtySelector {
 
     final CasualtyDetails casualtyDetails =
         hitsRemaining >= totalHitpoints
+                || sortedTargetsToPickFrom.size() == 1
                 || allTargetsOneTypeOneHitPoint(
                     sortedTargetsToPickFrom,
                     dependents,

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -422,7 +422,7 @@ public final class GameDataTestUtil {
     }
   }
 
-  static void assertMoveError(final Collection<Unit> units, final Route route) {
+  public static void assertMoveError(final Collection<Unit> units, final Route route) {
     Preconditions.checkArgument(!units.isEmpty());
     final String error = moveDelegate(route.getStart().getData()).move(units, route);
     if (error == null) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
@@ -293,10 +293,7 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
     assertFalse(Matches.unitHasMovementLeft().test(unit));
 
     // And just to double check, we can't move it.
-    advanceToStep(bridge, "NonCombatMove");
-    MoveDelegate moveDelegate = GameDataTestUtil.moveDelegate(gameData);
-    moveDelegate.setDelegateBridgeAndPlayer(bridge);
-    moveDelegate.start();
+    advanceToNonCombatMove(bridge);
     GameDataTestUtil.assertMoveError(sz23.getUnits(), new Route(sz23, sz25));
   }
 
@@ -305,6 +302,12 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
         (IEditableProperty<T>)
             gameData.getProperties().getEditablePropertiesByName().get(propertyName);
     property.setValue(value);
+  }
+
+  private void advanceToNonCombatMove(IDelegateBridge bridge) {
+    advanceToStep(bridge, "NonCombatMove");
+    moveDelegate(bridge.getData()).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(bridge.getData()).start();
   }
 
   private IDelegateBridge performCombatMove(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
@@ -11,6 +11,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.carrier;
 import static games.strategy.triplea.delegate.GameDataTestUtil.chinese;
 import static games.strategy.triplea.delegate.GameDataTestUtil.fighter;
 import static games.strategy.triplea.delegate.GameDataTestUtil.french;
+import static games.strategy.triplea.delegate.GameDataTestUtil.germanBattleship;
 import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
 import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
 import static games.strategy.triplea.delegate.GameDataTestUtil.japan;
@@ -20,6 +21,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
+import static games.strategy.triplea.delegate.GameDataTestUtil.unitType;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
 import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
@@ -32,6 +34,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -51,6 +54,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.MoveDelegate;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -58,6 +62,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.triplea.java.collections.CollectionUtils;
 
 class MustFightBattleTest extends AbstractClientSettingTestCase {
   @Test
@@ -222,7 +227,7 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
   }
 
   @Test
-  void testAlliedCarriedPlanesTransportedByIsResetWhenCancelingBattle() throws Exception {
+  void testAlliedCarriedPlanesTransportedByIsResetWhenCancelingBattle() {
     // Note: Test uses germans, british and france since other countries aren't at war on t1.
     final GameData gameData = TestMapGameData.GLOBAL1940.getGameData();
 
@@ -257,6 +262,42 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
     GameDataTestUtil.move(units, new Route(sz45, sz42));
     assertThat(fighters.get(0).getTransportedBy(), is(nullValue()));
     assertThat(fighters.get(1).getTransportedBy(), is(nullValue()));
+  }
+
+  @Test
+  void testCantMoveAfterHitTransform() {
+    final GameData gameData = TestMapGameData.TWW.getGameData();
+    final Territory sz23 = territory("23 Sea Zone", gameData);
+    removeFrom(sz23, sz23.getUnits());
+    final Territory sz25 = territory("25 Sea Zone", gameData);
+    removeFrom(sz25, sz25.getUnits());
+
+    addTo(sz25, germanBattleship(gameData).create(1, GameDataTestUtil.germany(gameData)));
+    addTo(sz23, unitType("americanDestroyer", gameData).create(1, GameDataTestUtil.usa(gameData)));
+
+    final Collection<Unit> attackers = List.copyOf(sz25.getUnits());
+    final IDelegateBridge bridge =
+        performCombatMove(GameDataTestUtil.germany(gameData), attackers, new Route(sz25, sz23));
+
+    final IBattle battle = AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz23);
+    assertNotNull(battle);
+    // Attacking battleship rolls a die with a hit, killing the destroyer.
+    // Defenders should roll a die with a hit, damaging the battleship.
+    whenGetRandom(bridge).thenAnswer(withDiceValues(1)).thenAnswer(withDiceValues(1));
+    battle.fight(bridge);
+    // The unit left should be the damaged german battleship.
+    assertEquals(1, sz23.getUnits().size());
+    final Unit unit = CollectionUtils.getAny(sz23.getUnits());
+    assertEquals("germanBattleship-damaged", unit.getType().getName());
+    // And it should have no movement left.
+    assertFalse(Matches.unitHasMovementLeft().test(unit));
+
+    // And just to double check, we can't move it.
+    advanceToStep(bridge, "NonCombatMove");
+    MoveDelegate moveDelegate = GameDataTestUtil.moveDelegate(gameData);
+    moveDelegate.setDelegateBridgeAndPlayer(bridge);
+    moveDelegate.start();
+    GameDataTestUtil.assertMoveError(sz23.getUnits(), new Route(sz23, sz25));
   }
 
   private static <T> void setPropertyValue(GameData gameData, String propertyName, T value) {

--- a/game-app/game-core/src/test/resources/Total_World_War_Dec1941.xml
+++ b/game-app/game-core/src/test/resources/Total_World_War_Dec1941.xml
@@ -1975,6 +1975,7 @@
     <unit name="germanAdvancedRocket"/>
     <unit name="germanTransport"/>
     <unit name="germanBattleship"/>
+    <unit name="germanBattleship-damaged"/>
     <unit name="germanHull"/>
     <unit name="germanCarrier"/>
     <unit name="germanSubmarine"/>
@@ -8049,6 +8050,18 @@
       <option name="requiresUnits" value="germanDocks:germanFactory"/>
       <option name="consumesUnits" value="1:germanHull"/>
       <option name="tuv" value="25"/>
+      <option name="whenHitPointsDamagedChangesInto" value="1:true:germanBattleship-damaged"/>
+    </attachment>
+    <attachment name="unitAttachment" attachTo="germanBattleship-damaged" javaClass="UnitAttachment" type="unitType">
+      <option name="movement" value="1"/>
+      <option name="attack" value="6"/>
+      <option name="defense" value="5"/>
+      <option name="canBombard" value="true"/>
+      <option name="isSea" value="true"/>
+      <option name="hitPoints" value="2"/>
+      <option name="bombard" value="5"/>
+      <option name="whenHitPointsRepairedChangesInto" value="0:true:germanBattleship"/>
+      <option name="tuv" value="17"/>
     </attachment>
     <attachment name="unitAttachment" attachTo="germanHull" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
       <option name="movement" value="0"/>


### PR DESCRIPTION
Fixes the 2.6 bug: https://github.com/triplea-game/triplea/issues/12334
See the issue for details on when this bug was introduced.

Adds a test.

Also makes a small logic improvement to the casualty selector:
  - Auto-select casualties if there's a single unit to pick from, even if it has multiple hit points.

The above logic improvement helps makes the test simpler (by avoiding mocking out things) and makes sense overall.
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
