### PR TITLE
Fix bug that could delete downloadedMaps folder.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
@@ -123,15 +123,16 @@ public class InstalledMapsListing {
    * directory of the 'map.yml' file describing that map.
    */
   public Optional<Path> findMapFolderByName(final String mapName) {
-    return findContentRootForMapName(mapName).map(
-        p -> {
-          Path parent = p.getParent();
-          // Some maps have their content root be the map folder itself.
-          if (parent.equals(ClientFileSystemHelper.getUserMapsFolder())) {
-            return p;
-          }
-          return parent;
-        });
+    return findContentRootForMapName(mapName)
+        .map(
+            p -> {
+              Path parent = p.getParent();
+              // Some maps have their content root be the map folder itself.
+              if (parent.equals(ClientFileSystemHelper.getUserMapsFolder())) {
+                return p;
+              }
+              return parent;
+            });
   }
 
   public Optional<Path> findMapSkin(final String mapName, final String skinName) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
@@ -123,7 +123,15 @@ public class InstalledMapsListing {
    * directory of the 'map.yml' file describing that map.
    */
   public Optional<Path> findMapFolderByName(final String mapName) {
-    return findContentRootForMapName(mapName).map(Path::getParent);
+    return findContentRootForMapName(mapName).map(
+        p -> {
+          Path parent = p.getParent();
+          // Some maps have their content root be the map folder itself.
+          if (parent.equals(ClientFileSystemHelper.getUserMapsFolder())) {
+            return p;
+          }
+          return parent;
+        });
   }
 
   public Optional<Path> findMapSkin(final String mapName, final String skinName) {


### PR DESCRIPTION
This would happen when removing a map where the content root isn't nested in a sub-dir, example "2020". Fixes: https://github.com/triplea-game/triplea/issues/12373

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
