### PR TITLE
Game selector panel fixes: update button text

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -56,12 +56,12 @@ public final class GameSelectorPanel extends JPanel implements Observer {
   private final JButton loadNewGame =
       new JButtonBuilder()
           .title("Select Game")
-          .toolTip("Start a new game or load an autosave from the host server.")
+          .toolTip("Start a new game (autosaves on bot servers will appear here)")
           .build();
 
   private final JButton loadSavedGame =
       new JButtonBuilder()
-          .title("Upload Saved Game")
+          .title("Saved Game")
           .toolTip("Open a game saved on your computer.")
           .build();
 


### PR DESCRIPTION
The button text was updated recently with the mistaken thought the buttons only appeared in bot servers. The buttons actually show up in all cases (single game, hosted game, bot game), hence "upload save game" does not make sense in all of those context.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
