### PR TITLE
Fixes: fix couples bugs around default game loading

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -315,7 +315,7 @@ public class ServerLauncher implements ILauncher {
     final Path f = launchAction.getAutoSaveFile();
     try {
       serverGame.saveGame(f);
-      gameSelectorModel.setSaveGameFileToLoad(f);
+      ClientSetting.defaultGameUri.setValueAndFlush(f.toUri().toString());
     } catch (final Exception e) {
       log.error("Failed to save game: " + f.toAbsolutePath(), e);
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -46,7 +46,6 @@ public class GameSelectorModel extends Observable implements GameSelector {
   // just for host bots, so we can get the actions for loading/saving games on the bots from this
   // model
   @Setter @Getter private ClientModel clientModelForHostBots = null;
-  private Optional<String> saveGameToLoad = Optional.empty();
 
   // Don't load a save game before the startup task to load the initial map has run, else that task
   // may "lose" the race and overwrite the loaded saved game.
@@ -186,28 +185,19 @@ public class GameSelectorModel extends Observable implements GameSelector {
     ThreadRunner.runInNewThread(this::loadDefaultGameSameThread);
   }
 
-  /** Sets the path of a save file that should be loaded. */
-  public void setSaveGameFileToLoad(final Path filePath) {
-    saveGameToLoad = Optional.of(filePath.toAbsolutePath().toString());
-  }
-
   /**
    * Runs the load default game logic in same thread. Default game is the one that we loaded on
    * startup.
    */
   public void loadDefaultGameSameThread() {
     final Optional<String> gameUri;
-    if (saveGameToLoad.isPresent()) {
-      gameUri = saveGameToLoad;
-    } else if (GameRunner.headless()
-        && Files.exists(new HeadlessAutoSaveFileUtils().getHeadlessAutoSaveFile())) {
+    if (GameRunner.headless() && Files.exists(new HeadlessAutoSaveFileUtils().getHeadlessAutoSaveFile())) {
       gameUri =
           Optional.of(
               new HeadlessAutoSaveFileUtils()
                   .getHeadlessAutoSaveFile()
                   .toAbsolutePath()
                   .toString());
-      saveGameToLoad = Optional.empty();
     } else {
       gameUri = ClientSetting.defaultGameUri.getValue();
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -191,7 +191,8 @@ public class GameSelectorModel extends Observable implements GameSelector {
    */
   public void loadDefaultGameSameThread() {
     final Optional<String> gameUri;
-    if (GameRunner.headless() && Files.exists(new HeadlessAutoSaveFileUtils().getHeadlessAutoSaveFile())) {
+    if (GameRunner.headless()
+        && Files.exists(new HeadlessAutoSaveFileUtils().getHeadlessAutoSaveFile())) {
       gameUri =
           Optional.of(
               new HeadlessAutoSaveFileUtils()

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -197,9 +197,10 @@ public class GameSelectorModel extends Observable implements GameSelector {
    */
   public void loadDefaultGameSameThread() {
     final Optional<String> gameUri;
-    if(saveGameToLoad.isPresent()) {
+    if (saveGameToLoad.isPresent()) {
       gameUri = saveGameToLoad;
-    } else if (GameRunner.headless() && Files.exists(new HeadlessAutoSaveFileUtils().getHeadlessAutoSaveFile())) {
+    } else if (GameRunner.headless()
+        && Files.exists(new HeadlessAutoSaveFileUtils().getHeadlessAutoSaveFile())) {
       gameUri =
           Optional.of(
               new HeadlessAutoSaveFileUtils()

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -197,7 +197,9 @@ public class GameSelectorModel extends Observable implements GameSelector {
    */
   public void loadDefaultGameSameThread() {
     final Optional<String> gameUri;
-    if (Files.exists(new HeadlessAutoSaveFileUtils().getHeadlessAutoSaveFile())) {
+    if(saveGameToLoad.isPresent()) {
+      gameUri = saveGameToLoad;
+    } else if (GameRunner.headless() && Files.exists(new HeadlessAutoSaveFileUtils().getHeadlessAutoSaveFile())) {
       gameUri =
           Optional.of(
               new HeadlessAutoSaveFileUtils()
@@ -219,6 +221,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
                 loadMap(file);
               } else {
                 // try to load it as a saved game whatever the extension
+                readyForSaveLoad.countDown();
                 loadSave(file);
               }
             },


### PR DESCRIPTION
Fixed new bug where we needed to check keep the check for 'saveGameToLoad.isPresent()', and the Headless autosave file loading needs a 'GameRunner.headless()' check.

Fixed latent bug where we need to release the 'ready to load save-game' latch if we are actually trying to load a save game.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
