### PR TITLE
Remove special handling of battle logic for edit mode.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -708,15 +708,13 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
               + " in "
               + battleSite.getName();
       if (!Properties.getLowLuckDamageOnly(gameData.getProperties())) {
+        final int diceSides = gameData.getDiceSides();
         if (doNotUseBombingBonus) {
           // no low luck, and no bonus, so just roll based on the map's dice sides
-          dice =
-              bridge.getRandom(
-                  gameData.getDiceSides(), rollCount, attacker, DiceType.BOMBING, annotation);
+          dice = bridge.getRandom(diceSides, rollCount, attacker, DiceType.BOMBING, annotation);
         } else {
           // we must use bombing bonus
           int i = 0;
-          final int diceSides = gameData.getDiceSides();
           for (final Unit u : attackingUnits) {
             final int rolls = getSbrRolls(u, attacker);
             if (rolls < 1) {
@@ -726,8 +724,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             int maxDice = ua.getBombingMaxDieSides();
             final int bonus = ua.getBombingBonus();
             // both could be -1, meaning they were not set. if they were not set, then we use
-            // default dice sides for
-            // the map, and zero for the bonus.
+            // default dice sides for the map, and zero for the bonus.
             if (maxDice < 0) {
               maxDice = diceSides;
             }
@@ -763,8 +760,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           int maxDice = ua.getBombingMaxDieSides();
           int bonus = ua.getBombingBonus();
           // both could be -1, meaning they were not set. if they were not set, then we use
-          // default dice sides for the
-          // map, and zero for the bonus.
+          // default dice sides for the map, and zero for the bonus.
           if (maxDice < 0 || doNotUseBombingBonus) {
             maxDice = diceSides;
           }
@@ -772,8 +768,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             bonus = 0;
           }
           // now, regardless of whether they were set or not, we have to apply "low luck" to them,
-          // meaning in this
-          // case that we reduce the luck by 2/3.
+          // meaning in this case that we reduce the luck by 2/3.
           if (maxDice >= 5) {
             bonus += (maxDice + 1) / 3;
             maxDice = (maxDice + 1) / 3;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
@@ -49,8 +49,7 @@ public class AaCasualtySelector {
         !defendingAa.isEmpty()
             && defendingAa.stream()
                 .allMatch(Matches.unitAaShotDamageableInsteadOfKillingInstantly());
-    if (EditDelegate.getEditMode(data.getProperties())
-        || Properties.getChooseAaCasualties(data.getProperties())) {
+    if (Properties.getChooseAaCasualties(data.getProperties())) {
       return CasualtySelector.selectCasualties(
           hitPlayer,
           planes,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
@@ -10,7 +10,6 @@ import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Die.DieType;
-import games.strategy.triplea.delegate.EditDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.power.calculator.AaPowerStrengthAndRolls;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -11,7 +11,6 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.ai.weak.WeakAi;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.DiceRoll;
-import games.strategy.triplea.delegate.EditDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
@@ -76,24 +75,6 @@ public class CasualtySelector {
         Properties.getTransportCasualtiesRestricted(data.getProperties())
             ? extraHits
             : dice.getHits();
-
-    if (EditDelegate.getEditMode(data.getProperties())) {
-      return tripleaPlayer.selectCasualties(
-          targetsToPickFrom,
-          dependents,
-          hitsRemaining,
-          text,
-          dice,
-          player,
-          combatValue.getFriendUnits(),
-          combatValue.getEnemyUnits(),
-          false,
-          List.of(),
-          new CasualtyDetails(),
-          battleId,
-          battleSite,
-          allowMultipleHitsPerUnit);
-    }
 
     if (dice.getHits() == 0) {
       return new CasualtyDetails();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
@@ -7,7 +7,6 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.delegate.EditDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
@@ -46,12 +45,7 @@ public class SelectMainBattleCasualties
     final int hitsLeftForRestrictedTransports = hitCount - totalHitPointsAvailable;
 
     final CasualtyDetails casualtyDetails;
-    if (EditDelegate.getEditMode(step.getBattleState().getGameData().getProperties())) {
-      final CasualtyDetails message =
-          selectFunction.apply(bridge, step, step.getFiringGroup().getTargetUnits(), 0);
-      casualtyDetails = new CasualtyDetails(message, true);
-
-    } else if (totalHitPointsAvailable > hitCount) {
+    if (totalHitPointsAvailable > hitCount) {
       // not all units were hit so the player needs to pick which ones are killed
       casualtyDetails =
           selectFunction.apply(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -12,7 +12,6 @@ import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Die;
-import games.strategy.triplea.delegate.EditDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleState;
@@ -257,10 +256,7 @@ public class BattleDisplay extends JPanel {
       final Collection<Unit> damaged,
       final Map<Unit, Collection<Unit>> dependents) {
     setStep(step);
-    final boolean isEditMode = (dice == null);
-    if (!isEditMode) {
-      dicePanel.setDiceRoll(dice);
-    }
+    dicePanel.setDiceRoll(dice);
     casualties.setNotification(killed, damaged, dependents);
     killed.addAll(updateKilledUnits(killed, player));
     if (player.equals(defender)) {
@@ -477,15 +473,11 @@ public class BattleDisplay extends JPanel {
 
     SwingUtilities.invokeLater(
         () -> {
-          final boolean isEditMode = EditDelegate.getEditMode(gameData.getProperties());
-          if (!isEditMode) {
-            dicePanel.setDiceRoll(dice);
-            casualties.setVisible(false);
-          }
-          final boolean plural = isEditMode || (count > 1);
-          final String countStr = isEditMode ? "" : "" + count;
+          dicePanel.setDiceRoll(dice);
+          casualties.setVisible(false);
+          final boolean plural = (count > 1);
           final String btnText =
-              hit.getName() + " select " + countStr + (plural ? " casualties" : " casualty");
+              hit.getName() + " select " + count + (plural ? " casualties" : " casualty");
           final var casualtySelection =
               new CasualtySelection(
                   selectFrom,
@@ -496,8 +488,7 @@ public class BattleDisplay extends JPanel {
                   defaultCasualties,
                   allowMultipleHitsPerUnit,
                   uiContext,
-                  BattleDisplay.this,
-                  isEditMode);
+                  BattleDisplay.this);
 
           actionButton.setAction(
               new AbstractAction(btnText) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/CasualtySelection.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/CasualtySelection.java
@@ -40,7 +40,6 @@ public class CasualtySelection {
   private final GamePlayer player;
 
   private final JDialog dialog;
-  private final boolean isEditMode;
 
   private final JOptionPane optionPane;
 
@@ -53,12 +52,9 @@ public class CasualtySelection {
       final CasualtyList defaultCasualties,
       final boolean allowMultipleHitsPerUnit,
       final UiContext uiContext,
-      final Component dialogParent,
-      final boolean isEditMode) {
+      final Component dialogParent) {
     this.hitsToTake = hitsToTake;
     this.player = player;
-
-    this.isEditMode = isEditMode;
 
     final boolean movementForAirUnitsOnly =
         playerMayChooseToDistributeHitsToUnitsWithDifferentMovement(selectFrom);
@@ -73,12 +69,7 @@ public class CasualtySelection {
             allowMultipleHitsPerUnit,
             uiContext);
     chooser.setTitle(title);
-
-    if (isEditMode) {
-      chooser.disableMax();
-    } else {
-      chooser.setMax(hitsToTake);
-    }
+    chooser.setMax(hitsToTake);
 
     final JScrollPane chooserScrollPane = new JScrollPane(chooser);
     chooserScrollPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
@@ -120,7 +111,7 @@ public class CasualtySelection {
 
     final List<Unit> killed = chooser.getSelected(false);
     final List<Unit> damaged = chooser.getSelectedDamagedMultipleHitPointUnits();
-    if (!isEditMode && (killed.size() + damaged.size() != hitsToTake)) {
+    if (killed.size() + damaged.size() != hitsToTake) {
       JOptionPane.showMessageDialog(
           dialog /*.getParent()*/,
           "Wrong number of casualties selected",

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
@@ -442,7 +442,6 @@ class AaCasualtySelectorTest {
       gameData =
           givenGameData()
               .withDiceSides(6)
-              .withEditMode(false)
               .withChooseAaCasualties(false)
               .withLowLuck(true)
               .build();

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
@@ -133,7 +133,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void hitsEqualToPlanesKillsAll() {
-
       final CasualtyDetails details =
           AaCasualtySelector.getAaCasualties(
               planeUnitType.createTemp(1, hitPlayer),
@@ -153,7 +152,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void hitsMoreThanPlanesKillsAll() {
-
       final CasualtyDetails details =
           AaCasualtySelector.getAaCasualties(
               planeUnitType.createTemp(1, hitPlayer),
@@ -173,7 +171,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void oneHitAgainstTwoPlanesOnlyKillsOne() {
-
       final UnitType aaNonInfiniteUnitType = new UnitType("aaNonInfiniteUnitType", gameData);
       final UnitAttachment aaNonInfiniteUnitAttachment =
           new UnitAttachment("aaNonInfiniteUnitAttachment", aaNonInfiniteUnitType, gameData);
@@ -203,7 +200,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void identicalDieRollsShouldStillKillPlanesEqualToHits() {
-
       final UnitType aaNonInfiniteUnitType = new UnitType("aaNonInfiniteUnitType", gameData);
       final UnitAttachment aaNonInfiniteUnitAttachment =
           new UnitAttachment("aaNonInfiniteUnitAttachment", aaNonInfiniteUnitType, gameData);
@@ -236,7 +232,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void hitsEqualToPlanesMultiHpDamagesAndKillsAll() {
-
       final CasualtyDetails details =
           AaCasualtySelector.getAaCasualties(
               planeMultiHpUnitType.createTemp(1, hitPlayer),
@@ -257,7 +252,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void hitsGreaterThanPlanesMultiHpDamagesAndKillsAll() {
-
       final CasualtyDetails details =
           AaCasualtySelector.getAaCasualties(
               planeMultiHpUnitType.createTemp(1, hitPlayer),
@@ -277,7 +271,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void oneHitAgainstMultiHpPlaneOnlyDamagesIt() {
-
       whenGetRandom(bridge).thenAnswer(withValues(0));
 
       final CasualtyDetails details =
@@ -299,7 +292,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void threeHitsAgainstTwoMultiHpPlanesKillsOneAndDamagesTheOther() {
-
       whenGetRandom(bridge).thenAnswer(withValues(0, 1, 2));
 
       final CasualtyDetails details =
@@ -327,7 +319,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void identicalDieRollsShouldStillKillAndDamagePlanesEqualToHits() {
-
       whenGetRandom(bridge).thenAnswer(withValues(6, 6, 6, 6, 6));
 
       final CasualtyDetails details =
@@ -382,7 +373,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void hitsEqualToPlanesKillsAll() {
-
       final CasualtyDetails details =
           AaCasualtySelector.getAaCasualties(
               planeUnitType.createTemp(1, hitPlayer),
@@ -402,7 +392,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void hitsLessThanPlanesKillsAccordingToTheRolledDice() {
-
       final List<Unit> planes = planeUnitType.createTemp(5, hitPlayer);
 
       final CasualtyDetails details =
@@ -487,7 +476,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void oneTypeOfPlaneWithAmountEqualToDiceSides() {
-
       final List<Unit> planes = planeUnitType.createTemp(6, hitPlayer);
       final List<Unit> aaUnits = aaUnitType.createTemp(1, aaPlayer);
 
@@ -554,7 +542,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndBothHaveAmountEqualToDiceSides() {
-
       final List<Unit> planes = planeUnitType.createTemp(6, hitPlayer);
       planes.addAll(otherPlaneUnitType.createTemp(6, hitPlayer));
       final List<Unit> aaUnits = aaUnitType.createTemp(1, aaPlayer);
@@ -586,7 +573,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndTogetherHaveAmountEqualToDiceSides() {
-
       // need to randomly pick a plane to kill
       whenGetRandom(bridge).thenAnswer(withValues(1));
 
@@ -621,7 +607,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void oneTypeOfMultiHpPlaneWithAmountEqualToDiceSides() {
-
       whenGetRandom(bridge).thenAnswer(withValues(1));
 
       final List<Unit> planes = planeMultiHpUnitType.createTemp(6, hitPlayer);
@@ -649,7 +634,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfMultiHpPlanesAndBothHaveAmountEqualToDiceSides() {
-
       whenGetRandom(bridge).thenAnswer(withValues(1, 1));
 
       final List<Unit> planes = planeMultiHpUnitType.createTemp(6, hitPlayer);
@@ -683,7 +667,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void oneTypeOfPlaneWithAmountLessThanDiceSidesButItHit() {
-
       // need to randomly pick a plane to kill
       whenGetRandom(bridge).thenAnswer(withValues(1));
 
@@ -712,7 +695,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndTogetherHaveAmountLessThanDiceSidesButItHit() {
-
       // need to randomly pick a plane to kill
       whenGetRandom(bridge).thenAnswer(withValues(1));
 
@@ -747,7 +729,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void oneTypeOfPlaneWithRemainderOverDiceSidesButNotExtraHit() {
-
       final List<Unit> planes = planeUnitType.createTemp(8, hitPlayer);
       final List<Unit> aaUnits = aaUnitType.createTemp(1, aaPlayer);
 
@@ -773,7 +754,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndBothHaveRemainderOverDiceSidesButNotExtraHit() {
-
       final List<Unit> planes = planeUnitType.createTemp(8, hitPlayer);
       planes.addAll(otherPlaneUnitType.createTemp(8, hitPlayer));
       final List<Unit> aaUnits = aaUnitType.createTemp(1, aaPlayer);
@@ -807,7 +787,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndTogetherHaveRemainderOverDiceSidesButNotExtraHit() {
-
       // need to randomly pick 1 planes out of the remainder to kill
       whenGetRandom(bridge).thenAnswer(withValues(1));
 
@@ -842,7 +821,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void oneTypeOfPlaneWithRemainderOverDiceSidesAndWithExtraHit() {
-
       // need to randomly pick a plane to kill
       whenGetRandom(bridge).thenAnswer(withValues(1));
 
@@ -871,7 +849,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void oneTypeOfPlaneWithRemainderOf1AndWithExtraHit() {
-
       final List<Unit> planes = planeUnitType.createTemp(7, hitPlayer);
       final List<Unit> aaUnits = aaUnitType.createTemp(1, aaPlayer);
 
@@ -897,7 +874,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndBothHaveRemainderOverDiceSidesAndWithExtraHit() {
-
       // need to pick one plane out of the remainder list
       whenGetRandom(bridge).thenAnswer(withValues(0));
 
@@ -934,7 +910,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndOneHasRemainderOf1AndWithExtraHit() {
-
       final List<Unit> planes = planeUnitType.createTemp(6, hitPlayer);
       planes.addAll(otherPlaneUnitType.createTemp(7, hitPlayer));
       final List<Unit> aaUnits = aaUnitType.createTemp(1, aaPlayer);
@@ -967,7 +942,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndTogetherHaveRemainderOverDiceSidesAndWithExtraHit() {
-
       // need to randomly pick 2 planes to kill
       whenGetRandom(bridge).thenAnswer(withValues(1, 1));
 
@@ -1002,7 +976,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndTogetherHaveRemainderOf1AndWithExtraHit() {
-
       // need to randomly pick 2 planes to kill
       whenGetRandom(bridge).thenAnswer(withValues(1, 2));
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
@@ -440,11 +440,7 @@ class AaCasualtySelectorTest {
     @BeforeEach
     void initializeGameData() {
       gameData =
-          givenGameData()
-              .withDiceSides(6)
-              .withChooseAaCasualties(false)
-              .withLowLuck(true)
-              .build();
+          givenGameData().withDiceSides(6).withChooseAaCasualties(false).withLowLuck(true).build();
       bridge = mock(IDelegateBridge.class);
       when(bridge.getData()).thenReturn(gameData);
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -6,7 +6,6 @@ import static games.strategy.triplea.Constants.CAPTURE_UNITS_ON_ENTERING_TERRITO
 import static games.strategy.triplea.Constants.CHOOSE_AA;
 import static games.strategy.triplea.Constants.DEFENDING_SUBS_SNEAK_ATTACK;
 import static games.strategy.triplea.Constants.DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE;
-import static games.strategy.triplea.Constants.EDIT_MODE;
 import static games.strategy.triplea.Constants.LHTR_HEAVY_BOMBERS;
 import static games.strategy.triplea.Constants.LOW_LUCK;
 import static games.strategy.triplea.Constants.NAVAL_BOMBARD_CASUALTIES_RETURN_FIRE;
@@ -181,11 +180,6 @@ public class MockGameData {
 
   public MockGameData withCaptureUnitsOnEnteringTerritory(final boolean value) {
     when(gameProperties.get(CAPTURE_UNITS_ON_ENTERING_TERRITORY, false)).thenReturn(value);
-    return this;
-  }
-
-  public MockGameData withEditMode(final boolean value) {
-    when(gameProperties.get(EDIT_MODE)).thenReturn(value);
     return this;
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualtiesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualtiesTest.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.delegate.battle.steps.fire;
 
-import static games.strategy.triplea.Constants.EDIT_MODE;
 import static games.strategy.triplea.Constants.TRANSPORT_CASUALTIES_RESTRICTED;
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.UNITS;
@@ -176,7 +175,6 @@ class SelectMainBattleCasualtiesTest {
     void moreNonTransportsHitPointsThanHits() {
       when(battleState.getGameData().getProperties().get(TRANSPORT_CASUALTIES_RESTRICTED, false))
           .thenReturn(true);
-      when(battleState.getGameData().getProperties().get(EDIT_MODE)).thenReturn(false);
 
       final List<Unit> nonTransportUnits = List.of(givenAnyUnit(), givenAnyUnit());
 
@@ -229,7 +227,6 @@ class SelectMainBattleCasualtiesTest {
     void equalNonTransportsHitPointsToHits() {
       when(battleState.getGameData().getProperties().get(TRANSPORT_CASUALTIES_RESTRICTED, false))
           .thenReturn(true);
-      when(battleState.getGameData().getProperties().get(EDIT_MODE)).thenReturn(false);
 
       final List<Unit> nonTransportUnits = List.of(givenAnyUnit(), givenAnyUnit());
 
@@ -276,7 +273,6 @@ class SelectMainBattleCasualtiesTest {
     void lessNonTransportsHitPointsThanHits() {
       when(battleState.getGameData().getProperties().get(TRANSPORT_CASUALTIES_RESTRICTED, false))
           .thenReturn(true);
-      when(battleState.getGameData().getProperties().get(EDIT_MODE)).thenReturn(false);
 
       final List<Unit> nonTransportUnits = List.of(givenAnyUnit(), givenAnyUnit());
 
@@ -345,7 +341,6 @@ class SelectMainBattleCasualtiesTest {
     void lessNonTransportsHitPointsThanHitsWithAlliedTransports() {
       when(battleState.getGameData().getProperties().get(TRANSPORT_CASUALTIES_RESTRICTED, false))
           .thenReturn(true);
-      when(battleState.getGameData().getProperties().get(EDIT_MODE)).thenReturn(false);
 
       final List<Unit> nonTransportUnits = List.of(givenAnyUnit(), givenAnyUnit());
 
@@ -425,7 +420,6 @@ class SelectMainBattleCasualtiesTest {
     void moreHitsThanHitPoints() {
       when(battleState.getGameData().getProperties().get(TRANSPORT_CASUALTIES_RESTRICTED, false))
           .thenReturn(true);
-      when(battleState.getGameData().getProperties().get(EDIT_MODE)).thenReturn(false);
 
       final List<Unit> nonTransportUnits = List.of(givenAnyUnit(), givenAnyUnit());
 
@@ -481,7 +475,6 @@ class SelectMainBattleCasualtiesTest {
     void moreHitsThanHitPointsWithAlly() {
       when(battleState.getGameData().getProperties().get(TRANSPORT_CASUALTIES_RESTRICTED, false))
           .thenReturn(true);
-      when(battleState.getGameData().getProperties().get(EDIT_MODE)).thenReturn(false);
 
       final List<Unit> nonTransportUnits = List.of(givenAnyUnit(), givenAnyUnit());
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualtiesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualtiesTest.java
@@ -63,49 +63,6 @@ class SelectMainBattleCasualtiesTest {
     return diceRoll;
   }
 
-  @Test
-  @DisplayName("Edit mode always calls the select function")
-  @SuppressWarnings("unchecked")
-  void isEditMode() {
-    final List<Unit> targetUnits = List.of(givenAnyUnit(), givenAnyUnit());
-    when(battleState.getGameData().getProperties().get(TRANSPORT_CASUALTIES_RESTRICTED, false))
-        .thenReturn(false);
-    when(battleState.getGameData().getProperties().get(EDIT_MODE)).thenReturn(true);
-
-    final FiringGroup firingGroup =
-        FiringGroup.groupBySuicideOnHit(UNITS, List.of(firingUnit), targetUnits).get(0);
-
-    final FireRoundState fireRoundState = new FireRoundState();
-    fireRoundState.setDice(mock(DiceRoll.class));
-
-    final SelectCasualties selectCasualties =
-        new SelectCasualties(
-            battleState,
-            BattleState.Side.OFFENSE,
-            firingGroup,
-            fireRoundState,
-            (arg1, arg2) -> new CasualtyDetails());
-
-    final SelectMainBattleCasualties.Select selectFunction =
-        mock(SelectMainBattleCasualties.Select.class);
-    final CasualtyDetails expected = new CasualtyDetails(targetUnits, List.of(), false);
-    when(selectFunction.apply(any(), any(), anyCollection(), anyInt())).thenReturn(expected);
-
-    final CasualtyDetails details =
-        new SelectMainBattleCasualties(selectFunction).apply(delegateBridge, selectCasualties);
-
-    assertThat(details.getKilled().toArray(), is(targetUnits.toArray()));
-    assertThat(
-        "edit mode always sets auto calculated to true", details.getAutoCalculated(), is(true));
-
-    verify(selectFunction)
-        .apply(
-            eq(delegateBridge),
-            eq(selectCasualties),
-            (Collection<Unit>) argThat(containsInAnyOrder(targetUnits.toArray())),
-            eq(0));
-  }
-
   @Nested
   class TransportCasualtiesNotRestricted {
 

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -449,7 +449,6 @@ public final class BattlePanel extends ActionPanel {
       final boolean allowMultipleHitsPerUnit) {
     final Supplier<CasualtyDetails> action =
         () -> {
-          final boolean isEditMode = (dice == null);
           final UnitChooser chooser =
               new UnitChooser(
                   selectFrom,
@@ -460,15 +459,9 @@ public final class BattlePanel extends ActionPanel {
                   allowMultipleHitsPerUnit,
                   getMap().getUiContext());
           chooser.setTitle(message);
-          if (isEditMode) {
-            chooser.setMax(selectFrom.size());
-          } else {
-            chooser.setMax(count);
-          }
+          chooser.setMax(count);
           final DicePanel dicePanel = new DicePanel(getMap().getUiContext(), getData());
-          if (!isEditMode) {
-            dicePanel.setDiceRoll(dice);
-          }
+          dicePanel.setDiceRoll(dice);
           final JPanel panel = new JPanel();
           panel.setLayout(new BorderLayout());
           panel.add(chooser, BorderLayout.CENTER);


### PR DESCRIPTION
This logic was just adding code complexity and some bugs and it's not clear why it's needed.

(It was making so no casualties would ever happen during battles when edit mode is on.)

Fixes: https://github.com/triplea-game/triplea/issues/12488
(And the duplicate issues.)

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
