### PR TITLE
Simpler Map unzip - delete old & simple unzip 

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -130,7 +130,9 @@ public class ZippedMapsExtractor {
       final Path extractionTarget =
           mapsFolder.resolve(computeExtractionFolderName(mapZip.getFileName().toString()));
       log.info(
-          "Extracting map zip: {} -> {}", mapZip.toAbsolutePath(), extractionTarget.toAbsolutePath());
+          "Extracting map zip: {} -> {}",
+          mapZip.toAbsolutePath(),
+          extractionTarget.toAbsolutePath());
       FileUtils.deleteDirectory(extractionTarget);
       ZipExtractor.unzipFile(mapZip, extractionTarget);
 
@@ -149,11 +151,10 @@ public class ZippedMapsExtractor {
         return Optional.empty();
       }
     } catch (final IOException e) {
-      log.warn("Error extracting file: {}, {}", mapZip.toAbsolutePath() + ", " + e.getMessage(), e);
+      log.warn("Error extracting file: {}, {}", mapZip.toAbsolutePath(), e.getMessage(), e);
       return Optional.empty();
     }
   }
-
 
   /**
    * Removes the '.zip' or '-master.zip' suffix from map names if present. <br>


### PR DESCRIPTION
Updates map extraction algorithm to the following:
- on startup, or immediately following map download: detect '.zip' file in 'downloadedMaps' folder
- determine target folder for extraction (strip '-master' suffix if present)
- delete target folder
- unzip the zip file to the target folder


The above is simpler notably because we just 'unzip'. Before the algorithm would check the case whether the extracted contents is a single folder, or if the zip contained all the map files in an exploded format. With this update, it does not matter, we just unzip into a destination folder.

The delete is unfortunate but required. Existing maps will potentially have this format: `[map-name]/*`, rather than something like `[map-name]/[map-name-mastter]/*`. Because of this mismatch, if we just extract, then we would wind up with duplicate map files. 



<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
