### PR TITLE
Remove unnecessary BidMode.NOT_BID check.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -193,6 +193,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
   @Override
   public @Nullable String placeUnits(
       final Collection<Unit> units, final Territory at, final BidMode bidMode) {
+    // The bidMode param is unused.
+    return placeUnits(units, at);
+  }
+
+  public @Nullable String placeUnits(final Collection<Unit> units, final Territory at) {
     if (units.isEmpty()) {
       return null;
     }
@@ -217,10 +222,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
 
       int maxPlaceable = maxPlaceableMap.getInt(producer);
       if (maxPlaceable == 0) {
-        if (bidMode == BidMode.NOT_BID) {
-          continue;
-        }
-        maxPlaceable = 1;
+        continue;
       }
 
       // units may have special restrictions like RequiresUnits

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1103,7 +1103,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
   }
 
   /** Returns -1 if we can place unlimited units. */
-  protected int getMaxUnitsToBePlacedFrom(
+  private int getMaxUnitsToBePlacedFrom(
       final Territory producer,
       final Collection<Unit> units,
       final Territory to,
@@ -1118,8 +1118,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       final Territory to,
       final GamePlayer player,
       final boolean countSwitchedProductionToNeighbors,
-      final Collection<Territory> notUsableAsOtherProducers,
-      final Map<Territory, Integer> currentAvailablePlacementForOtherProducers) {
+      final @Nullable Collection<Territory> notUsableAsOtherProducers,
+      final @Nullable Map<Territory, Integer> currentAvailablePlacementForOtherProducers) {
     final GameProperties properties = getProperties();
     final boolean unitPlacementRestrictions = hasUnitPlacementRestrictions();
     // we may have special units with requiresUnits restrictions

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -92,18 +92,6 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     return units.size();
   }
 
-  @Override
-  protected int getMaxUnitsToBePlacedFrom(
-      final Territory producer,
-      final @Nullable Collection<Unit> units,
-      final Territory to,
-      final GamePlayer player) {
-    if (units == null) {
-      return -1;
-    }
-    return getMaxUnitsToBePlacedFrom(producer, units, to, player, false, null, null);
-  }
-
   // Return collection of bid units which can placed in a land territory
   @Override
   protected Collection<Unit> getUnitsToBePlaced(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -9,6 +9,7 @@ import games.strategy.triplea.delegate.UndoablePlacement;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import java.io.Serializable;
 import java.util.Collection;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
 /** Logic for placing units within a territory. */
 public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePlacement> {
@@ -27,7 +28,8 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePl
     return placeUnits(units, at, BidMode.NOT_BID);
   }
 
-  /** Indicates whether bidding is enabled during placement. */
+  /** Indicates whether bidding is enabled during placement. No longer used. */
+  @RemoveOnNextMajorRelease
   enum BidMode {
     BID,
     NOT_BID


### PR DESCRIPTION
This check is not needed, because the BID codepath this is trying to handle is impossible now.

For it to be possible, maxPlaceableMap would need to have an entry with 0 in bid mode. But this can't happen because:
  - producers will always just have a single territory of at due to the override impl for bid
  - maxPlaceableMap will never have an 0-entry, since it calls getMaxUnitsToBePlacedFrom() to fill the map and that function is overridden for bid to return -1 or units.size()

So this should have no functional changes and all the tests pass.

Also removes an unnecessary override and marks some params as nullable.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
