### PR TITLE
Dirty hack to fix moderator toolbox

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/maps/MapsTabModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/maps/MapsTabModel.java
@@ -31,19 +31,21 @@ public class MapsTabModel {
 
   /** Queries server for the list of known maps. */
   List<MapDownloadItem> fetchMapsList() {
-    try {
-      return mapsClient.fetchMapListing();
-    } catch (FeignException e) {
-      log.warn("Failed to download the list of available maps from TripleA servers.", e);
-      return List.of();
-    }
+    return List.of();
+    //    try {
+    //      return mapsClient.fetchMapListing();
+    //    } catch (FeignException e) {
+    //      log.warn("Failed to download the list of available maps from TripleA servers.", e);
+    //      return List.of();
+    //    }
   }
 
   /** Queries server for the set of available tag names mapped to their allowed values. */
   List<MapTagMetaData> fetchAllowedMapTagValues() {
-    return mapTagAdminClient.fetchAllowedMapTagValues().stream()
-        .sorted(Comparator.comparing(MapTagMetaData::getDisplayOrder))
-        .collect(Collectors.toList());
+    return List.of();
+    //    return mapTagAdminClient.fetchAllowedMapTagValues().stream()
+    //        .sorted(Comparator.comparing(MapTagMetaData::getDisplayOrder))
+    //        .collect(Collectors.toList());
   }
 
   /** Sends a request to server to update a map tag to a new value. */

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/maps/MapsTabModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/maps/MapsTabModel.java
@@ -1,9 +1,6 @@
 package games.strategy.engine.lobby.moderator.toolbox.tabs.maps;
 
-import feign.FeignException;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Setter;


### PR DESCRIPTION
Moderator toolbox was rigged to manage map tagging. Toolbox requires endpoints on the maps server to function. The maps server is not yet available.
This is a hack fix to remove the dependency so that the toolbox works again.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
