### PR TITLE
Publish just a standard JAR and not a shadow jar for http-clients

### DIFF
--- a/http-clients/lobby-client/build.gradle
+++ b/http-clients/lobby-client/build.gradle
@@ -34,9 +34,4 @@ publishing {
             }
         }
     }
-    publications {
-        shadow(MavenPublication) { publication ->
-            project.shadow.component(publication)
-        }
-    }
 }


### PR DESCRIPTION
Shadow jar causes version issues for server, since the shadow jar brings in a variety of dependencies that are potentially not compatible.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
