### PR TITLE
Jar publish fixes

### DIFF
--- a/http-clients/lobby-client/build.gradle
+++ b/http-clients/lobby-client/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id("maven-publish")
-    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 dependencies {
@@ -27,7 +27,8 @@ def getGitCommitCount = { ->
 }
 
 shadowJar {
-    version = "0." + getGitCommitCount()
+    archiveVersion = "0." + getGitCommitCount()
+    archiveClassifier = ""
 }
 
 publishing {


### PR DESCRIPTION
More fine tuning, set classifier to empty
so that the publish jar does not contain a '*-all.jar' but instead contains a jar file named simply '*.jar'

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
