### PR TITLE
Expand Nullable annotations.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
@@ -2,7 +2,6 @@ package games.strategy.engine.data;
 
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TechAttachment;
-import java.util.Optional;
 import lombok.Getter;
 
 /** A game data change that captures a change to an attachment property value. */
@@ -62,11 +61,8 @@ public class ChangeAttachmentChange extends Change {
       final Object oldValue,
       final String property,
       final boolean clearFirst) {
-    this.attachmentName =
-        Optional.ofNullable(attachmentName)
-            // replace-all to automatically correct legacy (1.8) attachment spelling
-            .map(name -> name.replaceAll("ttatch", "ttach"))
-            .orElse(null);
+    // replace-all to automatically correct legacy (1.8) attachment spelling
+    this.attachmentName = attachmentName.replaceAll("ttatch", "ttach");
     attachedTo = attachTo;
     this.newValue = newValue;
     this.oldValue = oldValue;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
@@ -2,6 +2,8 @@ package games.strategy.engine.data;
 
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TechAttachment;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import lombok.Getter;
 
 /** A game data change that captures a change to an attachment property value. */
@@ -56,13 +58,17 @@ public class ChangeAttachmentChange extends Change {
    */
   public ChangeAttachmentChange(
       final Attachable attachTo,
-      final String attachmentName,
+      final @Nullable String attachmentName,
       final Object newValue,
       final Object oldValue,
       final String property,
       final boolean clearFirst) {
     // replace-all to automatically correct legacy (1.8) attachment spelling
-    this.attachmentName = attachmentName.replaceAll("ttatch", "ttach");
+    this.attachmentName =
+        Optional.ofNullable(attachmentName)
+            // replace-all to automatically correct legacy (1.8) attachment spelling
+            .map(name -> name.replaceAll("ttatch", "ttach"))
+            .orElse(null);
     attachedTo = attachTo;
     this.newValue = newValue;
     this.oldValue = oldValue;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
@@ -63,7 +63,6 @@ public class ChangeAttachmentChange extends Change {
       final Object oldValue,
       final String property,
       final boolean clearFirst) {
-    // replace-all to automatically correct legacy (1.8) attachment spelling
     this.attachmentName =
         Optional.ofNullable(attachmentName)
             // replace-all to automatically correct legacy (1.8) attachment spelling

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -36,7 +36,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
   private static final Splitter COLON_SPLITTER = Splitter.on(':');
 
   @Setter private Attachable attachedTo;
-  private String name;
+  private @Nullable String name;
 
   protected DefaultAttachment(
       final String name, final Attachable attachable, final GameData gameData) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DynamicallyModifiable.java
@@ -3,6 +3,7 @@ package games.strategy.engine.data;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * An interface to implement by objects that are dynamically being modified. This will most likely
@@ -17,6 +18,7 @@ public interface DynamicallyModifiable {
    *
    * @return The property with the specified name or null if the property doesn't exist.
    */
+  @Nullable
   MutableProperty<?> getPropertyOrNull(String name);
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -295,8 +295,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *
    * @param cond condition that covered territories of the route must match
    */
-  @Nullable
-  public Route getRoute(
+  public @Nullable Route getRoute(
       final Territory start, final Territory end, final Predicate<Territory> cond) {
     checkNotNull(start);
     checkNotNull(end);
@@ -306,8 +305,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /** See {@link #getRouteForUnits(Territory, Territory, Predicate, Collection, GamePlayer)}. */
-  @Nullable
-  public Route getRouteForUnit(
+  public @Nullable Route getRouteForUnit(
       final Territory start,
       final Territory end,
       final Predicate<Territory> cond,
@@ -327,8 +325,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param units checked against canals and for movement costs
    * @param player player used to check canal ownership
    */
-  @Nullable
-  public Route getRouteForUnits(
+  public @Nullable Route getRouteForUnits(
       final Territory start,
       final Territory end,
       final Predicate<Territory> cond,

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -87,7 +87,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *
    * @param s name of the searched territory (case sensitive)
    */
-  public Territory getTerritory(final String s) {
+  public @Nullable Territory getTerritory(final String s) {
     return territoryLookup.get(s);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/IAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/IAttachment.java
@@ -17,7 +17,8 @@ public interface IAttachment extends Serializable, DynamicallyModifiable {
 
   void setAttachedTo(Attachable attachable);
 
-  @Nullable String getName();
+  @Nullable
+  String getName();
 
   void setName(String name);
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/IAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/IAttachment.java
@@ -2,6 +2,7 @@ package games.strategy.engine.data;
 
 import games.strategy.engine.data.gameparser.GameParseException;
 import java.io.Serializable;
+import javax.annotation.Nullable;
 
 /**
  * Behavior or data that can be attached to a game object. Permits open-ended extension of game
@@ -16,7 +17,7 @@ public interface IAttachment extends Serializable, DynamicallyModifiable {
 
   void setAttachedTo(Attachable attachable);
 
-  String getName();
+  @Nullable String getName();
 
   void setName(String name);
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.ToString;
 import org.triplea.java.RemoveOnNextMajorRelease;
@@ -61,10 +62,11 @@ public class PlayerList extends GameDataComponent implements Iterable<GamePlayer
     return players.size();
   }
 
-  public GamePlayer getPlayerId(final String name) {
+  public @Nullable GamePlayer getPlayerId(final String name) {
     if (getNullPlayer().getName().equals(name)) {
       return getNullPlayer();
     }
+    // Can return null if a bogus name was passed.
     return players.get(name);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.util.Tuple;
@@ -77,7 +78,7 @@ public class Route implements Serializable, Iterable<Territory> {
    * @return a new Route starting at r1.start() going to r2.end() along r1, r2, or null if the
    *     routes can't be joined it the joining would form a loop
    */
-  public static Route join(final Route r1, final Route r2) {
+  public static @Nullable Route join(final @Nullable Route r1, final @Nullable Route r2) {
     if (r1 == null || r2 == null) {
       return null;
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -222,7 +222,7 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "owner":
         return MutableProperty.ofSimple(this::setOwner, this::getOwner);

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -34,7 +34,7 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
     unitTypes.put(type.getName(), type);
   }
 
-  public UnitType getUnitType(final String name) {
+  public @Nullable UnitType getUnitType(final String name) {
     return unitTypes.get(name);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/player/Player.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/player/Player.java
@@ -285,7 +285,8 @@ public interface Player extends IRemote {
 
   /** Asks the player if they wish to perform any kamikaze suicide attacks. */
   @RemoteActionCode(21)
-  @Nullable Map<Territory, Map<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
+  @Nullable
+  Map<Territory, Map<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
       Map<Territory, Collection<Unit>> possibleUnitsToAttack);
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/player/Player.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/player/Player.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import org.triplea.java.ChangeOnNextMajorRelease;
 import org.triplea.java.RemoveOnNextMajorRelease;
 import org.triplea.java.collections.IntegerMap;
@@ -284,7 +285,7 @@ public interface Player extends IRemote {
 
   /** Asks the player if they wish to perform any kamikaze suicide attacks. */
   @RemoteActionCode(21)
-  Map<Territory, Map<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
+  @Nullable Map<Territory, Map<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
       Map<Territory, Collection<Unit>> possibleUnitsToAttack);
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/net/nio/NioWriter.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/nio/NioWriter.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.ThreadRunner;
 
@@ -137,7 +138,7 @@ class NioWriter {
     }
   }
 
-  private SocketWriteData getData(final SocketChannel to) {
+  private @Nullable SocketWriteData getData(final SocketChannel to) {
     synchronized (mutex) {
       if (!writing.containsKey(to)) {
         return null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
@@ -65,7 +65,7 @@ public class UnitUtils {
    * @param accountForDamage {@code true} if the production capacity should account for unit damage;
    *     otherwise {@code false}.
    */
-  public static Unit getBiggestProducer(
+  public static @Nullable Unit getBiggestProducer(
       final Collection<Unit> units,
       final Territory producer,
       final GamePlayer player,
@@ -104,7 +104,7 @@ public class UnitUtils {
    *     {@code false} to allow a negative production capacity.
    */
   public static int getHowMuchCanUnitProduce(
-      final Unit unit,
+      final @Nullable Unit unit,
       final Territory producer,
       final TechTracker techTracker,
       final GameProperties properties,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -41,6 +41,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.CollectionUtils;
@@ -265,7 +266,7 @@ public abstract class AbstractAi extends AbstractBasePlayer {
   }
 
   @Override
-  public Map<Territory, Map<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
+  public @Nullable Map<Territory, Map<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
       final Map<Territory, Collection<Unit>> possibleUnitsToAttack) {
     final GamePlayer gamePlayer = this.getGamePlayer();
     // we are going to just assign random attacks to each unit randomly, til we run out of tokens to

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AiUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AiUtils.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
 
 /** Handy utility methods for the writers of an AI. */
@@ -45,7 +46,7 @@ public final class AiUtils {
    *
    * <p>If no such rule can be found, then return null.
    */
-  private static ProductionRule getProductionRule(
+  private static @Nullable ProductionRule getProductionRule(
       final UnitType unitType, final GamePlayer player) {
     final ProductionFrontier frontier = player.getProductionFrontier();
     if (frontier == null) {
@@ -98,7 +99,7 @@ public final class AiUtils {
     return strength;
   }
 
-  public static Unit getLastUnitMatching(
+  public static @Nullable Unit getLastUnitMatching(
       final List<Unit> units, final Predicate<Unit> match, final int endIndex) {
     final int index = getIndexOfLastUnitMatching(units, match, endIndex);
     if (index == -1) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -369,7 +369,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "conditions":
         return MutableProperty.of(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -326,7 +326,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "movementRestrictionType":
         return MutableProperty.ofString(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -405,7 +405,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "countEach":
         return MutableProperty.ofReadOnly(this::getCountEach);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -275,7 +275,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   public void validate(final GameState data) {}
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "uses":
         return MutableProperty.ofMapper(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -209,7 +209,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "text":
         return MutableProperty.ofString(this::setText, this::getText, this::resetText);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -173,7 +173,7 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "canalName":
         return MutableProperty.ofString(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -62,7 +62,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   /** Convenience method. can be null */
-  public static PlayerAttachment get(final GamePlayer p) {
+  public static @Nullable PlayerAttachment get(final GamePlayer p) {
     // allow null
     return p.getPlayerAttachment();
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -360,7 +360,7 @@ public class PlayerAttachment extends DefaultAttachment {
   public void validate(final GameState data) {}
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "vps":
         return MutableProperty.ofMapper(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -195,7 +195,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "relationshipChange":
         return MutableProperty.of(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -8,6 +8,7 @@ import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.RelationshipType;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.Constants;
+import javax.annotation.Nullable;
 import lombok.Getter;
 
 /** An attachment for instances of {@link RelationshipType}. */
@@ -434,7 +435,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   public void validate(final GameState data) {}
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "archeType":
         return MutableProperty.ofString(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -1077,7 +1077,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "techs":
         return MutableProperty.of(this::setTechs, this::setTechs, this::getTechs, this::resetTechs);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -875,7 +875,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "attackBonus":
         return MutableProperty.of(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -11,6 +11,7 @@ import games.strategy.triplea.delegate.GenericTechAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import lombok.Getter;
 
 /**
@@ -312,7 +313,7 @@ public class TechAttachment extends DefaultAttachment {
   public void validate(final GameState data) {}
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "techCost":
         return MutableProperty.of(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -47,7 +47,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   @Getter private int production = 0;
   @Getter private int victoryCity = 0;
   private boolean isImpassable = false;
-  @Getter private GamePlayer originalOwner = null;
+  @Getter private @Nullable GamePlayer originalOwner = null;
   private boolean convoyRoute = false;
   private @Nullable Set<Territory> convoyAttached = null;
   private @Nullable List<GamePlayer> changeUnitOwners = null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -153,7 +153,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   /** Convenience method. Can return null. */
-  public static TerritoryAttachment get(final Territory t) {
+  public static @Nullable TerritoryAttachment get(final Territory t) {
     return (TerritoryAttachment) t.getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -725,7 +725,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   public void validate(final GameState data) {}
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "capital":
         return MutableProperty.ofString(this::setCapital, this::getCapital, this::resetCapital);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -206,7 +206,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   public void validate(final GameState data) {}
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case COMBAT_DEFENSE_EFFECT:
         return MutableProperty.of(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2557,7 +2557,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "frontier":
         return MutableProperty.of(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3398,7 +3398,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "isAir":
         return MutableProperty.of(this::setIsAir, this::setIsAir, this::getIsAir, this::resetIsAir);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -413,7 +413,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   public void validate(final GameState data) {}
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case UNIT_TYPE:
         return MutableProperty.of(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -172,7 +172,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "activateTrigger":
         return MutableProperty.of(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.IntStream;
+import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
 
 /** An abstraction of MoveDelegate in order to allow other delegates to extend this. */
@@ -74,7 +75,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   }
 
   @Override
-  public String undoMove(final int moveIndex) {
+  public @Nullable String undoMove(final int moveIndex) {
     if (movesToUndo.isEmpty()) {
       return "No moves to undo";
     }
@@ -150,7 +151,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
    * @param end target territory
    * @return the route that a unit used to move into the given territory.
    */
-  public static Route getRouteUsedToMoveInto(
+  public static @Nullable Route getRouteUsedToMoveInto(
       final List<UndoableMove> undoableMoves, final Unit unit, final Territory end) {
     final ListIterator<UndoableMove> iter = undoableMoves.listIterator(undoableMoves.size());
     while (iter.hasPrevious()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Triple;
@@ -48,7 +49,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String removeUnits(final Territory territory, final Collection<Unit> units) {
+  public @Nullable String removeUnits(final Territory territory, final Collection<Unit> units) {
     String result = checkEditMode();
     if (result != null) {
       return result;
@@ -81,7 +82,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String addUnits(final Territory territory, final Collection<Unit> units) {
+  public @Nullable String addUnits(final Territory territory, final Collection<Unit> units) {
     String result = checkEditMode();
     if (result != null) {
       return result;
@@ -225,7 +226,8 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String removeTechAdvance(final GamePlayer player, final Collection<TechAdvance> advances) {
+  public @Nullable String removeTechAdvance(
+      final GamePlayer player, final Collection<TechAdvance> advances) {
     String result = checkEditMode();
     if (result != null) {
       return result;
@@ -241,7 +243,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String changeUnitHitDamage(
+  public @Nullable String changeUnitHitDamage(
       final IntegerMap<Unit> unitDamageMap, final Territory territory) {
     String result = checkEditMode();
     if (result != null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -210,7 +210,8 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public @Nullable String addTechAdvance(final GamePlayer player, final Collection<TechAdvance> advances) {
+  public @Nullable String addTechAdvance(
+      final GamePlayer player, final Collection<TechAdvance> advances) {
     String result = checkEditMode();
     if (result != null) {
       return result;
@@ -378,7 +379,8 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
     return null;
   }
 
-  @Nullable String checkEditMode() {
+  @Nullable
+  String checkEditMode() {
     final String result = checkPlayerId();
     if (null != result) {
       return result;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -148,7 +148,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String changeTerritoryOwner(final Territory territory, final GamePlayer player) {
+  public @Nullable String changeTerritoryOwner(final Territory territory, final GamePlayer player) {
     String result = checkEditMode();
     if (result != null) {
       return result;
@@ -187,7 +187,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String changeResource(
+  public @Nullable String changeResource(
       final GamePlayer player, final String resourceName, final int newTotal) {
     final String result = checkEditMode();
     if (result != null) {
@@ -210,7 +210,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String addTechAdvance(final GamePlayer player, final Collection<TechAdvance> advances) {
+  public @Nullable String addTechAdvance(final GamePlayer player, final Collection<TechAdvance> advances) {
     String result = checkEditMode();
     if (result != null) {
       return result;
@@ -277,7 +277,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String changeUnitBombingDamage(
+  public @Nullable String changeUnitBombingDamage(
       final IntegerMap<Unit> unitDamageMap, final Territory territory) {
     String result = checkEditMode();
     if (result != null) {
@@ -313,7 +313,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String changePoliticalRelationships(
+  public @Nullable String changePoliticalRelationships(
       final Collection<Triple<GamePlayer, GamePlayer, RelationshipType>> relationshipChanges) {
     if (relationshipChanges == null || relationshipChanges.isEmpty()) {
       return null;
@@ -370,7 +370,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
     return true;
   }
 
-  private String checkPlayerId() {
+  private @Nullable String checkPlayerId() {
     final Player remotePlayer = bridge.getRemotePlayer();
     if (!bridge.getGamePlayer().equals(remotePlayer.getGamePlayer())) {
       return "Edit actions can only be performed during players turn";
@@ -378,7 +378,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
     return null;
   }
 
-  String checkEditMode() {
+  @Nullable String checkEditMode() {
     final String result = checkPlayerId();
     if (null != result) {
       return result;
@@ -400,7 +400,7 @@ public class EditDelegate extends BasePersistentDelegate implements IEditDelegat
   }
 
   @Override
-  public String addComment(final String message) {
+  public @Nullable String addComment(final String message) {
     final String result = checkPlayerId();
     if (result != null) {
       return result;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate;
 
+import com.google.common.base.Preconditions;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
@@ -25,7 +26,8 @@ import org.triplea.util.Triple;
 final class EditValidator {
   private EditValidator() {}
 
-  private static String validateTerritoryBasic(final GameData data, final Territory territory) {
+  private static @Nullable String validateTerritoryBasic(
+      final GameData data, final Territory territory) {
     // territory cannot be in an UndoableMove route
     final List<UndoableMove> moves = data.getMoveDelegate().getMovesMade();
     for (final UndoableMove move : moves) {
@@ -110,7 +112,7 @@ final class EditValidator {
     return validateTerritoryBasic(data, territory);
   }
 
-  static String validateRemoveUnits(
+  static @Nullable String validateRemoveUnits(
       final GameData data, final Territory territory, final Collection<Unit> units) {
     if (units.isEmpty()) {
       return "No units selected";
@@ -142,8 +144,7 @@ final class EditValidator {
     return null;
   }
 
-  @Nullable
-  static String validateAddTech(
+  static @Nullable String validateAddTech(
       final GameState data, final Collection<TechAdvance> techs, final GamePlayer player) {
     if (techs == null) {
       return "No tech selected";
@@ -169,8 +170,7 @@ final class EditValidator {
     return null;
   }
 
-  @Nullable
-  static String validateRemoveTech(
+  static @Nullable String validateRemoveTech(
       final GameState data, final Collection<TechAdvance> techs, final GamePlayer player) {
     if (techs == null) {
       return "No tech selected";
@@ -199,7 +199,7 @@ final class EditValidator {
     return null;
   }
 
-  static String validateChangeHitDamage(
+  static @Nullable String validateChangeHitDamage(
       final GameData data, final IntegerMap<Unit> unitDamageMap, final Territory territory) {
     if (unitDamageMap == null || unitDamageMap.isEmpty()) {
       return "Damage map is empty";
@@ -230,7 +230,7 @@ final class EditValidator {
     return null;
   }
 
-  static String validateChangeBombingDamage(
+  static @Nullable String validateChangeBombingDamage(
       final GameData data, final IntegerMap<Unit> unitDamageMap, final Territory territory) {
     if (unitDamageMap == null || unitDamageMap.isEmpty()) {
       return "Damage map is empty";
@@ -263,12 +263,9 @@ final class EditValidator {
     return null;
   }
 
-  @Nullable
-  static String validateChangePoliticalRelationships(
+  static @Nullable String validateChangePoliticalRelationships(
       final Collection<Triple<GamePlayer, GamePlayer, RelationshipType>> relationshipChanges) {
-    if (relationshipChanges == null || relationshipChanges.isEmpty()) {
-      return "Relationship Changes are empty";
-    }
+    Preconditions.checkArgument(!relationshipChanges.isEmpty());
     for (final Triple<GamePlayer, GamePlayer, RelationshipType> relationshipChange :
         relationshipChanges) {
       if (relationshipChange.getFirst() == null || relationshipChange.getSecond() == null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.sound.SoundPath;
 
@@ -326,7 +327,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   }
 
   /** if null, the game is not over yet. */
-  public Collection<GamePlayer> getWinners() {
+  public @Nullable Collection<GamePlayer> getWinners() {
     if (!gameOver) {
       return null;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
@@ -162,7 +163,7 @@ public class PurchaseDelegate extends BaseTripleADelegate
   }
 
   @Override
-  public String purchase(final IntegerMap<ProductionRule> productionRules) {
+  public @Nullable String purchase(final IntegerMap<ProductionRule> productionRules) {
     final IntegerMap<Resource> costs = getCosts(productionRules);
     final IntegerMap<NamedAttachable> results = getResults(productionRules);
     if (!canAfford(costs, player)) {
@@ -252,7 +253,7 @@ public class PurchaseDelegate extends BaseTripleADelegate
   }
 
   @Override
-  public String purchaseRepair(final Map<Unit, IntegerMap<RepairRule>> repairRules) {
+  public @Nullable String purchaseRepair(final Map<Unit, IntegerMap<RepairRule>> repairRules) {
     final IntegerMap<Resource> costs = getRepairCosts(repairRules, player);
     if (!canAfford(costs, player)) {
       return NOT_ENOUGH_RESOURCES;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -137,7 +137,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
         return false;
       }
       final Collection<GamePlayer> helpPay = pa.getHelpPayTechCost();
-      if (helpPay == null || helpPay.isEmpty()) {
+      if (helpPay.isEmpty()) {
         return false;
       }
       for (final GamePlayer p : helpPay) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import lombok.Value;
 import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.CollectionUtils;
@@ -254,7 +255,7 @@ public class TransportTracker {
    * determine why we can't unload an additional unit. Since transports only hold up to two units,
    * we only need to return one territory, not multiple territories.
    */
-  public static Territory getTerritoryTransportHasUnloadedTo(final Unit transport) {
+  public static @Nullable Territory getTerritoryTransportHasUnloadedTo(final Unit transport) {
     final Collection<Unit> unloaded = transport.getUnloaded();
     if (unloaded.isEmpty()) {
       return null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -1663,14 +1663,13 @@ public class MoveValidator {
   }
 
   /** Get the route ignoring forced territories. */
-  public static Route getBestRoute(
+  public static @Nullable Route getBestRoute(
       final Territory start,
       final Territory end,
       final GameData data,
       final GamePlayer player,
       final Collection<Unit> units,
       final boolean forceLandOrSeaRoute) {
-
     final boolean hasLand = units.stream().anyMatch(Matches.unitIsLand());
     final boolean hasAir = units.stream().anyMatch(Matches.unitIsAir());
     final boolean isNeutralsImpassable =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
@@ -6,6 +6,7 @@ import games.strategy.engine.message.IRemote;
 import games.strategy.engine.message.RemoteActionCode;
 import java.io.Serializable;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Remote interface for MoveDelegate and PlaceDelegate.
@@ -28,7 +29,7 @@ public interface IAbstractMoveDelegate<T> extends IRemote, IDelegate {
    * @return an error string if the move could not be undone, null otherwise
    */
   @RemoteActionCode(12)
-  String undoMove(int moveIndex);
+  @Nullable String undoMove(int moveIndex);
 
   @RemoteActionCode(7)
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
@@ -29,7 +29,8 @@ public interface IAbstractMoveDelegate<T> extends IRemote, IDelegate {
    * @return an error string if the move could not be undone, null otherwise
    */
   @RemoteActionCode(12)
-  @Nullable String undoMove(int moveIndex);
+  @Nullable
+  String undoMove(int moveIndex);
 
   @RemoteActionCode(7)
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -9,6 +9,7 @@ import games.strategy.triplea.delegate.UndoablePlacement;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import java.io.Serializable;
 import java.util.Collection;
+import javax.annotation.Nullable;
 import org.triplea.java.RemoveOnNextMajorRelease;
 
 /** Logic for placing units within a territory. */
@@ -63,7 +64,7 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePl
 
   @RemoteActionCode(17)
   @Override
-  String undoMove(int moveIndex);
+  @Nullable String undoMove(int moveIndex);
 
   @RemoteActionCode(10)
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -64,7 +64,8 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePl
 
   @RemoteActionCode(17)
   @Override
-  @Nullable String undoMove(int moveIndex);
+  @Nullable
+  String undoMove(int moveIndex);
 
   @RemoteActionCode(10)
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IEditDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IEditDelegate.java
@@ -9,6 +9,7 @@ import games.strategy.engine.message.IRemote;
 import games.strategy.engine.message.RemoteActionCode;
 import games.strategy.triplea.delegate.TechAdvance;
 import java.util.Collection;
+import javax.annotation.Nullable;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Triple;
 
@@ -21,33 +22,33 @@ public interface IEditDelegate extends IRemote, IPersistentDelegate {
   void setEditMode(boolean editMode);
 
   @RemoteActionCode(11)
-  String removeUnits(Territory t, Collection<Unit> units);
+  @Nullable String removeUnits(Territory t, Collection<Unit> units);
 
   @RemoteActionCode(2)
-  String addUnits(Territory t, Collection<Unit> units);
+  @Nullable String addUnits(Territory t, Collection<Unit> units);
 
   @RemoteActionCode(6)
-  String changeTerritoryOwner(Territory t, GamePlayer player);
+  @Nullable String changeTerritoryOwner(Territory t, GamePlayer player);
 
   @RemoteActionCode(13)
-  String changeResource(GamePlayer player, String resourceName, int newTotal);
+  @Nullable String changeResource(GamePlayer player, String resourceName, int newTotal);
 
   @RemoteActionCode(1)
-  String addTechAdvance(GamePlayer player, Collection<TechAdvance> advance);
+  @Nullable String addTechAdvance(GamePlayer player, Collection<TechAdvance> advance);
 
   @RemoteActionCode(10)
-  String removeTechAdvance(GamePlayer player, Collection<TechAdvance> advance);
+  @Nullable String removeTechAdvance(GamePlayer player, Collection<TechAdvance> advance);
 
   @RemoteActionCode(8)
-  String changeUnitHitDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
+  @Nullable String changeUnitHitDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
 
   @RemoteActionCode(7)
-  String changeUnitBombingDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
+  @Nullable String changeUnitBombingDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
 
   @RemoteActionCode(0)
-  String addComment(String message);
+  @Nullable String addComment(String message);
 
   @RemoteActionCode(4)
-  String changePoliticalRelationships(
+  @Nullable String changePoliticalRelationships(
       Collection<Triple<GamePlayer, GamePlayer, RelationshipType>> relationshipChanges);
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IEditDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IEditDelegate.java
@@ -22,33 +22,43 @@ public interface IEditDelegate extends IRemote, IPersistentDelegate {
   void setEditMode(boolean editMode);
 
   @RemoteActionCode(11)
-  @Nullable String removeUnits(Territory t, Collection<Unit> units);
+  @Nullable
+  String removeUnits(Territory t, Collection<Unit> units);
 
   @RemoteActionCode(2)
-  @Nullable String addUnits(Territory t, Collection<Unit> units);
+  @Nullable
+  String addUnits(Territory t, Collection<Unit> units);
 
   @RemoteActionCode(6)
-  @Nullable String changeTerritoryOwner(Territory t, GamePlayer player);
+  @Nullable
+  String changeTerritoryOwner(Territory t, GamePlayer player);
 
   @RemoteActionCode(13)
-  @Nullable String changeResource(GamePlayer player, String resourceName, int newTotal);
+  @Nullable
+  String changeResource(GamePlayer player, String resourceName, int newTotal);
 
   @RemoteActionCode(1)
-  @Nullable String addTechAdvance(GamePlayer player, Collection<TechAdvance> advance);
+  @Nullable
+  String addTechAdvance(GamePlayer player, Collection<TechAdvance> advance);
 
   @RemoteActionCode(10)
-  @Nullable String removeTechAdvance(GamePlayer player, Collection<TechAdvance> advance);
+  @Nullable
+  String removeTechAdvance(GamePlayer player, Collection<TechAdvance> advance);
 
   @RemoteActionCode(8)
-  @Nullable String changeUnitHitDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
+  @Nullable
+  String changeUnitHitDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
 
   @RemoteActionCode(7)
-  @Nullable String changeUnitBombingDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
+  @Nullable
+  String changeUnitBombingDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
 
   @RemoteActionCode(0)
-  @Nullable String addComment(String message);
+  @Nullable
+  String addComment(String message);
 
   @RemoteActionCode(4)
-  @Nullable String changePoliticalRelationships(
+  @Nullable
+  String changePoliticalRelationships(
       Collection<Triple<GamePlayer, GamePlayer, RelationshipType>> relationshipChanges);
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
@@ -55,7 +55,8 @@ public interface IMoveDelegate
 
   @RemoteActionCode(19)
   @Override
-  @Nullable String undoMove(int moveIndex);
+  @Nullable
+  String undoMove(int moveIndex);
 
   @RemoteActionCode(5)
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
@@ -11,6 +11,7 @@ import games.strategy.triplea.delegate.UndoableMove;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /** Remote interface for MoveDelegate. */
 public interface IMoveDelegate
@@ -54,7 +55,7 @@ public interface IMoveDelegate
 
   @RemoteActionCode(19)
   @Override
-  String undoMove(int moveIndex);
+  @Nullable String undoMove(int moveIndex);
 
   @RemoteActionCode(5)
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
@@ -20,11 +20,13 @@ public interface IPurchaseDelegate extends IAbstractForumPosterDelegate {
    * @return null if units bought, otherwise an error message
    */
   @RemoteActionCode(10)
-  @Nullable String purchase(IntegerMap<ProductionRule> productionRules);
+  @Nullable
+  String purchase(IntegerMap<ProductionRule> productionRules);
 
   /** Returns an error code, or null if all is good. */
   @RemoteActionCode(11)
-  @Nullable String purchaseRepair(Map<Unit, IntegerMap<RepairRule>> productionRules);
+  @Nullable
+  String purchaseRepair(Map<Unit, IntegerMap<RepairRule>> productionRules);
 
   @RemoteActionCode(14)
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
@@ -8,6 +8,7 @@ import games.strategy.engine.message.IRemote;
 import games.strategy.engine.message.RemoteActionCode;
 import java.io.Serializable;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.triplea.java.collections.IntegerMap;
 
 /** Logic for purchasing and repairing units. */
@@ -19,11 +20,11 @@ public interface IPurchaseDelegate extends IAbstractForumPosterDelegate {
    * @return null if units bought, otherwise an error message
    */
   @RemoteActionCode(10)
-  String purchase(IntegerMap<ProductionRule> productionRules);
+  @Nullable String purchase(IntegerMap<ProductionRule> productionRules);
 
   /** Returns an error code, or null if all is good. */
   @RemoteActionCode(11)
-  String purchaseRepair(Map<Unit, IntegerMap<RepairRule>> productionRules);
+  @Nullable String purchaseRepair(Map<Unit, IntegerMap<RepairRule>> productionRules);
 
   @RemoteActionCode(14)
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
+import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
 
@@ -106,7 +107,7 @@ public final class TileImageFactory {
     resourceLoader = loader;
   }
 
-  public Image getBaseTile(final int x, final int y) {
+  public @Nullable Image getBaseTile(final int x, final int y) {
     final String fileName = getBaseTileImageName(x, y);
     if (resourceLoader.getResource(fileName) == null) {
       return null;
@@ -119,7 +120,7 @@ public final class TileImageFactory {
     return "baseTiles" + "/" + x + "_" + y + ".png";
   }
 
-  private Image getImage(final String fileName, final boolean transparent) {
+  private @Nullable Image getImage(final String fileName, final boolean transparent) {
     final URL url = resourceLoader.getResource(fileName);
 
     if ((!showMapBlends || !showReliefImages || !transparent) && url == null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
@@ -17,8 +17,7 @@ final class IntegerClientSetting extends ClientSetting<Integer> {
   }
 
   @Override
-  @Nullable
-  protected Integer decodeValue(final String encodedValue) throws ValueEncodingException {
+  protected @Nullable Integer decodeValue(final String encodedValue) throws ValueEncodingException {
     try {
       if (encodedValue.isEmpty()) {
         return null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/DiceChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/DiceChooser.java
@@ -41,7 +41,8 @@ class DiceChooser extends JPanel {
     createComponents();
   }
 
-  @Nullable int[] getDice() {
+  @Nullable
+  int[] getDice() {
     if (diceCount < numRolls) {
       return null;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/DiceChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/DiceChooser.java
@@ -5,6 +5,7 @@ import games.strategy.triplea.image.DiceImageFactory;
 import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.Collection;
+import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -40,6 +41,7 @@ class DiceChooser extends JPanel {
     createComponents();
   }
 
+  @Nullable
   int[] getDice() {
     if (diceCount < numRolls) {
       return null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/DiceChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/DiceChooser.java
@@ -41,8 +41,7 @@ class DiceChooser extends JPanel {
     createComponents();
   }
 
-  @Nullable
-  int[] getDice() {
+  @Nullable int[] getDice() {
     if (diceCount < numRolls) {
       return null;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -80,7 +80,8 @@ class PlayerChooser extends JOptionPane {
    *
    * @return the player or null
    */
-  @Nullable GamePlayer getSelected() {
+  @Nullable
+  GamePlayer getSelected() {
     if (getValue() != null && getValue().equals(JOptionPane.OK_OPTION)) {
       return list.getSelectedValue();
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -9,6 +9,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collection;
+import javax.annotation.Nullable;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.ImageIcon;
 import javax.swing.JList;
@@ -79,6 +80,7 @@ class PlayerChooser extends JOptionPane {
    *
    * @return the player or null
    */
+  @Nullable
   GamePlayer getSelected() {
     if (getValue() != null && getValue().equals(JOptionPane.OK_OPTION)) {
       return list.getSelectedValue();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -80,8 +80,7 @@ class PlayerChooser extends JOptionPane {
    *
    * @return the player or null
    */
-  @Nullable
-  GamePlayer getSelected() {
+  @Nullable GamePlayer getSelected() {
     if (getValue() != null && getValue().equals(JOptionPane.OK_OPTION)) {
       return list.getSelectedValue();
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -254,7 +254,8 @@ public class PoliticalStateOverview extends JPanel {
     this.revalidate();
   }
 
-  @Nullable Collection<Triple<GamePlayer, GamePlayer, RelationshipType>> getEditChanges() {
+  @Nullable
+  Collection<Triple<GamePlayer, GamePlayer, RelationshipType>> getEditChanges() {
     if (!editable) {
       return null;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -254,8 +254,7 @@ public class PoliticalStateOverview extends JPanel {
     this.revalidate();
   }
 
-  @Nullable
-  Collection<Triple<GamePlayer, GamePlayer, RelationshipType>> getEditChanges() {
+  @Nullable Collection<Triple<GamePlayer, GamePlayer, RelationshipType>> getEditChanges() {
     if (!editable) {
       return null;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.swing.Box;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -253,6 +254,7 @@ public class PoliticalStateOverview extends JPanel {
     this.revalidate();
   }
 
+  @Nullable
   Collection<Triple<GamePlayer, GamePlayer, RelationshipType>> getEditChanges() {
     if (!editable) {
       return null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceChooser.java
@@ -7,6 +7,7 @@ import java.awt.Dimension;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JDialog;
 import javax.swing.JList;
@@ -59,6 +60,7 @@ class ResourceChooser extends JOptionPane {
    *
    * @return the resource or null
    */
+  @Nullable
   Resource getSelected() {
     if (getValue() != null && getValue().equals(JOptionPane.OK_OPTION)) {
       return list.getSelectedValue();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -140,7 +141,7 @@ class StatPanel extends JPanel implements GameDataChangeListener {
     return icon;
   }
 
-  protected ImageIcon getIcon(final String playerName) {
+  protected @Nullable ImageIcon getIcon(final String playerName) {
     final GamePlayer player = gameData.getPlayerList().getPlayerId(playerName);
     if (player == null) {
       return null;

--- a/game-app/game-core/src/main/java/org/triplea/util/LocalizeHtml.java
+++ b/game-app/game-core/src/main/java/org/triplea/util/LocalizeHtml.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import lombok.experimental.UtilityClass;
 import org.triplea.io.FileUtils;
 
@@ -23,7 +24,8 @@ public final class LocalizeHtml {
    * Replaces relative image links within a given {@code htmlText} with absolute links that point to
    * the correct location on the local file system.
    */
-  public static String localizeImgLinksInHtml(final String htmlText, final Path mapContentFolder) {
+  public static @Nullable String localizeImgLinksInHtml(
+      final String htmlText, final Path mapContentFolder) {
     if (htmlText == null) {
       return null;
     }

--- a/game-app/game-core/src/main/java/tools/image/CenterPicker.java
+++ b/game-app/game-core/src/main/java/tools/image/CenterPicker.java
@@ -265,7 +265,7 @@ public final class CenterPicker {
      * @param p A point on the map.
      */
     private String findTerritoryName(final Point p) {
-      return ToolsUtil.findTerritoryName(p, polygons, "unknown");
+      return ToolsUtil.findTerritoryName(p, polygons).orElse("unknown");
     }
 
     private void mouseEvent(final Point point, final boolean rightMouse) {

--- a/game-app/game-core/src/main/java/tools/image/FileOpen.java
+++ b/game-app/game-core/src/main/java/tools/image/FileOpen.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 @Getter
 public class FileOpen {
   /** -- GETTER -- Returns the newly selected file. Will return null if no file is selected. */
-  @Nullable private Path file;
+  private @Nullable Path file;
 
   public FileOpen(final String title, final Path currentDirectory, final String... extensions) {
     this(title, currentDirectory, null, extensions);

--- a/game-app/game-core/src/main/java/tools/image/MapFolderLocationSystemProperty.java
+++ b/game-app/game-core/src/main/java/tools/image/MapFolderLocationSystemProperty.java
@@ -11,8 +11,7 @@ import tools.util.ToolArguments;
 @Slf4j
 public class MapFolderLocationSystemProperty {
 
-  @Nullable
-  public Path read() {
+  public @Nullable Path read() {
     final String value = System.getProperty(ToolArguments.MAP_FOLDER);
     if (value != null && value.length() > 0) {
       final Path mapFolder = Path.of(value);

--- a/game-app/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-app/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.swing.Action;
 import javax.swing.JCheckBoxMenuItem;
@@ -247,7 +248,7 @@ public final class PolygonGrabber {
                 for (final String territoryName : centers.keySet()) {
                   final Point center = centers.get(territoryName);
                   log.info("Detecting Polygon for:" + territoryName);
-                  final Polygon p = findPolygon(center.x, center.y);
+                  final @Nullable Polygon p = findPolygon(center.x, center.y);
                   // test if the poly contains the center point (this often fails when there is an
                   // island right above (because findPolygon will grab the island instead)
                   if (p == null || !p.contains(center)) {
@@ -442,7 +443,7 @@ public final class PolygonGrabber {
     /** Loads a pre-defined file with map polygon points. */
     private void loadPolygons() {
       log.info("Load a polygon file");
-      final Path polyName =
+      final @Nullable Path polyName =
           new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getFile();
       if (polyName == null) {
         return;
@@ -456,7 +457,7 @@ public final class PolygonGrabber {
     }
 
     private void mouseEvent(final Point point, final boolean ctrlDown, final boolean rightMouse) {
-      final Polygon p = findPolygon(point.x, point.y);
+      final @Nullable Polygon p = findPolygon(point.x, point.y);
       if (p == null) {
         return;
       }
@@ -608,7 +609,7 @@ public final class PolygonGrabber {
     }
 
     /** Algorithm to find a polygon given a x/y coordinates and returns the found polygon. */
-    private Polygon findPolygon(final int x, final int y) {
+    private @Nullable Polygon findPolygon(final int x, final int y) {
       // walk up, find the first black point
       final Point startPoint = new Point(x, y);
       while (inBounds(startPoint.x, startPoint.y - 1, bufferedImage)

--- a/game-app/game-core/src/main/java/tools/image/TileImageBreaker.java
+++ b/game-app/game-core/src/main/java/tools/image/TileImageBreaker.java
@@ -14,6 +14,7 @@ import java.awt.Transparency;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Path;
+import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -146,7 +147,7 @@ public final class TileImageBreaker {
    *
    * @return The loaded image.
    */
-  private Image loadImage() {
+  private @Nullable Image loadImage() {
     log.info("Select the map");
     final Path mapName =
         new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png").getFile();

--- a/game-app/game-core/src/main/java/tools/image/TileImageReconstructor.java
+++ b/game-app/game-core/src/main/java/tools/image/TileImageReconstructor.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
@@ -65,7 +66,7 @@ public final class TileImageReconstructor {
   }
 
   private void runInternal() {
-    Path mapFolderLocation = MapFolderLocationSystemProperty.read();
+    @Nullable Path mapFolderLocation = MapFolderLocationSystemProperty.read();
     JOptionPane.showMessageDialog(
         null,
         new JLabel(

--- a/game-app/game-core/src/main/java/tools/map/making/ImageShrinker.java
+++ b/game-app/game-core/src/main/java/tools/map/making/ImageShrinker.java
@@ -9,6 +9,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import javax.annotation.Nullable;
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriteParam;
@@ -58,7 +59,7 @@ public final class ImageShrinker {
                 + "<br>So we suggest you instead shrink the image with paint.net or photoshop or "
                 + "gimp, etc, then clean it up before saving."
                 + "</html>"));
-    final Path mapFile =
+    final @Nullable Path mapFile =
         new FileOpen("Select The Large Image", mapFolderLocation, ".gif", ".png").getFile();
     if (mapFile == null || !Files.exists(mapFile)) {
       throw new IllegalStateException(mapFile + " File does not exist");

--- a/game-app/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-app/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -567,7 +567,7 @@ public final class PlacementPicker {
      */
     private void mouseEvent(final Point point, final boolean ctrlDown, final boolean rightMouse) {
       if (!rightMouse && !ctrlDown) {
-        currentCountry = ToolsUtil.findTerritoryName(point, polygons, "there be dragons");
+        currentCountry = ToolsUtil.findTerritoryName(point, polygons).orElse("there be dragons");
         // If there isn't an existing array, create one
         if (placements == null || placements.get(currentCountry) == null) {
           currentPlacements = new ArrayList<>();

--- a/game-app/game-core/src/main/java/tools/util/ToolsUtil.java
+++ b/game-app/game-core/src/main/java/tools/util/ToolsUtil.java
@@ -21,22 +21,7 @@ public class ToolsUtil {
    */
   public static Optional<String> findTerritoryName(
       final Point p, final Map<String, List<Polygon>> terrPolygons) {
-    return Optional.ofNullable(findTerritoryName(p, terrPolygons, null));
-  }
-
-  /**
-   * Finds a land territory name or some sea zone name where the point is contained in according to
-   * the territory name -> polygons map. If no land or sea territory has been found a default name
-   * is returned.
-   *
-   * @param p A point on the map.
-   * @param terrPolygons a map territory name -> polygons
-   * @param defaultTerrName Default territory name that gets returns if nothing was found.
-   * @return found territory name of defaultTerrName
-   */
-  public static String findTerritoryName(
-      final Point p, final Map<String, List<Polygon>> terrPolygons, final String defaultTerrName) {
-    String lastWaterTerrName = defaultTerrName;
+    String lastWaterTerrName = null;
     // try to find a land territory.
     // sea zones often surround a land territory
     for (final String terrName : terrPolygons.keySet()) {
@@ -46,12 +31,12 @@ public class ToolsUtil {
           if (isTerritoryNameIndicatingWater(terrName)) {
             lastWaterTerrName = terrName;
           } else {
-            return terrName;
+            return Optional.of(terrName);
           }
         } // if p is contained
       } // polygons collection loop
     } // terrPolygons map loop
-    return lastWaterTerrName;
+    return Optional.ofNullable(lastWaterTerrName);
   }
 
   /**

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +45,7 @@ final class DefaultAttachmentTest {
       public void validate(final GameState data) {}
 
       @Override
-      public MutableProperty<?> getPropertyOrNull(String propertyName) {
+      public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
         return null;
       }
 

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.Runnables;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /** Fake implementation of {@link IAttachment} useful for testing. */
@@ -64,7 +65,7 @@ public final class FakeAttachment implements IAttachment {
   }
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "name":
         return MutableProperty.ofString(this::setName, this::getName, Runnables.doNothing());

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -45,7 +45,7 @@ public final class FakeAttachment implements IAttachment {
   }
 
   @Override
-  public String getName() {
+  public @Nullable String getName() {
     return name;
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
@@ -23,7 +23,7 @@ public class TestAttachment extends DefaultAttachment {
   public void setAttachedTo(final Attachable unused) {}
 
   @Override
-  public String getName() {
+  public @Nullable String getName() {
     return null;
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.data;
 
+import javax.annotation.Nullable;
 import lombok.Getter;
 
 /** Fake attachment used for testing. */
@@ -41,7 +42,7 @@ public class TestAttachment extends DefaultAttachment {
   public void validate(final GameState data) {}
 
   @Override
-  public MutableProperty<?> getPropertyOrNull(String propertyName) {
+  public @Nullable MutableProperty<?> getPropertyOrNull(String propertyName) {
     switch (propertyName) {
       case "value":
         return MutableProperty.ofString(this::setValue, this::getValue, this::resetValue);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -48,6 +48,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import javax.swing.ButtonModel;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
@@ -790,7 +791,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
   }
 
   @Override
-  public Map<Territory, Map<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
+  public @Nullable Map<Territory, Map<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
       final Map<Territory, Collection<Unit>> possibleUnitsToAttack) {
     final GamePlayer gamePlayer = this.getGamePlayer();
     final PlayerAttachment pa = PlayerAttachment.get(gamePlayer);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -134,11 +135,11 @@ public abstract class AbstractMovePanel extends ActionPanel {
     disableCancelButton();
   }
 
-  final String undoMove(final int moveIndex) {
+  final @Nullable String undoMove(final int moveIndex) {
     return undoMove(moveIndex, false);
   }
 
-  final String undoMove(final int moveIndex, final boolean suppressError) {
+  final @Nullable String undoMove(final int moveIndex, final boolean suppressError) {
     // clean up any state we may have
     cancelMove();
     // undo the move

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -1043,7 +1043,7 @@ public class MovePanel extends AbstractMovePanel {
   }
 
   /** Get the route ignoring forced territories. */
-  private Route getRouteNonForced(
+  private @Nullable Route getRouteNonForced(
       final Territory start, final Territory end, final Collection<Unit> selectedUnits) {
     // can't rely on current player being the unit owner in Edit Mode
     // look at the units being moved to determine allies and enemies
@@ -1057,7 +1057,8 @@ public class MovePanel extends AbstractMovePanel {
         !GameStepPropertiesHelper.isAirborneMove(getData()));
   }
 
-  private void updateUnitsThatCanMoveOnRoute(final Collection<Unit> units, final Route route) {
+  private void updateUnitsThatCanMoveOnRoute(
+      final Collection<Unit> units, final @Nullable Route route) {
     if (route == null || route.hasNoSteps()) {
       clearStatusMessage();
       getMap().showMouseCursor();
@@ -1108,7 +1109,7 @@ public class MovePanel extends AbstractMovePanel {
   }
 
   /** Route can be null. */
-  final void updateRouteAndMouseShadowUnits(final Route route) {
+  final void updateRouteAndMouseShadowUnits(final @Nullable Route route) {
     routeCached = route;
     getMap().setRoute(route, mouseSelectedPoint, mouseCurrentPoint, currentCursorImage);
     if (route == null) {
@@ -1371,7 +1372,7 @@ public class MovePanel extends AbstractMovePanel {
     return "MovePanel";
   }
 
-  final void setFirstSelectedTerritory(final Territory firstSelectedTerritory) {
+  final void setFirstSelectedTerritory(final @Nullable Territory firstSelectedTerritory) {
     if (Objects.equals(this.firstSelectedTerritory, firstSelectedTerritory)) {
       return;
     }

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -17,6 +17,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -238,7 +239,7 @@ class WebSocketConnection {
     }
 
     @Override
-    public CompletionStage<?> onText(
+    public @Nullable CompletionStage<?> onText(
         final WebSocket webSocket, final CharSequence data, final boolean last) {
       // No need to synchronize access, this listener is never called concurrently
       // and always called in-order by the API
@@ -253,7 +254,7 @@ class WebSocketConnection {
     }
 
     @Override
-    public CompletionStage<?> onClose(
+    public @Nullable CompletionStage<?> onClose(
         final WebSocket webSocket, final int statusCode, final String reason) {
       pingSender.cancel();
       if (reason.equals(WebSocketConnection.CLIENT_DISCONNECT_MESSAGE)) {


### PR DESCRIPTION
In some cases, cleans up the code some conditions were impossible or there was additional simplification to be made. Also moves some method-level Nullable annotations to return value for clarity. (They're equivalent.)

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
