### PR TITLE
Quick fix for download-map progress bars to be more accurate

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
@@ -28,7 +28,7 @@ final class MapDownloadProgressListener {
         () -> {
           progressBar.setIndeterminate(false);
           progressBar.setString(null);
-          progressBar.setValue(percentComplete);
+          progressBar.setValue(Math.max(0, percentComplete));
           progressBar.setToolTipText(toolTipText);
         });
   }


### PR DESCRIPTION
Download length is currently always '-1', the negative values cause odd behavior.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
