### PR TITLE
Lobby websocket - fix disconnect - increase ping frequency

### DIFF
--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -88,8 +88,8 @@ class WebSocketConnection {
     this.serverUri = serverUri;
     pingSender =
         Timers.fixedRateTimer("websocket-ping-sender")
-            .period(45, TimeUnit.SECONDS)
-            .delay(45, TimeUnit.SECONDS)
+            .period(10, TimeUnit.SECONDS)
+            .delay(10, TimeUnit.SECONDS)
             .task(this::sendPingTask);
     this.headers = headers;
   }


### PR DESCRIPTION
Lobby was upgraded recently to be on a newer version of the server platform. Seemingly the websocket timeout has dropped to 30 seconds. The previous keep-alive of 45 seconds was not enough.

Changing the value to 10 seconds allows for 3 failed tries before a disconnect.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
