### PR TITLE
Jar publishing: also publish 'domain-data' jar

### DIFF
--- a/.github/workflows/upload-http-client-jars.yml
+++ b/.github/workflows/upload-http-client-jars.yml
@@ -28,6 +28,6 @@ jobs:
           BUILD_VERSION=$(game-app/run/.build/get-build-version)
           echo "JAR_VERSION=$BUILD_VERSION" | tee -a $GITHUB_ENV
       - name: Publish lobby client JAR
-        run: ./gradlew :http-clients:lobby-client:publish
+        run: ./gradlew :http-clients:lobby-client:publish :game-app:domain-data:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/game-app/domain-data/build.gradle
+++ b/game-app/domain-data/build.gradle
@@ -1,1 +1,30 @@
+import org.gradle.api.publish.maven.MavenPublication
+
+plugins {
+    id 'java-library'
+    id("maven-publish")
+}
+
+version = System.getenv("JAR_VERSION")
+
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact(tasks.named(sourceSets.main.jarTaskName)) {
+                extension 'jar'
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = "https://maven.pkg.github.com/triplea-game/triplea"
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}
 


### PR DESCRIPTION
Now that we no longer publish a shadow jar of 'http-client/lobby', we need to provide dependencies as well.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
