### PR TITLE
Bots: Fix 'info' logging appearing in chat

### DIFF
--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -141,6 +141,7 @@ public class HeadlessLaunchAction implements LaunchAction {
 
     ThresholdFilter filter = new ThresholdFilter();
     filter.setLevel(Level.WARN.toString());
+    filter.start();
     chatAppender.addFilter(filter);
     chatAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
     chatAppender.start();


### PR DESCRIPTION
The logging filter needs to have 'start()' called on it before it can do anything. Without this, all log messages were showing up in bot in-game chat rather than just the warn and error logging.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
