### PR TITLE
Map zip extraction: smarter precondition

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -110,8 +110,17 @@ public class ZippedMapsExtractor {
    * @return Returns extracted location (if successful, otherwise empty)
    */
   public static Optional<Path> unzipMap(final Path mapZip) {
+    if (!Files.exists(mapZip)) {
+      String msg =
+          "Unexpected, cannot extract map zip, no file exists at: " + mapZip.toAbsolutePath();
+      if (GameRunner.headless()) {
+        log.warn(msg);
+      } else {
+        log.info(msg);
+      }
+      return Optional.empty();
+    }
     Preconditions.checkArgument(!Files.isDirectory(mapZip), mapZip.toAbsolutePath());
-    Preconditions.checkArgument(Files.exists(mapZip), mapZip.toAbsolutePath());
     Preconditions.checkArgument(
         mapZip.getFileName().toString().endsWith(".zip"), mapZip.toAbsolutePath());
 


### PR DESCRIPTION
Multiple bots starting up at the same time can clobber each others files. This update makes the precondition check during map extraction smarter, to just no-op if the map-to-extract no longer exists.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
