### PR TITLE
Fix Bot autosave bug: include bot name in save game file

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/LobbyWatcherThread.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/LobbyWatcherThread.java
@@ -1,7 +1,5 @@
 package games.strategy.engine.framework.startup;
 
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
-
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcher;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
@@ -36,7 +34,6 @@ public class LobbyWatcherThread {
             watcher -> {
               watcher.setGameSelectorModel(gameSelectorModel);
               lobbyWatcher.setInGameLobbyWatcher(watcher);
-              System.clearProperty(TRIPLEA_NAME);
             });
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -9,15 +9,9 @@ import static org.hamcrest.core.Is.is;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.settings.ClientSetting;
 import java.nio.file.Path;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class ArgParserTest extends AbstractClientSettingTestCase {
-
-  @AfterEach
-  void tearDown() {
-    System.clearProperty(TRIPLEA_GAME);
-  }
 
   @Test
   void argsTurnIntoSystemProps() {

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/AutoSaveFileUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/AutoSaveFileUtilsTest.java
@@ -7,7 +7,6 @@ import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.settings.ClientSetting;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -30,15 +29,6 @@ final class AutoSaveFileUtilsTest extends AbstractClientSettingTestCase {
   @Nested
   final class GetAutoSaveFileNameTest {
     private static final String BASE_FILE_NAME = "baseFileName";
-
-    private void givenPlayerNameNotDefined() {
-      System.clearProperty(CliProperties.TRIPLEA_NAME);
-    }
-
-    @AfterEach
-    void clearSystemProperties() {
-      givenPlayerNameNotDefined();
-    }
 
     @Test
     void shouldNotPrefixFileNameWhenHeaded() {

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/HeadlessAutoSaveFileUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/HeadlessAutoSaveFileUtilsTest.java
@@ -4,28 +4,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
-import games.strategy.triplea.settings.ClientSetting;
-import java.nio.file.Path;
 import java.time.LocalDateTime;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class HeadlessAutoSaveFileUtilsTest extends AbstractClientSettingTestCase {
   private final HeadlessAutoSaveFileUtils autoSaveFileUtils = new HeadlessAutoSaveFileUtils();
-
-  @Nested
-  final class GetAutoSaveFileTest {
-    @Test
-    void shouldReturnFileInAutoSaveFolder() {
-      ClientSetting.saveGamesFolderPath.setValue(Path.of("path", "to", "saves"));
-
-      final String fileName = "savegame.tsvg";
-      assertThat(
-          autoSaveFileUtils.getAutoSaveFile(fileName),
-          is(Path.of("path", "to", "saves", "autoSave", fileName)));
-    }
-  }
 
   @Nested
   final class GetAutoSaveFileNameTest {
@@ -41,15 +25,6 @@ final class HeadlessAutoSaveFileUtilsTest extends AbstractClientSettingTestCase 
       System.setProperty(CliProperties.TRIPLEA_NAME, playerName);
     }
 
-    private void givenPlayerNameNotDefined() {
-      System.clearProperty(CliProperties.TRIPLEA_NAME);
-    }
-
-    @AfterEach
-    void clearSystemProperties() {
-      givenPlayerNameNotDefined();
-    }
-
     @Test
     void shouldPrefixFileNameWithPlayerNameWhenHeadless() {
       givenPlayerName(PLAYER_NAME);
@@ -61,7 +36,6 @@ final class HeadlessAutoSaveFileUtilsTest extends AbstractClientSettingTestCase 
 
     @Test
     void shouldPrefixFileNameWithHostNameWhenHeadlessAndPlayerNameNotDefined() {
-      givenPlayerNameNotDefined();
       givenHostName(HOST_NAME);
 
       assertThat(
@@ -71,8 +45,6 @@ final class HeadlessAutoSaveFileUtilsTest extends AbstractClientSettingTestCase 
 
     @Test
     void shouldNotPrefixFileNameWhenHeadlessAndPlayerNameNotDefinedAndHostNameNotDefined() {
-      givenPlayerNameNotDefined();
-
       assertThat(autoSaveFileUtils.getAutoSaveFileName(BASE_FILE_NAME), is(BASE_FILE_NAME));
     }
   }


### PR DESCRIPTION
In autosaves, we want the bot name to be included in the save game file so that multiple bot instances on the same server do not overwrite each others files.

Prevoiusly there was a bug "System.clear" of the bot name, thereby erasing it from the save game file. With that, all bot hosts on the same server were overwriting each others file. A further consequence, without the name of the bot instance, it was difficult to know whose autosave file was whose.

This update removes the unnecessary "System.clear" and with that, the bot name appears in the autosave file.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
