### PR TITLE
Automatic Bot Moderators

### DIFF
--- a/game-app/domain-data/src/main/java/org/triplea/domain/data/ChatParticipant.java
+++ b/game-app/domain-data/src/main/java/org/triplea/domain/data/ChatParticipant.java
@@ -26,7 +26,7 @@ public class ChatParticipant implements Serializable {
   @Nonnull private final String playerChatId;
 
   /** True if the player has moderator privileges. */
-  private final boolean isModerator;
+  @Setter private boolean isModerator;
 
   /** Status is custom text set by players, eg: "AFK" or "Looking for a game". */
   @Setter @Nullable private String status;

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -2,7 +2,8 @@ package games.strategy.engine.chat;
 
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.Sets;
-import games.strategy.engine.framework.startup.mc.ModeratorMessage;
+import games.strategy.engine.framework.startup.mc.messages.ModeratorMessage;
+import games.strategy.net.IMessageListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -14,6 +15,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.triplea.domain.data.ChatParticipant;
 import org.triplea.domain.data.UserName;
 
@@ -22,6 +24,7 @@ import org.triplea.domain.data.UserName;
  *
  * <p>A chat can be bound to multiple chat panels.
  */
+@Slf4j
 @SuppressWarnings("UnstableApiUsage")
 public class Chat implements ChatClient {
 
@@ -55,6 +58,13 @@ public class Chat implements ChatClient {
     sentMessagesHistory = new SentMessagesHistory();
     chatters.addAll(chatTransmitter.connect());
     updateConnections();
+  }
+
+  public void addMessengersListener(IMessageListener messageListener) {
+    if(chatTransmitter instanceof MessengersChatTransmitter) {
+      log.info("addming messengers listener");
+      ((MessengersChatTransmitter) chatTransmitter).getMessengers().addMessageListener(messageListener);
+    }
   }
 
   private void updateConnections() {
@@ -189,4 +199,15 @@ public class Chat implements ChatClient {
           "sendDisconnect on Chat.java is to support legacy 'messengers' communication only");
     }
   }
+
+  public void sendBan(UserName userName) {
+    if (chatTransmitter instanceof MessengersChatTransmitter) {
+      var messengers = ((MessengersChatTransmitter) chatTransmitter).getMessengers();
+      messengers.sendToServer(ModeratorMessage.newBan(userName.toString()));
+    } else {
+      throw new UnsupportedOperationException(
+          "sendDisconnect on Chat.java is to support legacy 'messengers' communication only");
+    }
+  }
+
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -61,9 +61,11 @@ public class Chat implements ChatClient {
   }
 
   public void addMessengersListener(IMessageListener messageListener) {
-    if(chatTransmitter instanceof MessengersChatTransmitter) {
+    if (chatTransmitter instanceof MessengersChatTransmitter) {
       log.info("addming messengers listener");
-      ((MessengersChatTransmitter) chatTransmitter).getMessengers().addMessageListener(messageListener);
+      ((MessengersChatTransmitter) chatTransmitter)
+          .getMessengers()
+          .addMessageListener(messageListener);
     }
   }
 
@@ -209,5 +211,4 @@ public class Chat implements ChatClient {
           "sendDisconnect on Chat.java is to support legacy 'messengers' communication only");
     }
   }
-
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -2,6 +2,7 @@ package games.strategy.engine.chat;
 
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.Sets;
+import games.strategy.engine.framework.startup.mc.ModeratorMessage;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -177,5 +178,15 @@ public class Chat implements ChatClient {
 
   Collection<UserName> getOnlinePlayers() {
     return chatters.stream().map(ChatParticipant::getUserName).collect(Collectors.toSet());
+  }
+
+  public void sendDisconnect(UserName userName) {
+    if (chatTransmitter instanceof MessengersChatTransmitter) {
+      var messengers = ((MessengersChatTransmitter) chatTransmitter).getMessengers();
+      messengers.sendToServer(ModeratorMessage.newDisconnect(userName.toString()));
+    } else {
+      throw new UnsupportedOperationException(
+          "sendDisconnect on Chat.java is to support legacy 'messengers' communication only");
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -2,8 +2,8 @@ package games.strategy.engine.chat;
 
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.Sets;
-import games.strategy.engine.framework.startup.mc.messages.ModeratorMessage;
 import games.strategy.net.IMessageListener;
+import games.strategy.net.Messengers;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -15,7 +15,6 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.triplea.domain.data.ChatParticipant;
 import org.triplea.domain.data.UserName;
 
@@ -24,7 +23,6 @@ import org.triplea.domain.data.UserName;
  *
  * <p>A chat can be bound to multiple chat panels.
  */
-@Slf4j
 @SuppressWarnings("UnstableApiUsage")
 public class Chat implements ChatClient {
 
@@ -62,7 +60,6 @@ public class Chat implements ChatClient {
 
   public void addMessengersListener(IMessageListener messageListener) {
     if (chatTransmitter instanceof MessengersChatTransmitter) {
-      log.info("addming messengers listener");
       ((MessengersChatTransmitter) chatTransmitter)
           .getMessengers()
           .addMessageListener(messageListener);
@@ -192,23 +189,11 @@ public class Chat implements ChatClient {
     return chatters.stream().map(ChatParticipant::getUserName).collect(Collectors.toSet());
   }
 
-  public void sendDisconnect(UserName userName) {
-    if (chatTransmitter instanceof MessengersChatTransmitter) {
-      var messengers = ((MessengersChatTransmitter) chatTransmitter).getMessengers();
-      messengers.sendToServer(ModeratorMessage.newDisconnect(userName.toString()));
-    } else {
+  public Messengers getMessengers() {
+    if (!(chatTransmitter instanceof MessengersChatTransmitter)) {
       throw new UnsupportedOperationException(
-          "sendDisconnect on Chat.java is to support legacy 'messengers' communication only");
+          "getMessengers is to support legacy 'messengers' communication only");
     }
-  }
-
-  public void sendBan(UserName userName) {
-    if (chatTransmitter instanceof MessengersChatTransmitter) {
-      var messengers = ((MessengersChatTransmitter) chatTransmitter).getMessengers();
-      messengers.sendToServer(ModeratorMessage.newBan(userName.toString()));
-    } else {
-      throw new UnsupportedOperationException(
-          "sendDisconnect on Chat.java is to support legacy 'messengers' communication only");
-    }
+    return ((MessengersChatTransmitter) chatTransmitter).getMessengers();
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
@@ -1,15 +1,12 @@
 package games.strategy.engine.chat;
 
 import com.google.common.base.Strings;
-import games.strategy.engine.framework.startup.mc.messages.ModeratorPromoted;
 import games.strategy.engine.message.MessageContext;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.net.IConnectionChangeListener;
-import games.strategy.net.IMessageListener;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 import games.strategy.net.ServerMessenger;
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
@@ -59,20 +59,6 @@ public class ChatController implements IChatController {
     chatName = name;
     this.messengers = messengers;
     this.serverMessenger = serverMessenger;
-    messengers.addMessageListener(
-        new IMessageListener() {
-          @Override
-          public void messageReceived(Serializable msg, INode from) {
-            if (msg instanceof ModeratorPromoted) {
-              String newModerator = ((ModeratorPromoted) msg).getPlayerName();
-
-              chatters.keySet().stream()
-                  .filter(node -> node.getName().equals(newModerator))
-                  .findAny()
-                  .ifPresent(mod -> chatters.put(mod, Tag.MODERATOR));
-            }
-          }
-        });
     chatChannel = getChatChannelName(name);
     messengers.registerRemote(this, getChatControllerRemoteName(name));
     messengers.addConnectionChangeListener(connectionChangeListener);

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
@@ -54,7 +54,8 @@ public class ChatController implements IChatController {
         }
       };
 
-  public ChatController(final String name, final Messengers messengers, ServerMessenger serverMessenger) {
+  public ChatController(
+      final String name, final Messengers messengers, ServerMessenger serverMessenger) {
     chatName = name;
     this.messengers = messengers;
     this.serverMessenger = serverMessenger;
@@ -69,7 +70,6 @@ public class ChatController implements IChatController {
                   .filter(node -> node.getName().equals(newModerator))
                   .findAny()
                   .ifPresent(mod -> chatters.put(mod, Tag.MODERATOR));
-
             }
           }
         });

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -1,5 +1,8 @@
 package games.strategy.engine.chat;
 
+import games.strategy.engine.framework.startup.mc.messages.ModeratorPromoted;
+import games.strategy.net.IMessageListener;
+import games.strategy.net.INode;
 import games.strategy.triplea.settings.ClientSetting;
 import java.awt.BorderLayout;
 import java.awt.Container;
@@ -7,6 +10,7 @@ import java.awt.Insets;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.io.Serializable;
 import javax.swing.Action;
 import javax.swing.BoundedRangeModel;
 import javax.swing.InputMap;
@@ -80,10 +84,21 @@ public class ChatMessagePanel extends JPanel implements ChatMessageListener {
 
   public ChatMessagePanel(
       final Chat chat, final ChatSoundProfile chatSoundProfile, final ClipPlayer clipPlayer) {
+
     this.chatSoundProfile = chatSoundProfile;
     this.clipPlayer = clipPlayer;
     init();
     setChat(chat);
+
+    log.info("INIT CHAT MESSAGE PANEL");
+    chat.addMessengersListener(new IMessageListener() {
+      @Override
+      public void messageReceived(Serializable msg, INode from) {
+        if(msg instanceof ModeratorPromoted) {
+          addGenericMessage("MODERATOR PROMOTED: " + ((ModeratorPromoted) msg).getPlayerName());
+        }
+      }
+    });
   }
 
   private void init() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -91,14 +91,15 @@ public class ChatMessagePanel extends JPanel implements ChatMessageListener {
     setChat(chat);
 
     log.info("INIT CHAT MESSAGE PANEL");
-    chat.addMessengersListener(new IMessageListener() {
-      @Override
-      public void messageReceived(Serializable msg, INode from) {
-        if(msg instanceof ModeratorPromoted) {
-          addGenericMessage("MODERATOR PROMOTED: " + ((ModeratorPromoted) msg).getPlayerName());
-        }
-      }
-    });
+    chat.addMessengersListener(
+        new IMessageListener() {
+          @Override
+          public void messageReceived(Serializable msg, INode from) {
+            if (msg instanceof ModeratorPromoted) {
+              addGenericMessage("MODERATOR PROMOTED: " + ((ModeratorPromoted) msg).getPlayerName());
+            }
+          }
+        });
   }
 
   private void init() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -90,13 +90,12 @@ public class ChatMessagePanel extends JPanel implements ChatMessageListener {
     init();
     setChat(chat);
 
-    log.info("INIT CHAT MESSAGE PANEL");
     chat.addMessengersListener(
         new IMessageListener() {
           @Override
           public void messageReceived(Serializable msg, INode from) {
             if (msg instanceof ModeratorPromoted) {
-              addGenericMessage("MODERATOR PROMOTED: " + ((ModeratorPromoted) msg).getPlayerName());
+              addGenericMessage("Moderator Promoted: " + ((ModeratorPromoted) msg).getPlayerName());
             }
           }
         });

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -57,22 +57,23 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
     layoutComponents();
     setupListeners();
     setChat(chat);
-    chat.addMessengersListener(new IMessageListener() {
-      @Override
-      public void messageReceived(Serializable msg, INode from) {
-        if(msg instanceof ModeratorPromoted) {
-          String newModerator = ((ModeratorPromoted) msg).getPlayerName();
-          for(int i = 0; i < listModel.getSize(); i ++) {
-            if(listModel.get(i).getUserName().toString().equals(newModerator)) {
-              listModel.get(i).setModerator(true);
-              players.repaint();
-              break;
+    chat.addMessengersListener(
+        new IMessageListener() {
+          @Override
+          public void messageReceived(Serializable msg, INode from) {
+            if (msg instanceof ModeratorPromoted) {
+              String newModerator = ((ModeratorPromoted) msg).getPlayerName();
+              for (int i = 0; i < listModel.getSize(); i++) {
+                if (listModel.get(i).getUserName().toString().equals(newModerator)) {
+                  listModel.get(i).setModerator(true);
+                  players.repaint();
+                  break;
+                }
+              }
+              repaint();
             }
           }
-          repaint();
-        }
-      }
-    });
+        });
   }
 
   /** Sets the chat whose players will be displayed in this panel. */
@@ -176,14 +177,16 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
               SwingAction.of(
                   "Slap " + clickedOn.getUserName(), e -> chat.sendSlap(clickedOn.getUserName()));
 
-
           // TODO: add check for if we are moderator
           final Action disconnect =
-              SwingAction.of("Disconnect " + clickedOn.getUserName(), e -> chat.sendDisconnect(clickedOn.getUserName()));
+              SwingAction.of(
+                  "Disconnect " + clickedOn.getUserName(),
+                  e -> chat.sendDisconnect(clickedOn.getUserName()));
           // TODO: add check for if we are moderator
 
           final Action ban =
-              SwingAction.of("Ban " + clickedOn.getUserName(), e -> chat.sendBan(clickedOn.getUserName()));
+              SwingAction.of(
+                  "Ban " + clickedOn.getUserName(), e -> chat.sendBan(clickedOn.getUserName()));
 
           return List.of(slap, ignore, disconnect, ban);
         });

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -67,11 +67,9 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
               for (int i = 0; i < listModel.getSize(); i++) {
                 if (listModel.get(i).getUserName().toString().equals(newModerator)) {
                   listModel.get(i).setModerator(true);
-                  players.repaint();
                   break;
                 }
               }
-              repaint();
             }
           }
         });

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -1,11 +1,15 @@
 package games.strategy.engine.chat;
 
+import games.strategy.engine.framework.startup.mc.messages.ModeratorPromoted;
+import games.strategy.net.IMessageListener;
+import games.strategy.net.INode;
 import games.strategy.triplea.EngineImageLoader;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -53,6 +57,22 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
     layoutComponents();
     setupListeners();
     setChat(chat);
+    chat.addMessengersListener(new IMessageListener() {
+      @Override
+      public void messageReceived(Serializable msg, INode from) {
+        if(msg instanceof ModeratorPromoted) {
+          String newModerator = ((ModeratorPromoted) msg).getPlayerName();
+          for(int i = 0; i < listModel.getSize(); i ++) {
+            if(listModel.get(i).getUserName().toString().equals(newModerator)) {
+              listModel.get(i).setModerator(true);
+              players.repaint();
+              break;
+            }
+          }
+          repaint();
+        }
+      }
+    });
   }
 
   /** Sets the chat whose players will be displayed in this panel. */
@@ -157,9 +177,15 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
                   "Slap " + clickedOn.getUserName(), e -> chat.sendSlap(clickedOn.getUserName()));
 
 
+          // TODO: add check for if we are moderator
           final Action disconnect =
               SwingAction.of("Disconnect " + clickedOn.getUserName(), e -> chat.sendDisconnect(clickedOn.getUserName()));
-          return List.of(slap, ignore, disconnect);
+          // TODO: add check for if we are moderator
+
+          final Action ban =
+              SwingAction.of("Ban " + clickedOn.getUserName(), e -> chat.sendBan(clickedOn.getUserName()));
+
+          return List.of(slap, ignore, disconnect, ban);
         });
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.chat;
 
+import games.strategy.engine.framework.startup.mc.messages.ModeratorMessage;
 import games.strategy.engine.framework.startup.mc.messages.ModeratorPromoted;
 import games.strategy.net.IMessageListener;
 import games.strategy.net.INode;
@@ -181,12 +182,19 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
           final Action disconnect =
               SwingAction.of(
                   "Disconnect " + clickedOn.getUserName(),
-                  e -> chat.sendDisconnect(clickedOn.getUserName()));
+                  e ->
+                      chat.getMessengers()
+                          .sendToServer(
+                              ModeratorMessage.newDisconnect(clickedOn.getUserName().getValue())));
           // TODO: add check for if we are moderator
 
           final Action ban =
               SwingAction.of(
-                  "Ban " + clickedOn.getUserName(), e -> chat.sendBan(clickedOn.getUserName()));
+                  "Ban " + clickedOn.getUserName(),
+                  e ->
+                      chat.getMessengers()
+                          .sendToServer(
+                              ModeratorMessage.newBan(clickedOn.getUserName().getValue())));
 
           return List.of(slap, ignore, disconnect, ban);
         });

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -155,7 +155,11 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
           final Action slap =
               SwingAction.of(
                   "Slap " + clickedOn.getUserName(), e -> chat.sendSlap(clickedOn.getUserName()));
-          return List.of(slap, ignore);
+
+
+          final Action disconnect =
+              SwingAction.of("Disconnect " + clickedOn.getUserName(), e -> chat.sendDisconnect(clickedOn.getUserName()));
+          return List.of(slap, ignore, disconnect);
         });
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
@@ -6,6 +6,7 @@ import games.strategy.net.Messengers;
 import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.settings.ClientSetting;
 import java.util.Collection;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.domain.data.ChatParticipant;
 import org.triplea.domain.data.UserName;
@@ -15,6 +16,7 @@ import org.triplea.java.concurrency.AsyncRunner;
 @Slf4j
 public class MessengersChatTransmitter implements ChatTransmitter {
   private final UserName userName;
+  @Getter
   private final Messengers messengers;
 
   private IChatChannel chatChannelSubscriber;

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
@@ -16,8 +16,7 @@ import org.triplea.java.concurrency.AsyncRunner;
 @Slf4j
 public class MessengersChatTransmitter implements ChatTransmitter {
   private final UserName userName;
-  @Getter
-  private final Messengers messengers;
+  @Getter private final Messengers messengers;
 
   private IChatChannel chatChannelSubscriber;
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ModeratorMessage.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ModeratorMessage.java
@@ -1,0 +1,31 @@
+package games.strategy.engine.framework.startup.mc;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+
+/** Represents a message sent to the server, from a moderator */
+@Value
+public class ModeratorMessage implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  @Nonnull String action;
+  @Nonnull String playerName;
+
+  public static ModeratorMessage newDisconnect(String playerName) {
+    return new ModeratorMessage("disconnect", playerName);
+  }
+
+  public static ModeratorMessage newBan(String playerName) {
+    return new ModeratorMessage("ban", playerName);
+  }
+
+  boolean isBan() {
+    return "ban".equalsIgnoreCase(action);
+  }
+
+  boolean isDisconnect() {
+    return "disconnect".equalsIgnoreCase(action);
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -219,7 +219,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
       // add moderator action handlers (eg: ban/disconnect)
       serverMessenger.addMessageListener(
           (msg, from) -> {
-            // check that from is a moderator
+            // check that message is from a moderator
             if (msg instanceof ModeratorMessage) {
               if (!serverMessenger.isModerator(from)) {
                 return;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -417,9 +417,6 @@ public class ServerModel extends Observable implements IConnectionChangeListener
   public void connectionAdded(final INode to) {
     notifyLobby(
         (lobbyConnection, gameId) -> lobbyConnection.playerJoined(gameId, to.getPlayerName()));
-    if (serverMessenger.isModerator(to)) {
-      chatModel.getChat().sendMessage("Moderator has joined: " + to.getPlayerName());
-    }
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -217,15 +217,15 @@ public class ServerModel extends Observable implements IConnectionChangeListener
           new ServerMessenger(props.getName(), props.getPort(), objectStreamFactory);
       serverMessenger.addConnectionChangeListener(this);
 
-      // register listeners to handle moderator actions
+      // add moderator action handlers (eg: ban/disconnect)
       serverMessenger.addMessageListener((msg, from) -> {
-
-
         // check that from is a moderator
-
         if (msg instanceof ModeratorMessage) {
-          ModeratorMessage moderatorMessage = (ModeratorMessage) msg;
+          if(!serverMessenger.isModerator(from)) {
+            return;
+          }
 
+          ModeratorMessage moderatorMessage = (ModeratorMessage) msg;
           if(moderatorMessage.isBan()) {
             serverMessenger.banPlayer(moderatorMessage.getPlayerName());
           } else if(moderatorMessage.isDisconnect()) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/messages/ModeratorMessage.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/messages/ModeratorMessage.java
@@ -1,8 +1,7 @@
-package games.strategy.engine.framework.startup.mc;
+package games.strategy.engine.framework.startup.mc.messages;
 
 import java.io.Serializable;
 import javax.annotation.Nonnull;
-import lombok.Builder;
 import lombok.Value;
 
 /** Represents a message sent to the server, from a moderator */
@@ -21,11 +20,11 @@ public class ModeratorMessage implements Serializable {
     return new ModeratorMessage("ban", playerName);
   }
 
-  boolean isBan() {
+  public boolean isBan() {
     return "ban".equalsIgnoreCase(action);
   }
 
-  boolean isDisconnect() {
+  public boolean isDisconnect() {
     return "disconnect".equalsIgnoreCase(action);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/messages/ModeratorPromoted.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/messages/ModeratorPromoted.java
@@ -1,0 +1,15 @@
+package games.strategy.engine.framework.startup.mc.messages;
+
+import java.io.Serializable;
+import lombok.Value;
+
+/**
+ * This is a message sent to all players to indicate moderator player has changed. For example, in a
+ * bot game, if there are 3 players - then the bot and oldest joined will be moderators. If the
+ * oldest joined leaves, then the remaining player become smoderator.
+ */
+@Value
+public class ModeratorPromoted implements Serializable {
+  /** The name of the player who is now a moderator. */
+  String playerName;
+}

--- a/game-app/game-core/src/main/java/games/strategy/net/MessageHeader.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/MessageHeader.java
@@ -19,9 +19,7 @@ public class MessageHeader implements Serializable {
   @Nullable private final INode from;
   private final Serializable message;
 
-  /**
-   * Indicates if the message is intended for everyone (true).
-   */
+  /** Indicates if the message is intended for everyone (true). */
   public boolean isBroadcast() {
     return to == null;
   }

--- a/game-app/game-core/src/main/java/games/strategy/net/MessageHeader.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/MessageHeader.java
@@ -18,4 +18,15 @@ public class MessageHeader implements Serializable {
   // from can be null if the sending node doesnt know its own address
   @Nullable private final INode from;
   private final Serializable message;
+
+  /**
+   * Indicates if the message is intended for everyone (true).
+   */
+  public boolean isBroadcast() {
+    return to == null;
+  }
+
+  public boolean isAddressedTo(INode target) {
+    return target.equals(to);
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/net/Messengers.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/Messengers.java
@@ -106,6 +106,10 @@ public class Messengers implements IMessenger, IRemoteMessenger, IChannelMesseng
     messenger.send(msg, to);
   }
 
+  public void sendToServer(final Serializable msg) {
+    messenger.send(msg, messenger.getServerNode());
+  }
+
   @Override
   public void addMessageListener(final IMessageListener listener) {
     messenger.addMessageListener(listener);

--- a/game-app/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -180,6 +180,19 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     miniBannedMacAddresses.add(mac);
   }
 
+  /** Bans & disconnects a player. */
+  public void banPlayer(String playerName) {
+    getNodes().stream()
+        .filter(n -> n.getName().equals(playerName))
+        .findAny()
+        .ifPresent(
+            nodeToBan -> {
+              miniBannedIpAddresses.add(nodeToBan.getIpAddress());
+              miniBannedMacAddresses.add(getPlayerMac(node.getPlayerName()));
+              removeConnection(nodeToBan);
+            });
+  }
+
   private void forward(final MessageHeader msg) {
     if (shutdown) {
       return;
@@ -310,19 +323,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   @Override
   public boolean isServer() {
     return true;
-  }
-
-  /** Bans & disconnects a player. */
-  public void banPlayer(String playerName) {
-    getNodes().stream()
-        .filter(n -> n.getName().equals(playerName))
-        .findAny()
-        .ifPresent(
-            nodeToBan -> {
-              miniBannedIpAddresses.add(nodeToBan.getIpAddress());
-              miniBannedMacAddresses.add(getPlayerMac(node.getPlayerName()));
-              removeConnection(nodeToBan);
-            });
   }
 
   public boolean isModerator(INode node) {

--- a/game-app/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -414,10 +414,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     }
     notifyConnectionsChanged(true, remote);
 
-    if (getModerators().contains(remote)) {
-      nodeToChannel.keySet().forEach(node -> send(new ModeratorPromoted(remote.getName()), node));
-    }
-
     log.info("Connection added to:" + remote);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -407,8 +407,9 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
       nodeToChannel.put(remote, channel);
     }
     channelToNode.put(channel, remote);
-    // only keep track of join order if the game is headless.
-    // If game is not headless, then it will end when the host leaves.
+    // only keep track of join order if the game is headless. If game is not headless,
+    // then it will end when the host leaves (and so we won't need to worry about
+    // promoting a next moderator).
     if (GameRunner.headless()) {
       nodeJoinOrder.add(remote);
     }

--- a/game-app/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -62,7 +62,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
 
   private final Map<UserName, String> cachedMacAddresses = new ConcurrentHashMap<>();
   private final Set<String> miniBannedIpAddresses = new ConcurrentSkipListSet<>();
-  private final Set<String> miniBannedMacAddresses = new ConcurrentSkipListSet<>();
 
   @Setter @Nullable private GameToLobbyConnection gameToLobbyConnection;
 
@@ -170,14 +169,12 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     }
 
     return miniBannedIpAddresses.contains(ip)
-        || miniBannedMacAddresses.contains(mac)
         || (gameToLobbyConnection != null && gameToLobbyConnection.isPlayerBanned(ip));
   }
 
   @Override
   public void banPlayer(final String ip, final String mac) {
     miniBannedIpAddresses.add(ip);
-    miniBannedMacAddresses.add(mac);
   }
 
   /** Bans & disconnects a player. */
@@ -188,7 +185,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
         .ifPresent(
             nodeToBan -> {
               miniBannedIpAddresses.add(nodeToBan.getIpAddress());
-              miniBannedMacAddresses.add(getPlayerMac(node.getPlayerName()));
               removeConnection(nodeToBan);
             });
   }
@@ -360,7 +356,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     notifyPlayerRemoval(nodeToRemove);
     final SocketChannel channel = nodeToChannel.remove(nodeToRemove);
     if (channel == null) {
-      log.warn("Could not find node to remove: " + nodeToRemove);
+      log.warn("Could not find node to remove: {}", nodeToRemove);
       return;
     }
     channelToNode.remove(channel);
@@ -377,7 +373,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     }
 
     notifyConnectionsChanged(false, nodeToRemove);
-    log.info("Connection removed:" + nodeToRemove);
+    log.info("Connection removed: {}", nodeToRemove);
   }
 
   @Override
@@ -415,6 +411,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     }
     notifyConnectionsChanged(true, remote);
 
-    log.info("Connection added to:" + remote);
+    log.info("Connection added to: {}", remote);
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -9,7 +9,6 @@ import games.strategy.engine.message.RemoteMessenger;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
 import games.strategy.net.ClientMessenger;
 import games.strategy.net.IMessenger;
-import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
 import games.strategy.net.ServerMessenger;
 import games.strategy.net.TestServerMessenger;

--- a/game-app/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -11,6 +11,7 @@ import games.strategy.net.ClientMessenger;
 import games.strategy.net.IMessenger;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
+import games.strategy.net.ServerMessenger;
 import games.strategy.net.TestServerMessenger;
 import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
@@ -32,7 +33,7 @@ final class ChatIntegrationTest extends AbstractClientSettingTestCase {
   private static final int MESSAGE_COUNT = 50;
   private static final int NODE_COUNT = 3;
 
-  private IServerMessenger messenger;
+  private ServerMessenger messenger;
   private IMessenger client1Messenger;
   private IMessenger client2Messenger;
   private RemoteMessenger remoteMessenger;
@@ -130,7 +131,7 @@ final class ChatIntegrationTest extends AbstractClientSettingTestCase {
 
   private ChatController newChatController() {
     return new ChatController(
-        CHAT_NAME, new Messengers(messenger, remoteMessenger, channelMessenger));
+        CHAT_NAME, new Messengers(messenger, remoteMessenger, channelMessenger), messenger);
   }
 
   private static Chat newChat(final Messengers messengers) {


### PR DESCRIPTION
Updates to give the host of a network game 'mod' powers. If the game is a bot, then also give the 'oldest' player 'mod' powers.

Mod powers allow: 
- disconnect players
- ban players (effective until restart of bot)

The bot case is interesting since the 'oldest' player can change. For example, two players enter a bot (to the staging screen), first is mod  & then leaves. Now the second player needs to become moderator.

To achieve this we add a "moderator promoted" message which is sent by the server to inform players of the new moderator.


### WIP

TODO:
- cleanup/polish 
- remove the extra stuff (perhaps a few too many listeners thrown in)
- bit more testing
- limit ability to see 'disconnect/ban' to the moderator