### PR TITLE
Fix for crash during air battle

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/history/change/units/RemoveUnitsHistoryChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/change/units/RemoveUnitsHistoryChange.java
@@ -40,10 +40,10 @@ public class RemoveUnitsHistoryChange implements HistoryChange {
   String messageTemplate;
 
   /** Units that were killed */
-  Collection<Unit> oldUnits = new ArrayList<>();
+  Collection<Unit> oldUnits = new HashSet<>();
 
   /** The units that were created after a transformation */
-  Collection<Unit> newUnits = new ArrayList<>();
+  Collection<Unit> newUnits = new HashSet<>();
 
   /**
    * @param messageTemplate ${units} and ${territory} will be replaced in this template


### PR DESCRIPTION
Problem: 'oldUnits' is stateful and may already contain units. We then "double add" a unit in the following code block

(RemoveUnitsHistoryChange.java:71)

```
    final Collection<Unit> allUnloadedUnits = new HashSet<>();
    for (Unit u : killedUnits) {
      oldUnits.add(u);
```

To resolve this issue, the 'oldUnits' and 'killedUnits' is converted into a set, which removes duplicate units. (This 'fix' is not very deep, arguably this is a hack. Why is the duplicate unit being added in the first place?)

Resolves: #12770

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
