### PR TITLE
Fix logic for damage units selection for 3hp units.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -156,9 +156,11 @@ public class CasualtySelector {
       }
     }
 
+    // Prefer units with less movement left to be killed first. with less movement should be killed.
     casualtyDetails.ensureUnitsAreKilledFirst(
         sortedTargetsToPickFrom, Matches.unitIsAir(), Comparator.comparing(Unit::getMovementLeft));
 
+    // Prefer units with most movement left to be damaged to have a better chance to get to safety.
     casualtyDetails.ensureUnitsAreDamagedFirst(
         sortedTargetsToPickFrom,
         Matches.unitIsAir(),

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -156,11 +156,11 @@ public class CasualtySelector {
       }
     }
 
-    // Prefer units with less movement left to be killed first. with less movement should be killed.
+    // Prefer units with less movement left to be killed first.
     casualtyDetails.ensureUnitsAreKilledFirst(
         sortedTargetsToPickFrom, Matches.unitIsAir(), Comparator.comparing(Unit::getMovementLeft));
 
-    // Prefer units with most movement left to be damaged to have a better chance to get to safety.
+    // Prefer units with most movement left for damage (to have a better chance to get to safety).
     casualtyDetails.ensureUnitsAreDamagedFirst(
         sortedTargetsToPickFrom,
         Matches.unitIsAir(),

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyDetails.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyDetails.java
@@ -132,8 +132,8 @@ public class CasualtyDetails extends CasualtyList {
           allTargetsOfOwnerAndTypeThatCanTakeHits,
           shouldTakeHitsFirst,
           targetsHitWithCorrectOrder);
-      // Note: Although removeAll() removes all duplicates entries, but in this case it's not a
-      // problem given how we're grouping things above.
+      // Note: Although removeAll() removes all duplicates entries, it's it's not a problem in this
+      // case given how we're iterating through units above.
       damaged.removeAll(oldTargetsOfOneOwnerAndType.getValue());
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyDetails.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyDetails.java
@@ -113,17 +113,15 @@ public class CasualtyDetails extends CasualtyList {
       final Collection<Unit> targets,
       final Predicate<Unit> matcher,
       final Comparator<Unit> shouldTakeHitsFirst) {
-
     final Map<UnitOwner, List<Unit>> targetsGroupedByOwnerAndType =
         targets.stream().collect(Collectors.groupingBy(UnitOwner::new, Collectors.toList()));
-
-    final List<Unit> targetsHitWithCorrectOrder = new ArrayList<>();
 
     final Map<UnitOwner, List<Unit>> oldTargetsToTakeHits =
         getDamaged().stream()
             .filter(matcher)
             .collect(Collectors.groupingBy(UnitOwner::new, Collectors.toList()));
 
+    final List<Unit> targetsHitWithCorrectOrder = new ArrayList<>();
     for (final Map.Entry<UnitOwner, List<Unit>> oldTargetsOfOneOwnerAndType :
         oldTargetsToTakeHits.entrySet()) {
       final List<Unit> allTargetsOfOwnerAndTypeThatCanTakeHits =
@@ -134,13 +132,12 @@ public class CasualtyDetails extends CasualtyList {
           allTargetsOfOwnerAndTypeThatCanTakeHits,
           shouldTakeHitsFirst,
           targetsHitWithCorrectOrder);
+      // Note: Although removeAll() removes all duplicates entries, but in this case it's not a
+      // problem given how we're grouping things above.
+      damaged.removeAll(oldTargetsOfOneOwnerAndType.getValue());
     }
 
-    damaged.addAll(
-        targetsHitWithCorrectOrder.stream()
-            .filter(unit -> !damaged.contains(unit))
-            .collect(Collectors.toList()));
-    damaged.removeIf(matcher.and(not(targetsHitWithCorrectOrder::contains)));
+    damaged.addAll(targetsHitWithCorrectOrder);
   }
 
   /**
@@ -165,13 +162,27 @@ public class CasualtyDetails extends CasualtyList {
     // collect the hits that are currently distributed to oldTargetsOfOneOwnerAndType
     int hitsToRedistributeToUnit;
     final Iterator<Unit> unitIterator = targets.iterator();
-    for (int hitsToRedistribute = targetsWithHitsBeforeRedistribution.size();
-        hitsToRedistribute > 0;
-        hitsToRedistribute -= hitsToRedistributeToUnit) {
-      final Unit unit = unitIterator.next();
+    // Don't change how many units take 1 hit vs. 2 hits by counting how many hits each unit takes
+    // and re-assigning at that level.
+    final Iterator<Long> numberOfHitsPerUnitIterator =
+        targetsWithHitsBeforeRedistribution.stream()
+            .collect(Collectors.groupingBy(e -> e, Collectors.counting()))
+            .values()
+            .stream()
+            .sorted(Comparator.reverseOrder()) // Sort in descending order
+            .collect(Collectors.toList())
+            .iterator();
+    int hitsToRedistribute = 0;
+    while (numberOfHitsPerUnitIterator.hasNext() || hitsToRedistribute > 0) {
+      if (numberOfHitsPerUnitIterator.hasNext()) {
+        hitsToRedistribute += numberOfHitsPerUnitIterator.next();
+      }
 
+      final Unit unit = unitIterator.next();
       hitsToRedistributeToUnit =
           Math.min(unit.hitsUnitCanTakeHitWithoutBeingKilled(), hitsToRedistribute);
+      // Note: Since the above may result in fewer hits assigned, keep track of the remainder.
+      hitsToRedistribute -= hitsToRedistributeToUnit;
 
       for (int i = 0; i < hitsToRedistributeToUnit; ++i) {
         targetsHitWithCorrectOrder.add(unit);


### PR DESCRIPTION
Previously logic was not working correctly and was overriding the user's selection in terms of how many units should take 2hp of damage vs. 1hp.

Adds a test. Also improves/adds some comments on the existing logic. Fixes: https://github.com/triplea-game/triplea/issues/12672

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
