### PR TITLE
Fix 10k rounds reached combat error.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -93,7 +93,7 @@ public class GameStep extends GameDataComponent {
     properties = stepProperties;
   }
 
-  public GamePlayer getPlayerId() {
+  public @Nullable GamePlayer getPlayerId() {
     return player;
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.odds.calculator;
 
+import static games.strategy.triplea.Constants.EDIT_MODE;
+
 import com.google.common.base.Preconditions;
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
@@ -44,6 +46,7 @@ class BattleCalculator implements IBattleCalculator {
 
   BattleCalculator(byte[] data) {
     gameData = GameDataUtils.createGameDataFromBytes(data).orElseThrow();
+    gameData.getProperties().set(EDIT_MODE, false);
   }
 
   @Override


### PR DESCRIPTION
This would happen when edit mode was left on when switching to an AI player. This changes makes such transitions turn off edit mode as well as making all battle simulations ignore edit mode.

FIxes: https://github.com/triplea-game/triplea/issues/12488

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
