### PR TITLE
Fix a race on startup that could clear a loaded save.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Observable;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import lombok.Getter;
@@ -45,40 +46,50 @@ public class GameSelectorModel extends Observable implements GameSelector {
   @Setter @Getter private ClientModel clientModelForHostBots = null;
   private Optional<String> saveGameToLoad = Optional.empty();
 
+  // Don't load a save game before the startup task to load the initial map has run, else that task
+  // may "lose" the race and overwrite the loaded saved game.
+  private CountDownLatch readyForSaveLoad = new CountDownLatch(1);
+
   public GameSelectorModel() {}
 
-  /**
-   * Loads game data by parsing a given file.
-   *
-   * @return True if successfully loaded, otherwise false.
-   */
-  public boolean load(final Path xmlFile) {
-    Preconditions.checkArgument(
-        Files.exists(xmlFile),
-        "Programming error, expected file to have already been checked to exist: "
-            + xmlFile.toAbsolutePath());
-
-    // if the file name is xml, load it as a new game
-    if (xmlFile.getFileName().toString().toLowerCase().endsWith("xml")) {
-      fileName = null;
-      GameData gameData = parseAndValidate(xmlFile);
-      if (gameData != null && gameData.getGameName() == null) {
-        gameData = null;
-      }
-      setGameData(gameData);
-      this.setDefaultGame(xmlFile, gameData);
-      return gameData != null;
-    } else {
-      // try to load it as a saved game whatever the extension
-      final GameData newData = GameDataManager.loadGame(xmlFile).orElse(null);
-      if (newData == null) {
-        return false;
-      }
-      newData.setSaveGameFileName(xmlFile.getFileName().toString());
-      this.fileName = xmlFile.getFileName().toString();
-      setGameData(newData);
-      return true;
+  public boolean loadMap(Path xmlFile) {
+    ensureExists(xmlFile);
+    fileName = null;
+    GameData gameData = parseAndValidate(xmlFile);
+    if (gameData != null && gameData.getGameName() == null) {
+      gameData = null;
     }
+    setGameData(gameData);
+    this.setDefaultGame(xmlFile, gameData);
+    return gameData != null;
+  }
+
+  public boolean loadSave(Path saveFile) {
+    try {
+      readyForSaveLoad.await();
+    } catch (InterruptedException e) {
+      return false;
+    }
+    ensureExists(saveFile);
+    final GameData newData = GameDataManager.loadGame(saveFile).orElse(null);
+    if (newData == null) {
+      return false;
+    }
+    newData.setSaveGameFileName(saveFile.getFileName().toString());
+    this.fileName = saveFile.getFileName().toString();
+    setGameData(newData);
+    return true;
+  }
+
+  public void setReadyForSaveLoad() {
+    readyForSaveLoad.countDown();
+  }
+
+  private void ensureExists(Path file) {
+    Preconditions.checkArgument(
+        Files.exists(file),
+        "Programming error, expected file to have already been checked to exist: "
+            + file.toAbsolutePath());
   }
 
   private void setDefaultGame(@Nullable final Path xmlFile, @Nullable final GameData gameData) {
@@ -192,7 +203,17 @@ public class GameSelectorModel extends Observable implements GameSelector {
         .filter(Predicate.not(String::isBlank))
         .filter(GameSelectorModel::gameUriExistsOnFileSystem)
         .map(GameSelectorModel::pathFromGameUri)
-        .ifPresentOrElse(this::load, this::resetDefaultGame);
+        .ifPresentOrElse(
+            (file) -> {
+              // if the file name is xml, load it as a new game
+              if (file.getFileName().toString().toLowerCase().endsWith("xml")) {
+                loadMap(file);
+              } else {
+                // try to load it as a saved game whatever the extension
+                loadSave(file);
+              }
+            },
+            this::resetDefaultGame);
   }
 
   private static Path pathFromGameUri(final String gameUri) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -48,7 +48,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
 
   // Don't load a save game before the startup task to load the initial map has run, else that task
   // may "lose" the race and overwrite the loaded saved game.
-  private CountDownLatch readyForSaveLoad = new CountDownLatch(1);
+  private final CountDownLatch readyForSaveLoad = new CountDownLatch(1);
 
   public GameSelectorModel() {}
 
@@ -176,7 +176,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
   /** Clears AI game over cache and loads default game in a new thread. */
   @Override
   public void onGameEnded() {
-    // clear out ai cached properties (this ended up being the best place to put it,
+    // clear out AI cached properties (this ended up being the best place to put it,
     // as we have definitely left a game at this point)
     GameShutdownRegistry.runShutdownActions();
     ThreadRunner.runInNewThread(this::loadDefaultGameSameThread);

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.concurrent.TimeUnit;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -36,6 +37,7 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import org.triplea.config.product.ProductVersionReader;
+import org.triplea.java.timer.Timers;
 import org.triplea.swing.DialogBuilder;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
@@ -367,7 +369,7 @@ public final class GameSelectorPanel extends JPanel implements Observer {
         .build()
         .run(
             () -> {
-              if (model.load(file)) {
+              if (model.loadSave(file)) {
                 setOriginalPropertiesMap(model.getGameData());
               }
             });
@@ -393,17 +395,10 @@ public final class GameSelectorPanel extends JPanel implements Observer {
     BackgroundTaskRunner.runInBackground(
         "Loading map...",
         () -> {
-          model.load(gameFile);
-          // warning: NPE check is not to protect against concurrency, another thread could still
-          // null
-          // out game data.
-          // The NPE check is to protect against the case where there are errors loading game, in
-          // which case we'll have a null game data.
-          if (model.getGameData() != null) {
+          if (model.loadMap(gameFile)) {
             setOriginalPropertiesMap(model.getGameData());
             // only for new games, not saved games, we set the default options, and set them only
-            // once
-            // (the first time it is loaded)
+            // once (the first time it is loaded)
             gamePropertiesCache.loadCachedGamePropertiesInto(model.getGameData());
           }
         });

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
-import java.util.concurrent.TimeUnit;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -37,7 +36,6 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import org.triplea.config.product.ProductVersionReader;
-import org.triplea.java.timer.Timers;
 import org.triplea.swing.DialogBuilder;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
@@ -240,15 +238,15 @@ public final class GameSelectorPanel extends JPanel implements Observer {
   private static GridBagConstraints buildGrid(
       final int x, final int y, final Insets insets, final int width) {
     final int gridHeight = 1;
-    final double weigthX = 0;
-    final double weigthY = 0;
+    final double weightX = 0;
+    final double weightY = 0;
     final int anchor = GridBagConstraints.WEST;
     final int fill = GridBagConstraints.NONE;
     final int ipadx = 0;
     final int ipady = 0;
 
     return new GridBagConstraints(
-        x, y, width, gridHeight, weigthX, weigthY, anchor, fill, insets, ipadx, ipady);
+        x, y, width, gridHeight, weightX, weightY, anchor, fill, insets, ipadx, ipady);
   }
 
   private void setOriginalPropertiesMap(final GameData data) {

--- a/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -142,7 +142,11 @@ public final class HeadedGameRunner {
           headedServerSetupModel = new HeadedServerSetupModel(gameSelectorModel);
           MainFrame.buildMainFrame(headedServerSetupModel, gameSelectorModel);
           headedServerSetupModel.showSelectType();
-          ThreadRunner.runInNewThread(HeadedGameRunner::showMainFrame);
+          ThreadRunner.runInNewThread(
+              () -> {
+                showMainFrame();
+                gameSelectorModel.setReadyForSaveLoad();
+              });
         });
 
     UpdateChecks.launch();
@@ -150,7 +154,7 @@ public final class HeadedGameRunner {
 
   /**
    * Sets the 'main frame' to visible. In this context the main frame is the initial welcome (launch
-   * lobby/single player game etc..) screen presented to GUI enabled clients.
+   * lobby/single player game etc.) screen presented to GUI enabled clients.
    */
   public static void showMainFrame() {
     GameShutdownRegistry.runShutdownActions();
@@ -169,7 +173,7 @@ public final class HeadedGameRunner {
       final String saveGameFileName = System.getProperty(TRIPLEA_GAME, "");
       if (!saveGameFileName.isEmpty()) {
         final Path saveGameFile = Path.of(saveGameFileName);
-        if (Files.exists(saveGameFile) && !gameSelectorModel.load(saveGameFile)) {
+        if (Files.exists(saveGameFile) && !gameSelectorModel.loadSave(saveGameFile)) {
           // abort launch if we failed to load the specified game
           return;
         }

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -60,7 +60,7 @@ public class HeadlessGameServer {
     log.info("Requested to change map to: " + gameName);
     // don't change mid-game and only if we have the game
     if (game == null && availableGames.hasGame(gameName)) {
-      gameSelectorModel.load(availableGames.findGameXmlPathByGameName(gameName).orElseThrow());
+      gameSelectorModel.loadMap(availableGames.findGameXmlPathByGameName(gameName).orElseThrow());
       log.info("Changed to game map: " + gameName);
     } else {
       log.info(
@@ -74,7 +74,7 @@ public class HeadlessGameServer {
     Preconditions.checkArgument(
         Files.exists(file), "File must exist to load it: " + file.toAbsolutePath());
     // don't change mid-game
-    if (game == null && gameSelectorModel.load(file)) {
+    if (game == null && gameSelectorModel.loadSave(file)) {
       log.info("Changed to save: " + file.getFileName());
     }
   }

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -67,7 +67,7 @@ public class HeadlessLaunchAction implements LaunchAction {
     serverModel.setAllPlayersToNullNodes();
     final Path autoSaveFile = getAutoSaveFileUtils().getHeadlessAutoSaveFile();
     if (Files.exists(autoSaveFile)) {
-      gameSelectorModel.load(autoSaveFile);
+      gameSelectorModel.loadSave(autoSaveFile);
     }
   }
 


### PR DESCRIPTION
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

I noticed the race when running the game in debug mode from IntelliJ, where it was consistently being hit for me when I would click the button to open a save right after startup.
This PR fixes it by ensuring the save game will only be loaded after the initial map load.

Also, splits the function to load a map vs. a game and updates call sites.

## Notes to Reviewer
