### PR TITLE
Fix purchase persisting on max built error.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -20,7 +20,6 @@ import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitTypeComparator;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
@@ -174,8 +173,7 @@ public class PurchaseDelegate extends BaseTripleADelegate
       if (!(next instanceof Resource)) {
         final UnitType type = (UnitType) next;
         final int quantity = results.getInt(type);
-        final UnitAttachment ua = type.getUnitAttachment();
-        final int maxBuilt = ua.getMaxBuiltPerPlayer();
+        final int maxBuilt = type.getUnitAttachment().getMaxBuiltPerPlayer();
         if (maxBuilt == 0) {
           return "May not build any of this unit right now: " + type.getName();
         } else if (maxBuilt > 0) {
@@ -184,13 +182,13 @@ public class PurchaseDelegate extends BaseTripleADelegate
 
           final Predicate<Unit> unitTypeOwnedBy =
               Matches.unitIsOfType(type).and(Matches.unitIsOwnedBy(player));
-          final Collection<Territory> allTerrs = getData().getMap().getTerritories();
-          for (final Territory t : allTerrs) {
+          for (final Territory t : getData().getMap().getTerritories()) {
             currentlyBuilt += t.getUnitCollection().countMatches(unitTypeOwnedBy);
           }
 
-          final int allowedBuild = maxBuilt - currentlyBuilt;
-          if (allowedBuild - quantity < 0) {
+          // Use Math.max(0, ...) to avoid negative if existing count exceeds limit.
+          final int allowedBuild = Math.max(0, maxBuilt - currentlyBuilt);
+          if (quantity > allowedBuild) {
             return String.format(
                 "May only build %s of %s this turn, may only build %s total",
                 allowedBuild, type.getName(), maxBuilt);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -39,7 +39,7 @@ public class PurchasePanel extends ActionPanel {
   private static final String BUY = "Buy...";
   private static final String CHANGE = "Change...";
 
-  private IntegerMap<ProductionRule> purchase;
+  private IntegerMap<ProductionRule> purchase = new IntegerMap<>();
   private boolean bid;
   private final SimpleUnitPanel purchasedPreviousRoundsUnits;
   private final JLabel purchasedPreviousRoundsLabel;
@@ -61,10 +61,10 @@ public class PurchasePanel extends ActionPanel {
           // Use the delegate from the step, since it may not actually be named 'purchase'.
           final IDelegate delegate = data.getSequence().getStep().getDelegate();
           if (delegate instanceof PurchaseDelegate) {
-            purchase = ((PurchaseDelegate) delegate).getPendingProductionRules();
-          }
-          if (purchase == null) {
-            purchase = new IntegerMap<>();
+            final var savedPurchase = ((PurchaseDelegate) delegate).getPendingProductionRules();
+            if (savedPurchase != null) {
+              purchase = savedPurchase;
+            }
           }
 
           purchase =
@@ -112,7 +112,7 @@ public class PurchasePanel extends ActionPanel {
     if (keepCurrentPurchase) {
       keepCurrentPurchase = false;
     } else {
-      purchase = new IntegerMap<>();
+      purchase.clear();
     }
     SwingUtilities.invokeLater(
         () -> {


### PR DESCRIPTION
The fix in https://github.com/triplea-game/triplea/pull/11818 regressed with the changes for saving purchases in saved games. This restores it.

Also fixes the error message to not display a negative max limit.

Fixes: https://github.com/triplea-game/triplea/issues/12664

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
