### PR TITLE
Gradle test config: simplify & add config to print passed & failed tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,9 +123,12 @@ subprojects {
     }
 
     tasks.withType(Test).configureEach {
+        useJUnitPlatform() {
+            excludeTags "RequiresDatabase"
+        }
         testLogging {
             exceptionFormat = "full"
-            showStandardStreams = true
+            events = ["standardOut", "standardError", "skipped", "failed"]
         }
     }
 
@@ -194,13 +197,6 @@ subprojects {
         java {
             googleJavaFormat()
             removeUnusedImports()
-        }
-    }
-
-    //  "test" runs only the tests that do _not_ need a database
-    test {
-        useJUnitPlatform() {
-            excludeTags "RequiresDatabase"
         }
     }
 


### PR DESCRIPTION
'ShowStandardStreams' is a shortcut for showing standard out & standard error events. This update adds to that to also show 'skipped' and 'failed' events.

Otherwise this update also consolidates test config, small simplification.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
