### PR TITLE
Fix stacking limit logic for bid placement.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -995,6 +995,10 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       placeableUnits2.removeAll(getUnitsThatCantBePlacedThatRequireUnits(unitsOfType, to));
     }
     // now check stacking limits
+    return applyStackingLimitsPerUnitType(placeableUnits2, to);
+  }
+
+  protected List<Unit> applyStackingLimitsPerUnitType(Collection<Unit> units, Territory to) {
     // Filter each type separately, since we don't want a max on one type to filter out all units of
     // another type, if the two types have a combined limit. UnitStackingLimitFilter doesn't do
     // that directly since other call sites (e.g. move validation) do need the combined filtering.
@@ -1004,7 +1008,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     for (UnitType ut : UnitUtils.getUnitTypesFromUnitList(units)) {
       result.addAll(
           UnitStackingLimitFilter.filterUnits(
-              CollectionUtils.getMatches(placeableUnits2, Matches.unitIsOfType(ut)),
+              CollectionUtils.getMatches(units, Matches.unitIsOfType(ut)),
               PLACEMENT_LIMIT,
               player,
               to,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -1,13 +1,11 @@
 package games.strategy.triplea.delegate;
 
-import static games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter.PLACEMENT_LIMIT;
 import static java.util.function.Predicate.not;
 
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.PlayerAttachment;
-import games.strategy.triplea.delegate.move.validation.UnitStackingLimitFilter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -133,7 +133,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
         Matches.unitConsumesUnitsOnCreation()
             .and(not(Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo))));
     // now check stacking limits
-    return UnitStackingLimitFilter.filterUnits(placeableUnits, PLACEMENT_LIMIT, player, to);
+    return applyStackingLimitsPerUnitType(placeableUnits, to);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
@@ -121,24 +121,23 @@ public class UnitStackingLimitFilter {
       max = Math.min(max, limitMax - totalInTerritory);
     }
 
-    if (stackingLimit == null) {
-      return max;
+    if (stackingLimit != null) {
+      final Predicate<Unit> stackingMatch;
+      final String stackingType = stackingLimit.getSecond();
+      switch (stackingType) {
+        case "owned":
+          stackingMatch = Matches.unitIsOfType(ut).and(Matches.unitIsOwnedBy(owner));
+          break;
+        case "allied":
+          stackingMatch = Matches.unitIsOfType(ut).and(Matches.isUnitAllied(owner));
+          break;
+        default:
+          stackingMatch = Matches.unitIsOfType(ut);
+          break;
+      }
+      final int totalInTerritory = CollectionUtils.countMatches(existingUnits, stackingMatch);
+      max = Math.min(max, ua.getStackingLimitMax(stackingLimit) - totalInTerritory);
     }
-    max = Math.min(max, ua.getStackingLimitMax(stackingLimit));
-    final Predicate<Unit> stackingMatch;
-    final String stackingType = stackingLimit.getSecond();
-    switch (stackingType) {
-      case "owned":
-        stackingMatch = Matches.unitIsOfType(ut).and(Matches.unitIsOwnedBy(owner));
-        break;
-      case "allied":
-        stackingMatch = Matches.unitIsOfType(ut).and(Matches.isUnitAllied(owner));
-        break;
-      default:
-        stackingMatch = Matches.unitIsOfType(ut);
-        break;
-    }
-    final int totalInTerritory = CollectionUtils.countMatches(existingUnits, stackingMatch);
-    return Math.max(0, max - totalInTerritory);
+    return Math.max(0, max);
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/BidPlaceDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/BidPlaceDelegateTest.java
@@ -13,7 +13,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import java.util.Collection;
@@ -25,15 +27,20 @@ import org.junit.jupiter.api.Test;
 import org.triplea.java.collections.CollectionUtils;
 
 class BidPlaceDelegateTest extends AbstractDelegateTestCase {
+  private final UnitType infantry2 = unitType("infantry2", gameData);
   private BidPlaceDelegate delegate;
 
-  @BeforeEach
-  void setupPlaceDelegate() {
-    final IDelegateBridge bridge = newDelegateBridge(british);
+  private void setupDelegate(GamePlayer player) {
+    final IDelegateBridge bridge = newDelegateBridge(player);
     delegate = new BidPlaceDelegate();
     delegate.initialize("bid");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
+  }
+
+  @BeforeEach
+  void setupPlaceDelegate() {
+    setupDelegate(british);
   }
 
   @Test
@@ -181,7 +188,6 @@ class BidPlaceDelegateTest extends AbstractDelegateTestCase {
     gameData.getProperties().set(UNIT_PLACEMENT_RESTRICTIONS, true);
     // Needed for canProduceXUnits to work. (!)
     gameData.getProperties().set(DAMAGE_FROM_BOMBING_DONE_TO_UNITS_INSTEAD_OF_TERRITORIES, true);
-    final var infantry2 = unitType("infantry2", gameData);
 
     final var threeInfantry2 = create(british, infantry2, 3);
     final var fourInfantry2 = create(british, infantry2, 4);
@@ -239,7 +245,7 @@ class BidPlaceDelegateTest extends AbstractDelegateTestCase {
   }
 
   @Test
-  void testPlayerAttachmentStackingLimit() {
+  void testPlayerAttachmentStackingLimitSea() {
     // we can place 3 battleships
     Collection<Unit> units = create(british, battleship, 3);
     assertValid(delegate.canUnitsBePlaced(northSea, units, british));
@@ -265,6 +271,35 @@ class BidPlaceDelegateTest extends AbstractDelegateTestCase {
     assertThat(result, hasSize(6));
     assertThat(CollectionUtils.getMatches(result, Matches.unitIsOfType(battleship)), hasSize(3));
     assertThat(CollectionUtils.getMatches(result, Matches.unitIsOfType(carrier)), hasSize(3));
+  }
+
+  @Test
+  void testPlayerAttachmentStackingLimitLand() {
+    setupDelegate(japanese);
+    // we can place 3 infantry
+    Collection<Unit> units = create(japanese, infantry, 3);
+    assertValid(delegate.canUnitsBePlaced(japan, units, japanese));
+    // but not 4
+    units = create(japanese, infantry, 4);
+    assertError(delegate.canUnitsBePlaced(japan, units, japanese));
+
+    // we can also place 2 infantry and an infantry2
+    units = create(japanese, infantry, 2);
+    units.addAll(create(japanese, infantry2, 1));
+    assertValid(delegate.canUnitsBePlaced(japan, units, japanese));
+    // but not 2 infantry and 2 infantry2
+    units.addAll(create(japanese, infantry2, 1));
+    assertError(delegate.canUnitsBePlaced(japan, units, japanese));
+    // However, getPlaceableUnits() should return 2 of each, since that's what's for filtering the
+    // options given to the user.
+    assertThat(
+        delegate.getPlaceableUnits(units, japan).getUnits(), containsInAnyOrder(units.toArray()));
+    units.addAll(create(japanese, infantry, 7));
+    units.addAll(create(japanese, infantry2, 5));
+    var result = delegate.getPlaceableUnits(units, japan).getUnits();
+    assertThat(CollectionUtils.getMatches(result, Matches.unitIsOfType(infantry)), hasSize(3));
+    assertThat(CollectionUtils.getMatches(result, Matches.unitIsOfType(infantry2)), hasSize(3));
+    assertThat(result, hasSize(6));
   }
 
   @Test

--- a/game-app/game-core/src/test/resources/DelegateTest.xml
+++ b/game-app/game-core/src/test/resources/DelegateTest.xml
@@ -439,7 +439,7 @@
         <player name="British" optional="false"/>
         <player name="Chinese" optional="false"/>
         <player name="Americans" optional="false"/>
-        <player name="Russians" optional="false"></player>
+        <player name="Russians" optional="false"/>
         <alliance player="Americans" alliance="imperial"/>
         <alliance player="British" alliance="imperial"/>
         <alliance player="Chinese" alliance="imperial"/>
@@ -474,7 +474,6 @@
         <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate"/>
         <delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
         <sequence>
-
             <step name="gameInitDelegate" delegate="initDelegate"/>
 
             <step name="britishTech" delegate="tech" player="British"/>
@@ -625,7 +624,6 @@
             <frontierRules name="buyFactoryIndustrialTechnology"/>
         </productionFrontier>
 
-
         <playerProduction player="British" frontier="production"/>
         <playerProduction player="Japanese" frontier="production"/>
         <playerProduction player="Americans" frontier="production"/>
@@ -715,10 +713,7 @@
             <option name="defense" value="2"/>
         </attachment>
 
-        <attachment name="unitAttachment"
-            attachTo="factory"
-            javaClass="UnitAttachment"
-            type="unitType">
+        <attachment name="unitAttachment" attachTo="factory" javaClass="UnitAttachment" type="unitType">
             <option name="isFactory" value="true"/>
         </attachment>
 
@@ -732,6 +727,7 @@
             <option name="attack" value="1"/>
             <option name="defense" value="2"/>
             <option name="requiresUnits" value="factory2"/>
+            <option name="placementLimit" value="owned" count="4"/>
         </attachment>
         <attachment name="unitAttachment" attachTo="submarine2" javaClass="UnitAttachment" type="unitType">
             <option name="isSub" value="true"/>
@@ -742,10 +738,7 @@
             <option name="requiresUnits" value="factory2"/>
         </attachment>
 
-        <attachment name="unitAttachment"
-            attachTo="aaGun"
-            javaClass="UnitAttachment"
-            type="unitType">
+        <attachment name="unitAttachment"  attachTo="aaGun" javaClass="UnitAttachment" type="unitType">
             <option name="isAA" value="true"/>
             <option name="transportCost" value="2"/>
             <option name="movement" value="1"/>
@@ -975,6 +968,10 @@
             <option name="movementLimit" value="owned:infantry" count="7"/>
         </attachment>
 
+        <attachment name="playerAttachment" attachTo="Japanese" javaClass="PlayerAttachment" type="player">
+            <option name="placementLimit" value="owned:infantry:infantry2" count="3"/>
+        </attachment>
+
         <!-- Chinese Rules -->
         <attachment name="rulesAttachment" attachTo="Chinese" javaClass="RulesAttachment" type="player">
             <option name="movementRestrictionTerritories" value="Yunnan:Manchuria:Kwangtung"/>
@@ -990,7 +987,6 @@
 
         <ownerInitialize>
             <territoryOwner territory="Japan" owner="Japanese"/>
-
 
             <territoryOwner territory="Syria Jordan" owner="Japanese"/>
             <territoryOwner territory="Congo" owner="Japanese"/>
@@ -1014,15 +1010,14 @@
         <unitInitialize>
             <!-- india -->
 
-            <unitPlacement unitType="infantry" territory="India" quantity = "5" owner="Americans"/>
-            <unitPlacement unitType="fighter" territory="India" quantity = "3" owner="Americans"/>
-            <unitPlacement unitType="armour" territory="India" quantity = "2" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="India" quantity="5" owner="Americans"/>
+            <unitPlacement unitType="fighter" territory="India" quantity="3" owner="Americans"/>
+            <unitPlacement unitType="armour" territory="India" quantity="2" owner="Americans"/>
 
             <unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese"/>
             <unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
             <unitPlacement unitType="transport" territory="Japan Sea Zone" quantity="2" owner="Japanese"/>
             <unitPlacement unitType="battleship" territory="Japan Sea Zone" quantity="1" owner="Japanese"/>
-
 
             <!-- indian ocean-->
             <unitPlacement unitType="transport" territory="Indian Ocean Sea Zone" quantity="2" owner="British"/>
@@ -1038,7 +1033,7 @@
             <unitPlacement unitType="submarine" territory="Baltic Sea Zone" quantity="1" owner="Germans"/>
             <unitPlacement unitType="transport" territory="Baltic Sea Zone" quantity="1" owner="Germans"/>
 
-            <!-- findland norway-->
+            <!-- finland norway-->
             <unitPlacement unitType="armour" territory="Finland Norway" quantity="1" owner="Germans" />
             <unitPlacement unitType="infantry" territory="Finland Norway" quantity="3" owner="Germans" />
             <unitPlacement unitType="fighter" territory="Finland Norway" quantity="1" owner="Germans" />
@@ -1047,8 +1042,7 @@
             <unitPlacement unitType="transport" territory="Red Sea Zone" quantity="2" owner="British"/>
             <unitPlacement unitType="carrier" territory="Red Sea Zone" quantity="2" owner="British"/>
 
-
-            <!--egypt -->
+            <!-- egypt -->
             <unitPlacement unitType="armour" territory="Anglo Sudan Egypt" quantity="6" owner="British"/>
             <unitPlacement unitType="fighter" territory="Anglo Sudan Egypt" quantity="6" owner="British"/>
             <unitPlacement unitType="bomber" territory="Anglo Sudan Egypt" quantity="6" owner="British"/>
@@ -1065,7 +1059,6 @@
             <unitPlacement unitType="carrier" territory="Congo Sea Zone" quantity="2" owner="British"/>
             <unitPlacement unitType="infantry" territory="Congo Sea Zone" quantity="4" owner="British"/>
             <unitPlacement unitType="fighter" territory="Congo Sea Zone" quantity="3" owner="British"/>
-
 
             <!-- congo -->
             <unitPlacement unitType="infantry" territory="Congo" quantity="4" owner="Japanese" />


### PR DESCRIPTION
The stacking limit needs to be applied per unit type for the dialog, which was already being done in the regular placement code, but wasn't in the bid placement code. This re-uses the logic for both.

Fixes another issue reported in: https://github.com/triplea-game/triplea/issues/12376

Also fixes a logic issue in UnitStackingLimitFilter when both a unit attachment and a player attachment limit applies.

Adds tests.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
