### PR TITLE
Remove some more unneeded collection copies.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ResourceList.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ResourceList.java
@@ -1,9 +1,9 @@
 package games.strategy.engine.data;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 /** A collection of {@link Resource}s keyed on the resource name. */
@@ -29,7 +29,7 @@ public class ResourceList extends GameDataComponent {
     return resources.get(name);
   }
 
-  public List<Resource> getResources() {
-    return new ArrayList<>(resources.values());
+  public Collection<Resource> getResources() {
+    return Collections.unmodifiableCollection(resources.values());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -10,6 +10,7 @@ import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Round;
 import games.strategy.triplea.ui.mapdata.MapData;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -45,7 +46,7 @@ public class StatisticsAggregator {
   }
 
   private static Map<OverTimeStatisticType, IStat> createOverTimeStatisticsMapping(
-      final List<Resource> resources) {
+      final Collection<Resource> resources) {
     final Map<OverTimeStatisticType, IStat> statisticsMapping =
         new HashMap<>(defaultStatisticsMapping);
     resources.forEach(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.ai.pro.util;
 
 import static java.util.function.Predicate.not;
 
-import com.google.common.collect.ImmutableList;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Territory;
@@ -247,7 +246,7 @@ public final class ProTransportUtils {
               .thenComparing(getDecreasingAttackComparator(player)));
       results.addAll(selectUnitsToTransportFromList(unit, units));
     }
-    return ImmutableList.copyOf(results);
+    return Collections.unmodifiableList(results);
   }
 
   private static Comparator<Unit> getDecreasingAttackComparator(final GamePlayer player) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.delegate;
 
-import com.google.common.collect.ImmutableList;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Route;
@@ -279,7 +278,7 @@ class AaInMoveUtil implements Serializable {
         territoriesWhereAaWillFire.add(route.getStart());
       }
     }
-    return ImmutableList.copyOf(territoriesWhereAaWillFire);
+    return Collections.unmodifiableList(territoriesWhereAaWillFire);
   }
 
   private BattleTracker getBattleTracker() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
@@ -8,7 +8,7 @@ import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.awt.image.BufferedImage;
-import java.util.List;
+import java.util.Collection;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -54,7 +54,7 @@ public class ResourceImageFactory extends AbstractImageFactory {
   private JPanel getResourcesPanel(
       final ResourceCollection resources, final boolean showEmpty, final GamePlayer player) {
     final JPanel resourcePanel = new JPanel();
-    final List<Resource> resourcesInOrder;
+    final Collection<Resource> resourcesInOrder;
     final GameData data = resources.getData();
     try (GameData.Unlocker ignored = data.acquireReadLock()) {
       resourcesInOrder = data.getResourceList().getResources();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -55,8 +55,7 @@ public class ExtendedStats extends StatPanel {
 
   private void fillExtendedStats(final GameState data) {
     // add other resources, other than PUs and tech tokens
-    final List<Resource> resources = data.getResourceList().getResources();
-    for (final Resource r : resources) {
+    for (final Resource r : data.getResourceList().getResources()) {
       if (r.getName().equals(Constants.PUS) || r.getName().equals(Constants.TECH_TOKENS)) {
         continue;
       }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -525,7 +525,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
               actions.add(new EditGameCommentAction(watcher, ServerSetupPanel.this));
               actions.add(new RemoveGameFromLobbyAction(watcher));
             });
-    return ImmutableList.copyOf(actions);
+    return actions;
   }
 
   @Override

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.framework.startup.ui;
 
-import com.google.common.collect.ImmutableList;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.framework.network.ui.BanPlayerAction;
 import games.strategy.engine.framework.network.ui.BootPlayerAction;

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -929,7 +929,9 @@ public class MovePanel extends AbstractMovePanel {
         }
       }
     }
-    return ImmutableList.copyOf(selectedUnitsToUnload);
+    // Return an unmodifiable list for consistent semantics for the caller, which sometimes returns
+    // List.of() and sometimes the result of this functiom.
+    return Collections.unmodifiableList(selectedUnitsToUnload);
   }
 
   public boolean confirmUnitChooserDialog(final UnitChooser chooser, final String title) {


### PR DESCRIPTION
These are not needed.

In some cases, switches to Collections.unmodifiable*() functions to maintain readonly semantics. (e.g. if the function returns List.of() in some codepaths already, to be consistent)

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
