### PR TITLE
Disallow placing units when a territory effect forbids it.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilter.java
@@ -8,6 +8,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -70,8 +71,12 @@ public class UnitStackingLimitFilter {
     // Note: This must check each unit individually and track the ones that passed in order to
     // correctly handle stacking limits that apply to multiple unit types.
     final var unitsAllowedSoFar = new ArrayList<>(existingUnitsToBePlaced);
+    final var forbiddenTypes = TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t);
     for (final Unit unit : units) {
       UnitType ut = unit.getType();
+      if (forbiddenTypes.contains(ut)) {
+        continue;
+      }
       Tuple<Integer, String> stackingLimit = stackingLimitGetter.apply(ut.getUnitAttachment());
       int maxAllowed =
           getMaximumNumberOfThisUnitTypeToReachStackingLimit(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTestCommon.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTestCommon.java
@@ -7,6 +7,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import games.strategy.engine.data.GamePlayer;
@@ -142,6 +143,14 @@ public abstract class PlaceDelegateTestCommon extends AbstractDelegateTestCase {
     // we can't place 2
     response = delegate.canUnitsBePlaced(egypt, create(british, factory, 2), british);
     assertError(response);
+  }
+
+  @Test
+  void testTerritoryEffectForbiddenUnits() {
+    List<Unit> units = armour.create(1, british);
+    final PlaceableUnits response = delegate.getPlaceableUnits(units, westCanada);
+    assertThat(response.getUnits(), is(empty()));
+    assertError(delegate.canUnitsBePlaced(westCanada, units, british));
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilterTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/UnitStackingLimitFilterTest.java
@@ -103,4 +103,10 @@ class UnitStackingLimitFilterTest extends AbstractDelegateTestCase {
     assertThat(expected, hasSize(3));
     assertThat(callFilterUnits(units, british, uk), is(expected));
   }
+
+  @Test
+  void testTerritoryEffectForbiddenUnits() {
+    List<Unit> units = armour.create(3, british);
+    assertThat(callFilterUnits(units, british, westCanada), is(empty()));
+  }
 }

--- a/game-app/game-core/src/test/resources/DelegateTest.xml
+++ b/game-app/game-core/src/test/resources/DelegateTest.xml
@@ -463,6 +463,9 @@
         <unit name="infantry2"/>
         <unit name="submarine2"/>
     </unitList>
+    <territoryEffectList>
+        <territoryEffect name="marsh"/>
+    </territoryEffectList>
 <gamePlay>
         <delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate"/>
         <delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate"/>
@@ -948,6 +951,7 @@
         </attachment>
         <attachment name="territoryAttachment" attachTo="West Canada" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
+            <option name="territoryEffect" value="marsh"/>
         </attachment>
         <attachment name="territoryAttachment" attachTo="West Europe" javaClass="TerritoryAttachment" type="territory">
             <option name="production" value="2" />
@@ -980,6 +984,10 @@
             <option name="placementAnyTerritory" value="true"/>
             <option name="placementCapturedTerritory" value="true"/>
             <option name="placementPerTerritory" value="3"/>
+        </attachment>
+
+        <attachment name="territoryEffectAttachment" attachTo="marsh" javaClass="TerritoryEffectAttachment" type="territoryEffect">
+            <option name="unitsNotAllowed" value="armour"/>
         </attachment>
 
     </attachmentList>


### PR DESCRIPTION
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

Previously, this was only considered for movement.
This makes both regular placement and bid placement forbid it as well.

Fixes another issue reported in: https://github.com/triplea-game/triplea/issues/12376

## Notes to Reviewer
