### PR TITLE
Restore unit properties code for unit overlays.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitIconImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitIconImageFactory.java
@@ -1,0 +1,31 @@
+package games.strategy.triplea.image;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.ResourceLoader;
+import games.strategy.triplea.ui.UnitIconProperties;
+import java.awt.Image;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+/** Retrieves and caches unit icon images. */
+public class UnitIconImageFactory extends ImageFactory {
+  private static final String PREFIX = "unitIcons/";
+
+  private final GameData data;
+  @Getter private final UnitIconProperties unitIconProperties;
+
+  public UnitIconImageFactory(GameData data, ResourceLoader loader) {
+    this.data = data;
+    unitIconProperties = new UnitIconProperties(data, loader);
+    setResourceLoader(loader);
+  }
+
+  public List<Image> getImages(String player, String unitType) {
+    return unitIconProperties.getImagePaths(player, unitType, data).stream()
+        .map(imagePath -> getImage(PREFIX + imagePath).orElse(null))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -14,6 +14,7 @@ import games.strategy.triplea.image.PuImageFactory;
 import games.strategy.triplea.image.ResourceImageFactory;
 import games.strategy.triplea.image.TerritoryEffectImageFactory;
 import games.strategy.triplea.image.TileImageFactory;
+import games.strategy.triplea.image.UnitIconImageFactory;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.image.UnitImageFactory.ImageKey;
 import games.strategy.triplea.ui.mapdata.MapData;
@@ -42,7 +43,7 @@ import org.triplea.debug.error.reporting.StackTraceReportModel;
 import org.triplea.java.concurrency.CountDownLatchHandler;
 import org.triplea.sound.ClipPlayer;
 
-/** A place to find images and map data for a ui. */
+/** A place to find images and map data for the ui. */
 @Slf4j
 public class UiContext {
   private static final String UNIT_SCALE_PREF = "UnitScale";
@@ -69,6 +70,7 @@ public class UiContext {
   @Getter private final ResourceLoader resourceLoader;
   @Getter private final TileImageFactory tileImageFactory = new TileImageFactory();
   @Getter private UnitImageFactory unitImageFactory;
+  @Getter private final UnitIconImageFactory unitIconImageFactory;
   @Getter private final ResourceImageFactory resourceImageFactory = new ResourceImageFactory();
   @Getter private final TooltipProperties tooltipProperties;
 
@@ -128,6 +130,7 @@ public class UiContext {
     unitImageFactory = new UnitImageFactory(resourceLoader, unitScale, mapData);
     resourceImageFactory.setResourceLoader(resourceLoader);
     territoryEffectImageFactory.setResourceLoader(resourceLoader);
+    unitIconImageFactory = new UnitIconImageFactory(data, resourceLoader);
     flagImageFactory.setResourceLoader(resourceLoader);
     puImageFactory.setResourceLoader(resourceLoader);
     tileImageFactory.setResourceLoader(resourceLoader);
@@ -139,7 +142,7 @@ public class UiContext {
     // load a new cursor
     cursor = Cursor.getDefaultCursor();
     final Toolkit toolkit = Toolkit.getDefaultToolkit();
-    // URL's use "/" not "\"
+    // URLs use "/" not "\"
     final URL cursorUrl = resourceLoader.getResource("misc/cursor.gif");
     if (cursorUrl != null) {
       try {
@@ -335,7 +338,7 @@ public class UiContext {
     // If you are calling this method while holding a lock on an object, while the EDT is separately
     // waiting for that lock, then you have a deadlock.
     // A real life example: player disconnects while you have the battle calc open.
-    // Non-EDT thread does shutdown on IGame and UiContext, causing btl calc to shutdown,
+    // Non-EDT thread does shutdown on IGame and UiContext, causing btl calc to shut down,
     // which calls the window closed event on the EDT, and waits for the lock on UiContext to
     // removeShutdownWindow, meanwhile our non-EDT tries to dispose the battle panel, which requires
     // the EDT with a invokeAndWait, resulting in a deadlock.

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -1,0 +1,220 @@
+package games.strategy.triplea.ui;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameState;
+import games.strategy.triplea.ResourceLoader;
+import games.strategy.triplea.attachments.AbstractConditionsAttachment;
+import games.strategy.triplea.attachments.AbstractPlayerRulesAttachment;
+import games.strategy.triplea.attachments.ICondition;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.util.FileNameUtils;
+
+/** Loads unit icons from unit_icons.properties. */
+@Slf4j
+public final class UnitIconProperties {
+  private static final String PROPERTY_FILE = "unit_icons.properties";
+
+  private final Properties properties;
+  private Map<ICondition, Boolean> conditionsStatus = new HashMap<>();
+  private final ImmutableList<UnitIconDescriptor> unitIconDescriptors;
+
+  private UnitIconProperties(final Properties properties) {
+    this.properties = properties;
+    this.unitIconDescriptors = parseUnitIconDescriptors();
+  }
+
+  public UnitIconProperties(final GameData gameData, final ResourceLoader loader) {
+    this(loader.loadPropertyFile(PROPERTY_FILE));
+    initializeConditionsStatus(gameData, AbstractPlayerRulesAttachment::getCondition);
+  }
+
+  @VisibleForTesting
+  UnitIconProperties(
+      final Properties properties,
+      final GameData gameData,
+      final ConditionSupplier conditionSupplier) {
+    this(properties);
+    initializeConditionsStatus(gameData, conditionSupplier);
+  }
+
+  private ImmutableList<UnitIconDescriptor> parseUnitIconDescriptors() {
+    final ImmutableList.Builder<UnitIconDescriptor> builder = ImmutableList.builder();
+    for (final Map.Entry<Object, Object> property : properties.entrySet()) {
+      try {
+        builder.add(
+            parseUnitIconDescriptor(property.getKey().toString(), property.getValue().toString()));
+      } catch (final MalformedUnitIconDescriptorException e) {
+        log.warn(
+            "Expected "
+                + PROPERTY_FILE
+                + " property key to be of the form "
+                + "<game_name>.<player>.<unit_type>;attachmentName OR if always true "
+                + "<game_name>.<player>.<unit_type>",
+            e);
+      }
+    }
+    return builder.build();
+  }
+
+  /**
+   * Parses a unit icon descriptor from a line in a unit_icons.properties file.
+   *
+   * <p>Each line in a unit_icons.properties file has the format:
+   *
+   * <p>{@code <encodedIconId>=<iconPath>}
+   *
+   * <p>Where {@code encodedIconId} is
+   *
+   * <p>{@code <encodedUnitTypeId>[;conditionName]}
+   *
+   * <p>Where {@code encodedUnitTypeId} is
+   *
+   * <p>{@code <gameName>.<playerName>.<unitTypeName>}
+   */
+  @VisibleForTesting
+  static UnitIconDescriptor parseUnitIconDescriptor(
+      final String encodedIconId, final String iconPath) {
+    final List<String> iconIdTokens = Splitter.on(';').splitToList(encodedIconId);
+    if (iconIdTokens.size() != 1 && iconIdTokens.size() != 2) {
+      throw new MalformedUnitIconDescriptorException(encodedIconId);
+    }
+    final String encodedUnitTypeId = iconIdTokens.get(0);
+    final Optional<String> conditionName =
+        (iconIdTokens.size() == 2) ? Optional.ofNullable(iconIdTokens.get(1)) : Optional.empty();
+
+    final List<String> unitTypeIdTokens = Splitter.on('.').limit(3).splitToList(encodedUnitTypeId);
+    if (unitTypeIdTokens.size() != 3) {
+      throw new MalformedUnitIconDescriptorException(encodedIconId);
+    }
+    final String gameName = unitTypeIdTokens.get(0);
+    final String playerName = unitTypeIdTokens.get(1);
+    final String unitTypeName = unitTypeIdTokens.get(2);
+
+    return new UnitIconDescriptor(gameName, playerName, unitTypeName, conditionName, iconPath);
+  }
+
+  private void initializeConditionsStatus(
+      final GameData gameData, final ConditionSupplier conditionSupplier) {
+    final String gameName = normalizeGameName(gameData);
+    for (final UnitIconDescriptor unitIconDescriptor : unitIconDescriptors) {
+      if (unitIconDescriptor.matches(gameName)) {
+        unitIconDescriptor.conditionName.ifPresent(
+            conditionName -> {
+              final @Nullable ICondition condition =
+                  conditionSupplier.getCondition(
+                      unitIconDescriptor.playerName, conditionName, gameData);
+              if (condition != null) {
+                conditionsStatus.put(condition, false);
+              }
+            });
+      }
+    }
+    conditionsStatus = getTestedConditions(gameData);
+  }
+
+  private static String normalizeGameName(final GameData gameData) {
+    return FileNameUtils.replaceIllegalCharacters(gameData.getGameName(), '_').replaceAll(" ", "_");
+  }
+
+  /**
+   * Get all unit icon images for given player and unit type that are currently true, ensuring order
+   * from the properties file.
+   */
+  public List<String> getImagePaths(
+      final String playerName, final String unitTypeName, final GameData gameData) {
+    return getImagePaths(
+        playerName, unitTypeName, gameData, AbstractPlayerRulesAttachment::getCondition);
+  }
+
+  @VisibleForTesting
+  List<String> getImagePaths(
+      final String playerName,
+      final String unitTypeName,
+      final GameData gameData,
+      final ConditionSupplier conditionSupplier) {
+    final List<String> imagePaths = new ArrayList<>();
+    final String gameName = normalizeGameName(gameData);
+    for (final UnitIconDescriptor unitIconDescriptor : unitIconDescriptors) {
+      if (unitIconDescriptor.matches(gameName, playerName, unitTypeName)) {
+        unitIconDescriptor.conditionName.ifPresentOrElse(
+            conditionName -> {
+              if (conditionsStatus.get(
+                  conditionSupplier.getCondition(playerName, conditionName, gameData))) {
+                imagePaths.add(unitIconDescriptor.unitIconPath);
+              }
+            },
+            () -> imagePaths.add(unitIconDescriptor.unitIconPath));
+      }
+    }
+    return imagePaths;
+  }
+
+  public boolean testIfConditionsHaveChanged(final GameData data) {
+    final Map<ICondition, Boolean> testedConditions = getTestedConditions(data);
+    if (!testedConditions.equals(conditionsStatus)) {
+      conditionsStatus = testedConditions;
+      return true;
+    }
+    return false;
+  }
+
+  private Map<ICondition, Boolean> getTestedConditions(final GameData data) {
+    final Set<ICondition> allConditionsNeeded =
+        AbstractConditionsAttachment.getAllConditionsRecursive(
+            new HashSet<>(conditionsStatus.keySet()), null);
+    return AbstractConditionsAttachment.testAllConditionsRecursive(
+        allConditionsNeeded, null, new ObjectiveDummyDelegateBridge(data));
+  }
+
+  @VisibleForTesting
+  interface ConditionSupplier {
+    @Nullable
+    ICondition getCondition(String playerName, String conditionName, GameState gameData);
+  }
+
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  @ToString
+  @VisibleForTesting
+  static final class UnitIconDescriptor {
+    final String gameName;
+    final String playerName;
+    final String unitTypeName;
+    final Optional<String> conditionName;
+    final String unitIconPath;
+
+    boolean matches(final String gameName) {
+      return this.gameName.equals(gameName);
+    }
+
+    boolean matches(final String gameName, final String playerName, final String unitTypeName) {
+      return this.gameName.equals(gameName)
+          && this.playerName.equals(playerName)
+          && this.unitTypeName.equals(unitTypeName);
+    }
+  }
+
+  @VisibleForTesting
+  static final class MalformedUnitIconDescriptorException extends RuntimeException {
+    private static final long serialVersionUID = 6408256411338749491L;
+
+    MalformedUnitIconDescriptorException(final String message) {
+      super(message);
+    }
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -21,7 +21,6 @@ import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.MouseDetails;
 import games.strategy.triplea.ui.UiContext;
-import games.strategy.triplea.ui.UnitIconProperties;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.SmallMapImageManager;
 import games.strategy.triplea.ui.screen.Tile;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -131,12 +131,12 @@ public class UnitsDrawer extends AbstractDrawable {
       // If unit is not in the "excluded list" it will get drawn
       if (maxRange != 0) {
         final Image flag = uiContext.getFlagImageFactory().getFlag(owner);
-        final int xoffset = img.getWidth(null) / 2 - flag.getWidth(null) / 2;
-        final int yoffset = img.getHeight(null) / 2 - flag.getHeight(null) / 4 - 5;
+        final int xOffset = img.getWidth(null) / 2 - flag.getWidth(null) / 2;
+        final int yOffset = img.getHeight(null) / 2 - flag.getHeight(null) / 4 - 5;
         graphics.drawImage(
             flag,
-            (placementPoint.x - bounds.x) + xoffset,
-            (placementPoint.y - bounds.y) + yoffset,
+            (placementPoint.x - bounds.x) + xOffset,
+            (placementPoint.y - bounds.y) + yOffset,
             null);
       }
       drawUnit(graphics, img, bounds);
@@ -145,22 +145,22 @@ public class UnitsDrawer extends AbstractDrawable {
       // If unit is not in the "excluded list" it will get drawn
       if (maxRange != 0) {
         final Image flag = uiContext.getFlagImageFactory().getSmallFlag(owner);
-        final int xoffset = img.getWidth(null) - flag.getWidth(null);
-        final int yoffset = img.getHeight(null) - flag.getHeight(null);
+        final int xOffset = img.getWidth(null) - flag.getWidth(null);
+        final int yOffset = img.getHeight(null) - flag.getHeight(null);
         // This Method draws the Flag in the lower right corner of the unit image. Since the
-        // position is the upper
-        // left corner we have to move the picture up by the height and left by the width.
+        // position is the upper left corner we have to move the picture up by the height and
+        // left by the width.
         graphics.drawImage(
             flag,
-            (placementPoint.x - bounds.x) + xoffset,
-            (placementPoint.y - bounds.y) + yoffset,
+            (placementPoint.x - bounds.x) + xOffset,
+            (placementPoint.y - bounds.y) + yOffset,
             null);
       }
     } else {
       drawUnit(graphics, img, bounds);
     }
 
-    // more then 1 unit of this category
+    // more than 1 unit of this category
     if (count != 1) {
       final int stackSize = mapData.getDefaultUnitsStackSize();
       if (stackSize > 0) { // Display more units as a stack
@@ -218,10 +218,19 @@ public class UnitsDrawer extends AbstractDrawable {
   /** This draws the given image onto the given graphics object. */
   private void drawUnit(final Graphics2D graphics, final Image image, final Rectangle bounds) {
     graphics.drawImage(image, placementPoint.x - bounds.x, placementPoint.y - bounds.y, null);
+
+    // draw unit icons in top right corner
+    final List<Image> unitIcons =
+        uiContext.getUnitIconImageFactory().getImages(playerName, unitType);
+    for (final Image unitIcon : unitIcons) {
+      final int xOffset = image.getWidth(null) - unitIcon.getWidth(null);
+      graphics.drawImage(
+          unitIcon, (placementPoint.x - bounds.x) + xOffset, (placementPoint.y - bounds.y), null);
+    }
   }
 
   private void displayHitDamage(final Rectangle bounds, final Graphics2D graphics) {
-    if (territoryName.length() != 0 && damaged > 1) {
+    if (!territoryName.isEmpty() && damaged > 1) {
       final String s = String.valueOf(damaged);
       final int x =
           placementPoint.x - bounds.x + uiContext.getUnitImageFactory().getUnitImageWidth() * 3 / 4;
@@ -238,7 +247,7 @@ public class UnitsDrawer extends AbstractDrawable {
   }
 
   private void displayFactoryDamage(final Rectangle bounds, final Graphics2D graphics) {
-    if (territoryName.length() != 0 && bombingUnitDamage > 0) {
+    if (!territoryName.isEmpty() && bombingUnitDamage > 0) {
       final String s = String.valueOf(bombingUnitDamage);
       final int x =
           placementPoint.x - bounds.x + uiContext.getUnitImageFactory().getUnitImageWidth() / 4;
@@ -277,8 +286,8 @@ public class UnitsDrawer extends AbstractDrawable {
 
   List<Unit> getUnits(final GameState data) {
     // note - it may be the case where the territory is being changed as a result to a mouse click,
-    // and the map units
-    // haven't updated yet, so the unit count from the territory wont match the units in count
+    // and the map units haven't updated yet, so the unit count from the territory won't match the
+    // units in count
     final Territory t = data.getMap().getTerritory(territoryName);
     final UnitType type = data.getUnitTypeList().getUnitType(unitType);
     final Predicate<Unit> selectedUnits =

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
@@ -1,0 +1,210 @@
+package games.strategy.triplea.ui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameState;
+import games.strategy.triplea.attachments.ICondition;
+import games.strategy.triplea.ui.UnitIconProperties.MalformedUnitIconDescriptorException;
+import games.strategy.triplea.ui.UnitIconProperties.UnitIconDescriptor;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import javax.annotation.Nullable;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class UnitIconPropertiesTest {
+  private static final String CONDITION_1_NAME = "condition1Name";
+  private static final String CONDITION_2_NAME = "condition2Name";
+  private static final String GAME_NAME = "gameName";
+  private static final String ICON_1_PATH = "path/to/icon_1.png";
+  private static final String ICON_2_PATH = "path/to/icon_2.png";
+  private static final String ICON_3_PATH = "path/to/icon_3.png";
+  private static final String PLAYER_NAME = "playerName";
+  private static final String UNIT_TYPE_NAME = "unitTypeName";
+
+  private static String formatIconId(final @Nullable String conditionName) {
+    return formatIconId(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME, conditionName);
+  }
+
+  private static String formatIconId(
+      final String gameName,
+      final String playerName,
+      final String unitTypeName,
+      final @Nullable String conditionName) {
+    final String encodedUnitTypeId = String.join(".", gameName, playerName, unitTypeName);
+    return (conditionName != null)
+        ? String.join(";", encodedUnitTypeId, conditionName)
+        : encodedUnitTypeId;
+  }
+
+  @Nested
+  final class GetImagePathsTest {
+    private GameData givenGameData() {
+      final GameData gameData = new GameData();
+      gameData.setGameName(GAME_NAME);
+      return gameData;
+    }
+
+    private ICondition givenCondition(final String name, final boolean satisfied) {
+      final ICondition condition = mock(ICondition.class);
+      when(condition.getConditions()).thenReturn(List.of());
+      when(condition.getName()).thenReturn(name);
+      when(condition.isSatisfied(any(), any())).thenReturn(satisfied);
+      return condition;
+    }
+
+    private UnitIconProperties.ConditionSupplier givenConditionSupplier(
+        final GameState gameData, final ICondition... conditions) {
+      final UnitIconProperties.ConditionSupplier conditionSupplier =
+          mock(UnitIconProperties.ConditionSupplier.class);
+      for (final ICondition condition : conditions) {
+        when(conditionSupplier.getCondition(PLAYER_NAME, condition.getName(), gameData))
+            .thenReturn(condition);
+      }
+      return conditionSupplier;
+    }
+
+    @Test
+    void shouldReturnImagePathsForIconsWithSatisfiedConditionOrNoCondition() {
+      final GameData gameData = givenGameData();
+      final UnitIconProperties.ConditionSupplier conditionSupplier =
+          givenConditionSupplier(
+              gameData,
+              givenCondition(CONDITION_1_NAME, true),
+              givenCondition(CONDITION_2_NAME, false));
+      final Properties properties = new OrderedProperties();
+      properties.put(formatIconId(CONDITION_1_NAME), ICON_1_PATH);
+      properties.put(formatIconId(CONDITION_2_NAME), ICON_2_PATH);
+      properties.put(formatIconId(null), ICON_3_PATH);
+      final UnitIconProperties unitIconProperties =
+          new UnitIconProperties(properties, gameData, conditionSupplier);
+
+      assertThat(
+          unitIconProperties.getImagePaths(
+              PLAYER_NAME, UNIT_TYPE_NAME, gameData, conditionSupplier),
+          contains(ICON_1_PATH, ICON_3_PATH));
+    }
+
+    @Test
+    void shouldIgnoreIconsThatHaveDifferentUnitTypeId() {
+      final GameData gameData = givenGameData();
+      final UnitIconProperties.ConditionSupplier conditionSupplier =
+          givenConditionSupplier(gameData);
+      final Properties properties = new OrderedProperties();
+      properties.put(formatIconId("otherGameName", PLAYER_NAME, UNIT_TYPE_NAME, null), ICON_1_PATH);
+      properties.put(formatIconId(GAME_NAME, "otherPlayerName", UNIT_TYPE_NAME, null), ICON_2_PATH);
+      properties.put(formatIconId(GAME_NAME, PLAYER_NAME, "otherUnitTypeName", null), ICON_3_PATH);
+      final UnitIconProperties unitIconProperties =
+          new UnitIconProperties(properties, gameData, conditionSupplier);
+
+      assertThat(
+          unitIconProperties.getImagePaths(
+              PLAYER_NAME, UNIT_TYPE_NAME, gameData, conditionSupplier),
+          is(empty()));
+    }
+  }
+
+  @Nested
+  final class ParseUnitIconDescriptorTest {
+    private UnitIconDescriptor newUnitIconDescriptorWithCondition(
+        final @Nullable String conditionName) {
+      return new UnitIconDescriptor(
+          GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME, Optional.ofNullable(conditionName), ICON_1_PATH);
+    }
+
+    private UnitIconDescriptor parseUnitIconDescriptorWithCondition(
+        final @Nullable String conditionName) {
+      return UnitIconProperties.parseUnitIconDescriptor(formatIconId(conditionName), ICON_1_PATH);
+    }
+
+    @Test
+    void shouldParseUnitIconDescriptorWithCondition() {
+      assertThat(
+          parseUnitIconDescriptorWithCondition(CONDITION_1_NAME),
+          is(newUnitIconDescriptorWithCondition(CONDITION_1_NAME)));
+    }
+
+    @Test
+    void shouldParseUnitIconDescriptorWithoutCondition() {
+      assertThat(
+          parseUnitIconDescriptorWithCondition(null), is(newUnitIconDescriptorWithCondition(null)));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenIconIdTokenCountNotEqualToOneOrTwo() {
+      assertThrows(
+          MalformedUnitIconDescriptorException.class,
+          () -> UnitIconProperties.parseUnitIconDescriptor("", ICON_1_PATH));
+      assertThrows(
+          MalformedUnitIconDescriptorException.class,
+          () -> UnitIconProperties.parseUnitIconDescriptor("a1.a2.a3;b1;c1", ICON_1_PATH));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUnitTypeIdTokenCountNotEqualToThree() {
+      assertThrows(
+          MalformedUnitIconDescriptorException.class,
+          () -> UnitIconProperties.parseUnitIconDescriptor("a1.a2;b1", ICON_1_PATH));
+    }
+  }
+
+  @Nested
+  final class UnitIconDescriptorTest {
+    @Nested
+    final class EqualsAndHashCodeTest {
+      @Test
+      void shouldBeEquatableAndHashable() {
+        EqualsVerifier.forClass(UnitIconDescriptor.class).verify();
+      }
+    }
+
+    @Nested
+    final class MatchesGameNameTest {
+      private final UnitIconDescriptor unitIconDescriptor =
+          new UnitIconDescriptor(
+              GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME, Optional.empty(), ICON_1_PATH);
+
+      @Test
+      void shouldReturnTrueWhenGameNameMatches() {
+        assertThat(unitIconDescriptor.matches(GAME_NAME), is(true));
+      }
+
+      @Test
+      void shouldReturnFalseWhenGameNameDoesNotMatch() {
+        assertThat(unitIconDescriptor.matches("otherGameName"), is(false));
+      }
+    }
+
+    @Nested
+    final class MatchesGameNameAndPlayerNameAndUnitTypeNameTest {
+      private final UnitIconDescriptor unitIconDescriptor =
+          new UnitIconDescriptor(
+              GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME, Optional.empty(), ICON_1_PATH);
+
+      @Test
+      void shouldReturnTrueWhenGameNameAndPlayerNameAndUnitTypeNameMatches() {
+        assertThat(unitIconDescriptor.matches(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME), is(true));
+      }
+
+      @Test
+      void shouldReturnFalseWhenGameNameOrPlayerNameOrUnitTypeNameDoesNotMatch() {
+        assertThat(
+            unitIconDescriptor.matches("otherGameName", PLAYER_NAME, UNIT_TYPE_NAME), is(false));
+        assertThat(
+            unitIconDescriptor.matches(GAME_NAME, "otherPlayerName", UNIT_TYPE_NAME), is(false));
+        assertThat(
+            unitIconDescriptor.matches(GAME_NAME, PLAYER_NAME, "otherUnitTypeName"), is(false));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This was incorrectly removed by 4dbdbdb in 2.6 even TWW and some other maps were using it.

Some code refactoring on the restored code to make it work with the current codebase.

Also, fixes some IntelliJ warnings in affected files.

Fixes https://github.com/triplea-game/triplea/issues/12333.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
