### PR TITLE
Image fix

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -227,7 +227,7 @@ public class UnitImageFactory {
   }
 
   /**
-   * Return the appropriate unit image. If an image cannot be found, a placeholder 'no-image' image
+   * Return the appropriate scaled unit image. If an image cannot be found, a placeholder 'no-image' image
    * is returned.
    */
   public Image getImage(final ImageKey imageKey) {
@@ -375,7 +375,7 @@ public class UnitImageFactory {
     return highlightedImage;
   }
 
-  /** Return an icon image for a unit. */
+  /** Return an _unscaled_ icon image for a unit.  */
   public ImageIcon getIcon(final ImageKey imageKey) {
     final String fullName = imageKey.getFullName();
     return icons.computeIfAbsent(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -265,6 +265,7 @@ public class UnitImageFactory {
               graphics.setFont(font.deriveFont(8.0f));
               graphics.setColor(Color.LIGHT_GRAY);
               graphics.drawString(imageKey.getBaseImageName(), 5, 28);
+              images.put(imageKey, image);
               return image;
             });
   }
@@ -375,9 +376,24 @@ public class UnitImageFactory {
   }
 
   /** Return an icon image for a unit. */
+//  public ImageIcon getIcon(final ImageKey imageKey) {
+//    final String fullName = imageKey.getFullName();
+//    return icons.computeIfAbsent(fullName, key -> new ImageIcon(getImage(imageKey)));
+//  }
+
   public ImageIcon getIcon(final ImageKey imageKey) {
     final String fullName = imageKey.getFullName();
-    return icons.computeIfAbsent(fullName, key -> new ImageIcon(getImage(imageKey)));
+    if (icons.containsKey(fullName)) {
+      return icons.get(fullName);
+    }
+    final Optional<Image> image = getTransformedImage(imageKey);
+    if (image.isEmpty()) {
+      return new ImageIcon(getImage(imageKey));
+    }
+
+    final ImageIcon icon = new ImageIcon(image.get());
+    icons.put(fullName, icon);
+    return icon;
   }
 
   public Dimension getImageDimensions(final ImageKey imageKey) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -383,17 +383,13 @@ public class UnitImageFactory {
 
   public ImageIcon getIcon(final ImageKey imageKey) {
     final String fullName = imageKey.getFullName();
-    if (icons.containsKey(fullName)) {
-      return icons.get(fullName);
-    }
-    final Optional<Image> image = getTransformedImage(imageKey);
-    if (image.isEmpty()) {
-      return new ImageIcon(getImage(imageKey));
-    }
-
-    final ImageIcon icon = new ImageIcon(image.get());
-    icons.put(fullName, icon);
-    return icon;
+    return icons.computeIfAbsent(fullName, name -> {
+      final Optional<Image> image = getTransformedImage(imageKey);
+      if (image.isEmpty()) {
+        return new ImageIcon(getImage(imageKey));
+      }
+      return new ImageIcon(image.get());
+    });
   }
 
   public Dimension getImageDimensions(final ImageKey imageKey) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -57,9 +57,9 @@ public class UnitImageFactory {
 
   private final int unitCounterOffsetWidth;
   private final int unitCounterOffsetHeight;
-  // maps Point -> image
+  // maps Point -> (scaled) image
   private final Map<ImageKey, Image> images = new HashMap<>();
-  // maps Point -> Icon
+  // maps Point -> (unscaled) Icon
   private final Map<String, ImageIcon> icons = new HashMap<>();
   // Temporary colorized image files used for URLs for html views (e.g. unit stats table).
   private final Map<ImageKey, URL> colorizedTempFiles = new HashMap<>();
@@ -227,8 +227,8 @@ public class UnitImageFactory {
   }
 
   /**
-   * Return the appropriate scaled unit image. If an image cannot be found, a placeholder 'no-image' image
-   * is returned.
+   * Return the appropriate scaled unit image. If an image cannot be found, a placeholder 'no-image'
+   * image is returned.
    */
   public Image getImage(final ImageKey imageKey) {
     return Optional.ofNullable(images.get(imageKey))
@@ -257,8 +257,7 @@ public class UnitImageFactory {
   }
 
   private Image createNoImageImage(ImageKey imageKey) {
-    BufferedImage image =
-        resourceLoader.getImageOrThrow(FILE_NAME_BASE + "missing_unit_image.png");
+    BufferedImage image = resourceLoader.getImageOrThrow(FILE_NAME_BASE + "missing_unit_image.png");
     Color playerColor = mapData.getPlayerColor(imageKey.getPlayer().getName());
     ImageTransformer.colorize(playerColor, image);
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -253,21 +253,22 @@ public class UnitImageFactory {
                           images.put(imageKey, scaledImage);
                           return scaledImage;
                         }))
-        .orElseGet(
-            () -> {
-              BufferedImage image =
-                  resourceLoader.getImageOrThrow(FILE_NAME_BASE + "missing_unit_image.png");
-              Color playerColor = mapData.getPlayerColor(imageKey.getPlayer().getName());
-              ImageTransformer.colorize(playerColor, image);
+        .orElseGet(() -> createNoImageImage(imageKey));
+  }
 
-              Graphics graphics = image.getGraphics();
-              Font font = graphics.getFont();
-              graphics.setFont(font.deriveFont(8.0f));
-              graphics.setColor(Color.LIGHT_GRAY);
-              graphics.drawString(imageKey.getBaseImageName(), 5, 28);
-              images.put(imageKey, image);
-              return image;
-            });
+  private Image createNoImageImage(ImageKey imageKey) {
+    BufferedImage image =
+        resourceLoader.getImageOrThrow(FILE_NAME_BASE + "missing_unit_image.png");
+    Color playerColor = mapData.getPlayerColor(imageKey.getPlayer().getName());
+    ImageTransformer.colorize(playerColor, image);
+
+    Graphics graphics = image.getGraphics();
+    Font font = graphics.getFont();
+    graphics.setFont(font.deriveFont(8.0f));
+    graphics.setColor(Color.LIGHT_GRAY);
+    graphics.drawString(imageKey.getBaseImageName(), 5, 28);
+    images.put(imageKey, image);
+    return image;
   }
 
   public Optional<URL> getBaseImageUrl(final ImageKey imageKey) {
@@ -375,12 +376,14 @@ public class UnitImageFactory {
     return highlightedImage;
   }
 
-  /** Return an _unscaled_ icon image for a unit.  */
+  /** Return an _unscaled_ icon image for a unit. */
   public ImageIcon getIcon(final ImageKey imageKey) {
     final String fullName = imageKey.getFullName();
     return icons.computeIfAbsent(
         fullName,
-        name -> new ImageIcon(getTransformedImage(imageKey).orElseGet(() -> getImage(imageKey))));
+        name ->
+            new ImageIcon(
+                getTransformedImage(imageKey).orElseGet(() -> createNoImageImage(imageKey))));
   }
 
   public Dimension getImageDimensions(final ImageKey imageKey) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -376,20 +376,11 @@ public class UnitImageFactory {
   }
 
   /** Return an icon image for a unit. */
-//  public ImageIcon getIcon(final ImageKey imageKey) {
-//    final String fullName = imageKey.getFullName();
-//    return icons.computeIfAbsent(fullName, key -> new ImageIcon(getImage(imageKey)));
-//  }
-
   public ImageIcon getIcon(final ImageKey imageKey) {
     final String fullName = imageKey.getFullName();
-    return icons.computeIfAbsent(fullName, name -> {
-      final Optional<Image> image = getTransformedImage(imageKey);
-      if (image.isEmpty()) {
-        return new ImageIcon(getImage(imageKey));
-      }
-      return new ImageIcon(image.get());
-    });
+    return icons.computeIfAbsent(
+        fullName,
+        name -> new ImageIcon(getTransformedImage(imageKey).orElseGet(() -> getImage(imageKey))));
   }
 
   public Dimension getImageDimensions(final ImageKey imageKey) {


### PR DESCRIPTION
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
Fixes: #12500

Issue is difference between: `getImage(imageKey)` vs `getTransformedImage(imageKey)`
`getImage` returns a scaled image, `getTransformedImage` returns an unscaled image.

Issue was introduced in:  1ab27d4031355305b4bf3ae9d9cf0b500aefa78b, there was a mistake to swap 'getTransformedImage' with 'getImage'. Without the clarification that one returns a scaled image and the other does not, it really does look they ought to return the same result. The multiple layers of caching also makes this confusing. It's very surprising for the 'image icon' cache to store unscaled images while the 'images' cache stores scaled images (one would expect both of them to store scaled images). 

The problem with the purchase screen is that the scaled images were being used, rather than the 100% scale images.

![image](https://github.com/triplea-game/triplea/assets/12397753/73872725-bf5e-4ebb-9ea6-91b1ef6b1b69)
