### PR TITLE
Bots: shutdown if there is an error connecting to lobby

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -15,6 +15,7 @@ import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameObjectStreamFactory;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.GameState;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.LobbyWatcherThread;
@@ -277,6 +278,10 @@ public class ServerModel extends Observable implements IConnectionChangeListener
     } catch (final IOException e) {
       log.error("Unable to create server socket.", e);
       cancel();
+      if (GameRunner.headless()) {
+        log.error("Failed to connect to lobby, shutting down.");
+        ExitStatus.FAILURE.exit();
+      }
     }
     return null;
   }


### PR DESCRIPTION
If bot fails to connect, it will just hang out and not reconnect. This update shuts the bot down in such a case (in which case it might be auto-restarted)

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
