### PR TITLE
Change 'invalid map' warning to be silent.

### DIFF
--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
@@ -63,8 +63,8 @@ class MapDescriptionYamlReader {
               .build();
 
       if (!mapDescriptionYaml.isValid(ymlFile)) {
-        log.warn(
-            "Invalid map description YML (map.yml) file detected: {}\n"
+        log.info(
+            "Warning: Invalid map description YML (map.yml) file detected: {}\n"
                 + "Check the file carefully and correct any mistakes.\n"
                 + "If this is a map you downloaded, please contact TripleA.\n"
                 + "Data parsed:\n"
@@ -75,8 +75,8 @@ class MapDescriptionYamlReader {
       }
       return Optional.of(mapDescriptionYaml);
     } catch (final ClassCastException | InvalidYamlFormatException e) {
-      log.warn(
-          "Invalid map description YML (map.yml) file detected: {}.\n"
+      log.info(
+          "Warning: Invalid map description YML (map.yml) file detected: {}.\n"
               + "If this is a map you downloaded, please contact TripleA.\n"
               + "{}",
           ymlFile.toAbsolutePath(),


### PR DESCRIPTION
The warning is very prominent and persistent.

This update logs the warning in the background without a pop-up.

A prominent popup would be okay if it were easily fixed (eg: the offending map deleted). Short of that, we're just making the warning quiet.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
