### PR TITLE
Check canOnlyBePlacedInTerritoryValuedAtX for bid placement.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -886,7 +886,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     return null;
   }
 
-  private boolean hasUnitPlacementRestrictions() {
+  protected boolean hasUnitPlacementRestrictions() {
     // Note: Overridden by BidPlaceDelegate.
     return Properties.getUnitPlacementRestrictions(getProperties());
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -6,6 +6,8 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.PlayerAttachment;
+import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.attachments.UnitAttachment;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -125,6 +127,15 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
               CollectionUtils.getMatches(units, Matches.unitIsOfType(currentUnit.getType())));
         }
       }
+    }
+    if (hasUnitPlacementRestrictions()) {
+      final int territoryProduction = TerritoryAttachment.getProduction(to);
+      final Predicate<Unit> cantBePlacedDueToTerritoryProduction =
+          u -> {
+            int requiredProduction = u.getUnitAttachment().getCanOnlyBePlacedInTerritoryValuedAtX();
+            return requiredProduction != -1 && requiredProduction > territoryProduction;
+          };
+      placeableUnits.removeIf(cantBePlacedDueToTerritoryProduction);
     }
     // remove any units that require other units to be consumed on creation (veqryn)
     placeableUnits.removeIf(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -7,7 +7,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;


### PR DESCRIPTION
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->
Fixes another issue observed on: https://github.com/triplea-game/triplea/issues/12376

This doesn't actually change behavior with what's allowed to be placed, it just makes it the dialog to select units to place omit  units that are already not allowed to be placed (and would otherwise show an error when selecting them).
## Notes to Reviewer
