### PR TITLE
Fix weird window resize behavior when starting game.

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedLaunchAction.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/mc/HeadedLaunchAction.java
@@ -92,8 +92,8 @@ public class HeadedLaunchAction implements LaunchAction {
         () -> {
           LookAndFeelSwingFrameListener.register(frame);
           frame.setSize(700, 400);
-          frame.setVisible(true);
           frame.setExtendedState(Frame.MAXIMIZED_BOTH);
+          frame.setVisible(true);
           frame.toFront();
         });
 


### PR DESCRIPTION
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

Before this PR, when opening a game, the window will start at a small size and then get resized as its maximized, which adds an unnecessary slowdown and is also visually jarring. This fixes that by starting the window at the correct maximized size already.

## Notes to Reviewer
