### PR TITLE
Fix type-ahead logic in map window.

### DIFF
--- a/lib/swing-lib/src/main/java/org/triplea/swing/JTableTypeAheadListener.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/JTableTypeAheadListener.java
@@ -28,7 +28,7 @@ public class JTableTypeAheadListener extends KeyAdapter {
     if (time > keyPressTime + INPUT_RESET_TIME_MS) {
       inputString = "";
     }
-    keyPressTime = keyPressTime;
+    keyPressTime = time;
     inputString += Character.toLowerCase(ch);
 
     final var tableModel = table.getModel();
@@ -44,8 +44,9 @@ public class JTableTypeAheadListener extends KeyAdapter {
     }
   }
 
-  private void selectRow(int rowIndex) {
-    table.setRowSelectionInterval(rowIndex, rowIndex);
-    table.scrollRectToVisible(table.getCellRect(rowIndex, 0, true));
+  private void selectRow(int modelRowIndex) {
+    int viewRowIndex = table.getRowSorter().convertRowIndexToView(modelRowIndex);
+    table.setRowSelectionInterval(viewRowIndex, viewRowIndex);
+    table.scrollRectToVisible(table.getCellRect(viewRowIndex, 0, true));
   }
 }


### PR DESCRIPTION
This was broken when we made the list always sorted in JTable, which caused view and model indexes to not correspond. Also fixes keyPressTime logic.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
