### PR TITLE
Fix TripleA's rolling log policy.

### DIFF
--- a/game-app/game-headed/src/main/resources/logback.xml
+++ b/game-app/game-headed/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- rollover daily -->
             <fileNamePattern>triplea-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <!-- each file should be at most 10MB, keep 3 days worth of history, but at most 50MB -->
+            <!-- each file should be at most 1MB, keep 3 days worth of history, but at most 10MB -->
             <maxFileSize>1MB</maxFileSize>
             <maxHistory>3</maxHistory>
             <totalSizeCap>10MB</totalSizeCap>

--- a/game-app/game-headed/src/main/resources/logback.xml
+++ b/game-app/game-headed/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
     <appender name="swingMessage" class="org.triplea.debug.Slf4jLogMessageUploader"/>
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${user.home}/triplea/triplea.log</file>
         <append>true</append>
         <encoder>
@@ -10,9 +10,9 @@
             <!-- rollover daily -->
             <fileNamePattern>triplea-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <!-- each file should be at most 10MB, keep 3 days worth of history, but at most 50MB -->
-            <maxFileSize>10MB</maxFileSize>
+            <maxFileSize>1MB</maxFileSize>
             <maxHistory>3</maxHistory>
-            <totalSizeCap>50MB</totalSizeCap>
+            <totalSizeCap>10MB</totalSizeCap>
         </rollingPolicy>
     </appender>
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
It wasn't specifying RollingFileAppender so the rolling and max size options weren't being used. I'm also changing the max size to 1MB and 10MB total.

Fixes: https://github.com/triplea-game/triplea/issues/12536

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
