### PR TITLE
Revert - Use static file for latest version & lobby message

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea;
 
+import java.net.URI;
 import lombok.experimental.UtilityClass;
 
 /** Grouping of hardcoded URL constants. */
@@ -10,6 +11,8 @@ public final class UrlConstants {
   public static final String GITHUB_ISSUES = "https://github.com/triplea-game/triplea/issues/new";
   public static final String LICENSE_NOTICE =
       "https://github.com/triplea-game/triplea/blob/master/README.md#license";
+  public static final URI LIVE_SERVERS_URI =
+      URI.create("https://raw.githubusercontent.com/triplea-game/triplea/master/servers.yml");
   public static final String MAP_MAKER_HELP =
       "https://github.com/triplea-game/triplea/wiki/How-to-create-custom-maps";
   public static final String PAYPAL_DONATE =

--- a/game-app/game-core/src/main/java/org/triplea/live/servers/LiveServersFetcher.java
+++ b/game-app/game-core/src/main/java/org/triplea/live/servers/LiveServersFetcher.java
@@ -1,33 +1,58 @@
 package org.triplea.live.servers;
 
-import feign.FeignException;
-import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.engine.framework.system.HttpProxy;
+import games.strategy.triplea.UrlConstants;
+import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import org.triplea.http.client.latest.version.LatestVersionClient;
 import org.triplea.http.client.latest.version.LatestVersionResponse;
+import org.triplea.io.CloseableDownloader;
+import org.triplea.io.ContentDownloader;
+import org.triplea.yaml.YamlReader;
 
 @Slf4j
 @UtilityClass
 public class LiveServersFetcher {
 
   /**
-   * Queries the lobby-server for the latest game engine version.
-   *
-   * @return Empty optional if server fails to return a value, otherwise latest game engine version
-   *     as known to the lobby-server.
+   * Fetches from remote source the latest TripleA version that has been released. This can be used
+   * to determine if the current version is out of date.
    */
   public static Optional<LatestVersionResponse> latestVersion() {
-    try {
+    try (CloseableDownloader downloader =
+        new ContentDownloader(UrlConstants.LIVE_SERVERS_URI, HttpProxy::addProxy)) {
+      var inputStream = downloader.getStream();
+      final Map<String, Object> yamlProps = YamlReader.readMap(inputStream);
+
       return Optional.of(
-          LatestVersionClient.newClient(ClientSetting.lobbyUri.getValueOrThrow())
-              .fetchLatestVersion());
-    } catch (final FeignException e) {
+          LatestVersionResponse.builder()
+              .latestEngineVersion((String) yamlProps.get("latest"))
+              .downloadUrl(UrlConstants.DOWNLOAD_WEBSITE)
+              .releaseNotesUrl(UrlConstants.RELEASE_NOTES)
+              .build());
+    } catch (final IOException e) {
       log.info(
           "Unable to complete engine out-of-date check. "
               + "(No internet connection or server not available?)",
           e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Reads from remote source the "lobby welcome message", this is the lobby-chat message displayed
+   * first to anyone joining the lobby.
+   */
+  public static Optional<String> getLobbyMessage() {
+    try (CloseableDownloader downloader =
+        new ContentDownloader(UrlConstants.LIVE_SERVERS_URI, HttpProxy::addProxy)) {
+      var inputStream = downloader.getStream();
+      final Map<String, Object> yamlProps = YamlReader.readMap(inputStream);
+      return Optional.of((String) yamlProps.get("message"));
+    } catch (IOException e) {
+      log.info("Unable to fetch lobby welcome message", e);
       return Optional.empty();
     }
   }

--- a/game-app/game-headed/build.gradle
+++ b/game-app/game-headed/build.gradle
@@ -65,9 +65,6 @@ task downloadAssets {
 
 run {
     dependsOn downloadAssets
-    dependsOn rootProject.composeUp
-    dependsOn(":spitfire-server:database:flywayMigrateLobbyDb")
-    dependsOn(":spitfire-server:database:flywayMigrateErrorReportDb")
 }
 
 runShadow {

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -16,6 +16,7 @@ import org.triplea.http.client.forgot.password.ForgotPasswordRequest;
 import org.triplea.http.client.lobby.login.CreateAccountResponse;
 import org.triplea.http.client.lobby.login.LobbyLoginClient;
 import org.triplea.http.client.lobby.login.LobbyLoginResponse;
+import org.triplea.live.servers.LiveServersFetcher;
 import org.triplea.swing.DialogBuilder;
 import org.triplea.swing.SwingComponents;
 
@@ -95,6 +96,7 @@ public class LobbyLogin {
               () -> lobbyLoginClient.login(panel.getUserName(), panel.getPassword()));
 
       if (loginResponse.getFailReason() == null) {
+        String lobbyWelcomeMessage = LiveServersFetcher.getLobbyMessage().orElse("");
         return Optional.of(
             LoginResult.builder()
                 .anonymousLogin(Strings.isNullOrEmpty(panel.getPassword()))
@@ -102,7 +104,7 @@ public class LobbyLogin {
                 .apiKey(ApiKey.of(loginResponse.getApiKey()))
                 .moderator(loginResponse.isModerator())
                 .passwordChangeRequired(loginResponse.isPasswordChangeRequired())
-                .loginMessage(loginResponse.getLobbyMessage())
+                .loginMessage(lobbyWelcomeMessage)
                 .build());
       } else {
         showMessage("Login Failed", loginResponse.getFailReason());
@@ -147,6 +149,7 @@ public class LobbyLogin {
     final CreateAccountPanel.ReturnValue returnValue = createAccountPanel.show(parentWindow);
     switch (returnValue) {
       case OK:
+        String lobbyWelcomeMessage = LiveServersFetcher.getLobbyMessage().orElse("");
         return createAccount(createAccountPanel)
             .map(
                 lobbyLoginResponse ->
@@ -154,7 +157,7 @@ public class LobbyLogin {
                         .username(UserName.of(createAccountPanel.getUsername()))
                         .apiKey(ApiKey.of(lobbyLoginResponse.getApiKey()))
                         .passwordChangeRequired(lobbyLoginResponse.isPasswordChangeRequired())
-                        .loginMessage(lobbyLoginResponse.getLobbyMessage())
+                        .loginMessage(lobbyWelcomeMessage)
                         .build());
       case CANCEL:
         return Optional.empty();

--- a/servers.yml
+++ b/servers.yml
@@ -1,5 +1,9 @@
 # This file is read by game clients 2.2 through 2.5
 latest: 2.5.22294
+message: |
+  Welcome to the TripleA lobby!
+  Please no politics, stay respectful, be welcoming, have fun.
+
 servers:
   - version: "2.5.22294"
     lobby_uri: https://prod.triplea-game.org


### PR DESCRIPTION
- Updates how we fetch "latest version", we go back to reading it from a static file hosted in the code repository.

- Format of the code repository latest file 'servers.yml' is updated to have a top level 'message'. This removes the notion of a per-version message. The intent is for us to get off this file soon, the 'message' would one day come from somewhere else.

- The fetch of the 'lobby message' is moved back to the file as well. We need to read this information on any successful login to lobby.

- Remove dependency on docker compose tasks to run game-headed project. This needs to be redone.
