### PR TITLE
    Bots: 'exit on game end' & automatically load last autosave on boot     

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -10,4 +10,8 @@ public final class GameRunner {
   public static boolean headless() {
     return Boolean.parseBoolean(System.getProperty(TRIPLEA_HEADLESS, "false"));
   }
+
+  public static boolean exitOnEndGame() {
+    return Boolean.parseBoolean(System.getProperty("triplea.exit.on.game.end", "false"));
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -404,6 +404,14 @@ public class ServerGame extends AbstractGame {
       delegateExecutionManager.resumeDelegateExecution();
     }
     gameData.getGameLoader().shutDown();
+    // if this is a bot, shut down the bot. We will rely on systemctl to restart the bot
+    // instance. This restart will help us pick up any new maps and/or new bot versions.
+    if (GameRunner.headless() && GameRunner.exitOnEndGame()) {
+      if (inGameLobbyWatcher != null) {
+        inGameLobbyWatcher.shutDown();
+      }
+      ExitStatus.SUCCESS.exit();
+    }
   }
 
   private void autoSaveBefore(final IDelegate delegate) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -6,7 +6,9 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.gameparser.GameParser;
 import games.strategy.engine.data.gameparser.GameParsingValidation;
 import games.strategy.engine.framework.GameDataManager;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.GameShutdownRegistry;
+import games.strategy.engine.framework.HeadlessAutoSaveFileUtils;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.GameSelector;
 import games.strategy.triplea.settings.ClientSetting;
@@ -66,7 +68,9 @@ public class GameSelectorModel extends Observable implements GameSelector {
 
   public boolean loadSave(Path saveFile) {
     try {
-      readyForSaveLoad.await();
+      if (!GameRunner.headless()) {
+        readyForSaveLoad.await();
+      }
     } catch (InterruptedException e) {
       return false;
     }
@@ -193,8 +197,13 @@ public class GameSelectorModel extends Observable implements GameSelector {
    */
   public void loadDefaultGameSameThread() {
     final Optional<String> gameUri;
-    if (saveGameToLoad.isPresent()) {
-      gameUri = saveGameToLoad;
+    if (Files.exists(new HeadlessAutoSaveFileUtils().getHeadlessAutoSaveFile())) {
+      gameUri =
+          Optional.of(
+              new HeadlessAutoSaveFileUtils()
+                  .getHeadlessAutoSaveFile()
+                  .toAbsolutePath()
+                  .toString());
       saveGameToLoad = Optional.empty();
     } else {
       gameUri = ClientSetting.defaultGameUri.getValue();

--- a/game-app/game-headless/scripts/run_bot.bat
+++ b/game-app/game-headless/scripts/run_bot.bat
@@ -69,6 +69,16 @@ REM Under normal circumstances, you will not have to change this variable.
 REM
 SET LOBBY_URI=https://prod.triplea-game.org
 
+
+REM
+REM Whether to shut down the bot when a game is over.
+REM
+REM This works well (set it to true) if the bot is installed as a service
+REM that is automatically restarted.
+REM
+SET EXIT_ON_GAME_END LOBBY_URI=false
+
+
 REM ###########################################################################
 REM VARIABLES THAT YOU MAY CUSTOMIZE END HERE
 REM
@@ -84,4 +94,5 @@ java^
  -Ptriplea.map.folder="%MAPS_FOLDER%"^
  -Ptriplea.name=%BOT_NAME%^
  -Ptriplea.port=%BOT_PORT%^
- -Ptriplea.server.password=%BOT_PASSWORD%
+ -Ptriplea.server.password=%BOT_PASSWORD%^
+ -Ptriplea.exit.on.game.end=%EXIT_ON_GAME_END%

--- a/game-app/game-headless/scripts/run_bot.bat
+++ b/game-app/game-headless/scripts/run_bot.bat
@@ -76,7 +76,7 @@ REM
 REM This works well (set it to true) if the bot is installed as a service
 REM that is automatically restarted.
 REM
-SET EXIT_ON_GAME_END LOBBY_URI=false
+SET EXIT_ON_GAME_END=false
 
 
 REM ###########################################################################

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -144,6 +144,7 @@ public class HeadlessGameServer {
   public void waitForUsers() {
     log.info("Waiting for users to connect.");
     setServerGame(null);
+    gameSelectorModel.loadDefaultGameSameThread();
 
     while (headlessServerSetup.waitUntilStart() && !startHeadlessGame()) {
       log.warn("Error in launcher, going back to waiting.");

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -9,6 +9,7 @@ import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.HeadlessChat;
 import games.strategy.engine.chat.MessengersChatTransmitter;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.HeadlessAutoSaveFileUtils;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.LocalPlayers;
@@ -61,6 +62,10 @@ public class HeadlessLaunchAction implements LaunchAction {
   @Override
   public void handleGameInterruption(
       final GameSelectorModel gameSelectorModel, final ServerModel serverModel) {
+    if (!GameRunner.exitOnEndGame()) {
+      // no-op, System.exit will be called later
+      return;
+    }
     log.info("Game ended, going back to waiting.");
     // if we do not do this, we can get into an infinite loop of launching a game,
     // then crashing out, then launching, etc.


### PR DESCRIPTION
    (1) Adds a flag to "exit on game end". This means instead of going
    to the staging screen, the bot instance instead shuts down.
    
    (2) On bot startup, bot will load 'autosave.tsvg' automatically if it exists.
    
    The exit on shutdown relies on the system to automatically restart
    a service that is no longer running. Thus, the bot service should
    be automatically brought back up if that is in place.
    
    There is a problem currently where bots are not returning
    to the staging screen when the last player has left. While this
    update does not fix that problem, setting the 'exit on end'
    flag would be a workaround.
    
    Further, having the bot restart is particularly useful as that
    picks up any new or updated maps. Otherwise it can be hard
    to manually find a good time to restart all bots.
