### PR TITLE
Revert "Release update: set all new builds as 'releases' (used to be prerelease) (#12568)"

### DIFF
--- a/.github/workflows/upload-game-installers.yml
+++ b/.github/workflows/upload-game-installers.yml
@@ -41,7 +41,7 @@ jobs:
           artifacts: build/artifacts/*
           tag: ${{ env.build_version }}
           name: ${{ env.release_name }}
-          prerelease: false
+          prerelease: true
           commit: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This reverts commit 73249a04df3ccd50f6a7d151e16b29468d252f6a.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
