### PR TITLE
Fix inconsistent sort order in map download list.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadSwingTable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadSwingTable.java
@@ -45,12 +45,10 @@ public class MapDownloadSwingTable {
     table =
         JTableBuilder.<MapDownloadItem>builder()
             .columnNames(columnNames)
-            .rowData(
-                maps.stream()
-                    .sorted(Comparator.comparing(MapDownloadItem::getMapName))
-                    .collect(Collectors.toList()))
+            .rowData(maps)
             .rowMapper(mapDownloadListing -> rowMapper(mapDownloadListing, tagNames))
             .build();
+    table.getRowSorter().toggleSortOrder(0);
     table.addKeyListener(new JTableTypeAheadListener(table, 0));
   }
 

--- a/lib/swing-lib/src/main/java/org/triplea/swing/JTableBuilder.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/JTableBuilder.java
@@ -3,6 +3,7 @@ package org.triplea.swing;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Preconditions;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -34,7 +35,7 @@ import lombok.NoArgsConstructor;
 public class JTableBuilder<T> {
 
   private Function<T, List<String>> rowMapper;
-  private List<T> rowData;
+  private Collection<T> rowData;
   private List<List<String>> tableData;
   private List<String> columnNames;
 
@@ -128,7 +129,7 @@ public class JTableBuilder<T> {
     return this;
   }
 
-  public JTableBuilder<T> rowData(final List<T> rowData) {
+  public JTableBuilder<T> rowData(final Collection<T> rowData) {
     this.rowData = rowData;
     return this;
   }


### PR DESCRIPTION
Instead of sorting ourselves, which doesn't match JTable's sorting, just use JTable's sorting when creating the table.

Fixes: https://github.com/triplea-game/triplea/issues/12446

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
