### PR TITLE
Clean up http-clients build (possible fix for "still shadow jar")

### DIFF
--- a/http-clients/lobby-client/build.gradle
+++ b/http-clients/lobby-client/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id("maven-publish")
-    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 version = System.getenv("JAR_VERSION")
@@ -12,16 +11,6 @@ dependencies {
     implementation project(":lib:websocket-client")
     testImplementation project(":lib:test-common")
 }
-
-def getGitCommitCount = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine "git", "rev-list", "--count", "HEAD"
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
-}
-
 
 publishing {
     repositories {


### PR DESCRIPTION
- Remove unused shadowjar plugin and unused method in http-clients build.

On previous builds, a full shadow jar has been published. This update will potentially "fix" that so we publish only a "shallow jar" instead. The transitive dependencies from a 'shadow-jar' are not desired.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
