### PR TITLE
Simplify zipped maps extraction error handling

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -61,15 +61,15 @@ public class ZippedMapsExtractor {
                         // Before 2.6 maps did not include a 'map.yaml' file and were zipped.
                         .ifPresent(MapDescriptionYaml::generateForMap);
                   } catch (final ZipReadException zipReadException) {
-                    log.warn(
-                        "Error reading zip: {}{}",
-                        mapZip.toAbsolutePath(),
-                        Files.exists(mapZip) ? ", moving to 'bad-zips' folder" : "",
-                        zipReadException);
-
-                    // Problem reading the zip, move it to a folder so that the user does
-                    // not repeatedly see an error trying to read this zip.
-                    if (Files.exists(mapZip)) {
+                    if (GameRunner.headless()) {
+                      log.warn(
+                          "Error reading zip file: {}, deleting the file.",
+                          mapZip,
+                          zipReadException);
+                      FileUtils.delete(mapZip);
+                    } else {
+                      // Problem reading the zip, move it to a folder so that the user does
+                      // not repeatedly see an error trying to read this zip.
                       moveBadZip(mapZip)
                           .ifPresent(
                               newLocation ->


### PR DESCRIPTION
Update to, if a bot - then simply delete the zip file. If not a bot, then move the zip file to bad-zips.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
