### PR TITLE
Sort battles cleanup

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
@@ -21,9 +21,9 @@ public class GameSequence extends GameDataComponent implements Iterable<GameStep
   }
 
   /**
-   * Only used when we are trying to export the data to a savegame, and we need to change the round
-   * and step to something other than the current round and step (because we are creating a savegame
-   * at a certain point in history, for example).
+   * Only used when we are trying to export the data to a save game, and we need to change the round
+   * and step to something other than the current round and step (because we are creating a save
+   * game at a certain point in history, for example).
    */
   public synchronized void setRoundAndStep(
       final int currentRound, final String stepDisplayName, final GamePlayer player) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -227,7 +227,7 @@ public class ServerLauncher implements ILauncher {
         } else {
           final String errorMessage =
               "Unrecognized error occurred. If this is a repeatable error, "
-                  + "please make a copy of this savegame and report to:\n"
+                  + "please make a copy of this save game and report to:\n"
                   + UrlConstants.GITHUB_ISSUES;
           log.error(errorMessage, e);
           stopGame();
@@ -310,7 +310,7 @@ public class ServerLauncher implements ILauncher {
   }
 
   private void saveAndEndGame(final INode node) {
-    // a hack, if headless save to the autosave to avoid polluting our savegames folder with a
+    // a hack, if headless save to the auto save to avoid polluting our save games folder with a
     // million saves
     final Path f = launchAction.getAutoSaveFile();
     try {

--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbem/IEmailSender.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbem/IEmailSender.java
@@ -23,7 +23,7 @@ public interface IEmailSender {
    *
    * @param subject the subject of the email
    * @param htmlMessage the html email body
-   * @param saveGame the savegame or null
+   * @param saveGame the save game or null
    * @throws IOException if an error occurs
    */
   void sendEmail(String subject, String htmlMessage, Path saveGame, String saveGameName)

--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
@@ -162,7 +162,7 @@ public class NodeBbForumPoster {
         return parseSaveGameUrlFromJsonResponse(json);
       }
       throw new IllegalStateException(
-          "Failed to upload savegame, server returned Error Code "
+          "Failed to upload save game, server returned Error Code "
               + status
               + "\nMessage:\n"
               + EntityUtils.toString(response.getEntity()));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -601,7 +601,7 @@ public abstract class AbstractAi extends AbstractBasePlayer {
     // as in the case of a naval battle preceding an amphibious attack, keep trying to fight every
     // battle
     while (true) {
-      final BattleListing listing = battleDelegate.getBattles();
+      final BattleListing listing = battleDelegate.getBattleListing();
       if (listing.isEmpty()) {
         return;
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -605,7 +605,8 @@ public abstract class AbstractAi extends AbstractBasePlayer {
       if (listing.isEmpty()) {
         return;
       }
-      for (final Entry<BattleType, Collection<Territory>> entry : listing.getBattles().entrySet()) {
+      for (final Entry<BattleType, Collection<Territory>> entry :
+          listing.getBattlesMap().entrySet()) {
         for (final Territory current : entry.getValue()) {
           final String error =
               battleDelegate.fightBattle(current, entry.getKey().isBombingRun(), entry.getKey());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -50,7 +50,7 @@ public final class ProSimulateTurnUtils {
 
     final BattleDelegate battleDelegate = data.getBattleDelegate();
     final Map<BattleType, Collection<Territory>> battleTerritories =
-        battleDelegate.getBattles().getBattles();
+        battleDelegate.getBattleListing().getBattles();
     for (final Entry<BattleType, Collection<Territory>> entry : battleTerritories.entrySet()) {
       for (final Territory t : entry.getValue()) {
         final IBattle battle =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -50,7 +50,7 @@ public final class ProSimulateTurnUtils {
 
     final BattleDelegate battleDelegate = data.getBattleDelegate();
     final Map<BattleType, Collection<Territory>> battleTerritories =
-        battleDelegate.getBattleListing().getBattles();
+        battleDelegate.getBattleListing().getBattlesMap();
     for (final Entry<BattleType, Collection<Territory>> entry : battleTerritories.entrySet()) {
       for (final Territory t : entry.getValue()) {
         final IBattle battle =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -1210,7 +1210,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             .and(Matches.unitCanEvade().negate());
     final boolean onlyWhereThereAreBattlesOrAmphibious =
         Properties.getKamikazeSuicideAttacksOnlyWhereBattlesAre(data.getProperties());
-    final Collection<Territory> pendingBattles = battleTracker.getPendingBattleSites(false);
+    final Collection<Territory> pendingBattles =
+        battleTracker.getPendingBattleSitesWithoutBombing();
     // create a list of all kamikaze zones, listed by enemy
     final Map<GamePlayer, Collection<Territory>> kamikazeZonesByEnemy = new HashMap<>();
     for (final Territory t : data.getMap().getTerritories()) {
@@ -1478,7 +1479,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         (Properties.getNeutralFlyoverAllowed(data.getProperties())
             && !Properties.getNeutralsImpassable(data.getProperties()));
     final Set<Territory> canNotLand = new HashSet<>();
-    canNotLand.addAll(battleTracker.getPendingBattleSites(false));
+    canNotLand.addAll(battleTracker.getPendingBattleSitesWithoutBombing());
     canNotLand.addAll(
         CollectionUtils.getMatches(
             data.getMap().getTerritories(), Matches.territoryHasEnemyUnits(alliedPlayer)));
@@ -1519,7 +1520,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                   possibleTerrs,
                   Matches.territoryHasUnitsThatMatch(Matches.unitIsAlliedCarrier(alliedPlayer))
                       .and(Matches.territoryIsWater())));
-      availableWater.removeAll(battleTracker.getPendingBattleSites(false));
+      availableWater.removeAll(battleTracker.getPendingBattleSitesWithoutBombing());
       // simple calculation, either we can take all the air, or we can't, nothing in the middle
       final int carrierCost = AirMovementValidator.carrierCost(strandedAir);
       final Iterator<Territory> waterIter = availableWater.iterator();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -193,7 +193,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
   @Override
   public boolean delegateCurrentlyRequiresUserInput() {
-    final BattleListing battles = getBattles();
+    final BattleListing battles = getBattleListing();
     if (battles.isEmpty()) {
       final IBattle battle = getCurrentBattle();
       return battle != null;
@@ -252,8 +252,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   }
 
   @Override
-  public BattleListing getBattles() {
-    return battleTracker.getPendingBattleSites();
+  public BattleListing getBattleListing() {
+    return battleTracker.getBattleListingFromPendingBattles();
   }
 
   /** Add bombardment units to battles. */
@@ -688,7 +688,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     if (!Properties.getScrambleRulesInEffect(data.getProperties())) {
       return;
     }
-    final BattleListing pendingBattleSites = battleTracker.getPendingBattleSites();
+    final BattleListing pendingBattleSites = battleTracker.getBattleListingFromPendingBattles();
     final Set<Territory> territoriesWithBattles =
         pendingBattleSites.getNormalBattlesIncludingAirBattles();
     if (Properties.getCanScrambleIntoAirBattles(data.getProperties())) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -39,7 +39,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1095,19 +1094,7 @@ public class BattleTracker implements Serializable {
   }
 
   public BattleListing getBattleListingFromPendingBattles() {
-    final Map<BattleType, Collection<Territory>> battles = new EnumMap<>(BattleType.class);
-    pendingBattles.stream()
-        .filter(b -> !b.isEmpty())
-        .forEach(
-            b -> {
-              Collection<Territory> territories = battles.get(b.getBattleType());
-              if (territories == null) {
-                territories = new HashSet<>();
-              }
-              territories.add(b.getTerritory());
-              battles.put(b.getBattleType(), territories);
-            });
-    return new BattleListing(battles);
+    return new BattleListing(pendingBattles);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -1094,7 +1094,7 @@ public class BattleTracker implements Serializable {
         .collect(Collectors.toSet());
   }
 
-  public BattleListing getPendingBattleSites() {
+  public BattleListing getBattleListingFromPendingBattles() {
     final Map<BattleType, Collection<Territory>> battles = new EnumMap<>(BattleType.class);
     pendingBattles.stream()
         .filter(b -> !b.isEmpty())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -38,6 +38,8 @@ import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -433,22 +435,23 @@ public class BattleTracker implements Serializable {
             .or(Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(gamePlayer));
     final Predicate<Territory> conquerable =
         Matches.territoryIsEmptyOfCombatUnits(gamePlayer).and(passableLandAndNotRestricted);
-    final Collection<Territory> conquered = new ArrayList<>();
+    final Collection<Territory> conqueredTerritories = new ArrayList<>();
     if (canConquerMiddleSteps) {
-      conquered.addAll(route.getMatches(conquerable));
+      conqueredTerritories.addAll(route.getMatches(conquerable));
       // in case we begin in enemy territory, and blitz out of it, check the first territory
       if (!route.getStart().equals(route.getEnd()) && conquerable.test(route.getStart())) {
-        conquered.add(route.getStart());
+        conqueredTerritories.add(route.getStart());
       }
     }
     // we handle the end of the route later
-    conquered.remove(route.getEnd());
-    final Collection<Territory> blitzed =
-        CollectionUtils.getMatches(conquered, Matches.territoryIsBlitzable(gamePlayer));
-    this.blitzed.addAll(CollectionUtils.getMatches(blitzed, Matches.isTerritoryEnemy(gamePlayer)));
+    conqueredTerritories.remove(route.getEnd());
+    final Collection<Territory> blitzedTerritories =
+        CollectionUtils.getMatches(conqueredTerritories, Matches.territoryIsBlitzable(gamePlayer));
+    this.blitzed.addAll(
+        CollectionUtils.getMatches(blitzedTerritories, Matches.isTerritoryEnemy(gamePlayer)));
     this.conquered.addAll(
-        CollectionUtils.getMatches(conquered, Matches.isTerritoryEnemy(gamePlayer)));
-    for (final Territory current : conquered) {
+        CollectionUtils.getMatches(conqueredTerritories, Matches.isTerritoryEnemy(gamePlayer)));
+    for (final Territory current : conqueredTerritories) {
       IBattle nonFight = getPendingBattle(current, BattleType.NORMAL);
       // TODO: if we ever want to scramble to a blitzed territory, then we need to fix this
       if (nonFight == null) {
@@ -885,8 +888,10 @@ public class BattleTracker implements Serializable {
         final Map<String, Tuple<String, IntegerMap<UnitType>>> map =
             u.getUnitAttachment().getWhenCapturedChangesInto();
         final GamePlayer currentOwner = u.getOwner();
-        for (final String value : map.keySet()) {
-          final String[] s = Iterables.toArray(Splitter.on(':').split(value), String.class);
+        for (Map.Entry<String, Tuple<String, IntegerMap<UnitType>>> mapEntry :
+            Collections.unmodifiableSet(map.entrySet())) {
+          final String[] s =
+              Iterables.toArray(Splitter.on(':').split(mapEntry.getKey()), String.class);
           if (!(s[0].equals("any")
               || data.getPlayerList().getPlayerId(s[0]).equals(currentOwner))) {
             continue;
@@ -897,7 +902,7 @@ public class BattleTracker implements Serializable {
           }
           final CompositeChange changes = new CompositeChange();
           final Collection<Unit> toAdd = new ArrayList<>();
-          final Tuple<String, IntegerMap<UnitType>> toCreate = map.get(value);
+          final Tuple<String, IntegerMap<UnitType>> toCreate = mapEntry.getValue();
           final boolean translateAttributes = toCreate.getFirst().equalsIgnoreCase("true");
           for (final UnitType ut : toCreate.getSecond().keySet()) {
             toAdd.addAll(ut.create(toCreate.getSecond().getInt(ut), newOwner));
@@ -1036,17 +1041,15 @@ public class BattleTracker implements Serializable {
   }
 
   public Collection<IBattle> getPendingBattles(final Territory t) {
-    return pendingBattles.stream()
-        .filter(b -> b.getTerritory().equals(t))
-        .collect(Collectors.toSet());
+    return CollectionUtils.getMatches(pendingBattles, b -> b.getTerritory().equals(t));
   }
 
   public boolean hasPendingNonBombingBattle(final Territory t) {
-    return getPendingBattle(t) != null;
+    return getPendingNonBombingBattle(t) != null;
   }
 
   @Nullable
-  public IBattle getPendingBattle(final Territory t) {
+  public IBattle getPendingNonBombingBattle(final Territory t) {
     return BattleType.nonBombingBattleTypes().stream()
         .map(type -> getPendingBattle(t, type))
         .filter(Objects::nonNull)
@@ -1056,49 +1059,54 @@ public class BattleTracker implements Serializable {
 
   @Nullable
   public IBattle getPendingBattle(final Territory t, final BattleType type) {
-    for (final IBattle battle : pendingBattles) {
-      if (battle.getTerritory().equals(t) && type == battle.getBattleType()) {
-        return battle;
-      }
-    }
-    return null;
+    return pendingBattles.stream()
+        .filter(b -> b.getBattleType().equals(type) && b.getTerritory().equals(t))
+        .findFirst()
+        .orElse(null);
   }
 
   public IBattle getPendingBattle(final UUID uuid) {
     if (uuid == null) {
       return null;
     }
-
     return pendingBattles.stream().filter(b -> b.getBattleId().equals(uuid)).findAny().orElse(null);
+  }
+
+  /** Returns a collection of territories where no bombing battles are pending. */
+  public Collection<Territory> getPendingBattleSitesWithoutBombing() {
+    return getPendingBattleSites(false);
+  }
+
+  /** Returns a collection of territories where bombing battles are pending. */
+  public Collection<Territory> getPendingBattleSitesWithBombing() {
+    return getPendingBattleSites(true);
   }
 
   /**
    * Returns a collection of territories where battles are pending.
    *
-   * @param bombing whether only battles where there is bombing.
+   * @param bombing whether only battles where there is bombing or where there is no bombing.
    */
-  public Collection<Territory> getPendingBattleSites(final boolean bombing) {
-    final Collection<Territory> battles = new ArrayList<>();
-    for (final IBattle battle : pendingBattles) {
-      if (!battle.isEmpty() && battle.getBattleType().isBombingRun() == bombing) {
-        battles.add(battle.getTerritory());
-      }
-    }
-    return battles;
+  private Collection<Territory> getPendingBattleSites(final boolean bombing) {
+    return pendingBattles.stream()
+        .filter(b -> !b.isEmpty() && b.getBattleType().isBombingRun() == bombing)
+        .map(IBattle::getTerritory)
+        .collect(Collectors.toSet());
   }
 
   public BattleListing getPendingBattleSites() {
-    final Map<BattleType, Collection<Territory>> battles = new HashMap<>();
-    for (final IBattle battle : pendingBattles) {
-      if (!battle.isEmpty()) {
-        Collection<Territory> territories = battles.get(battle.getBattleType());
-        if (territories == null) {
-          territories = new HashSet<>();
-        }
-        territories.add(battle.getTerritory());
-        battles.put(battle.getBattleType(), territories);
-      }
-    }
+    final Map<BattleType, Collection<Territory>> battles = new EnumMap<>(BattleType.class);
+    pendingBattles.stream()
+        .filter(b -> !b.isEmpty())
+        .forEach(
+            b -> {
+              Collection<Territory> territories = battles.get(b.getBattleType());
+              if (territories == null) {
+                territories = new HashSet<>();
+              }
+              territories.add(b.getTerritory());
+              battles.put(b.getBattleType(), territories);
+            });
     return new BattleListing(battles);
   }
 
@@ -1131,9 +1139,9 @@ public class BattleTracker implements Serializable {
   }
 
   private void removeDependency(final IBattle blocked, final IBattle blocking) {
-    final Collection<IBattle> dependencies = this.dependencies.get(blocked);
-    dependencies.remove(blocking);
-    if (dependencies.isEmpty()) {
+    final Collection<IBattle> dependenciesOfBlocked = this.dependencies.get(blocked);
+    dependenciesOfBlocked.remove(blocking);
+    if (dependenciesOfBlocked.isEmpty()) {
       this.dependencies.remove(blocked);
     }
   }
@@ -1204,7 +1212,7 @@ public class BattleTracker implements Serializable {
    */
   void fightAirRaidsAndStrategicBombing(final IDelegateBridge delegateBridge) {
     fightAirRaidsAndStrategicBombing(
-        delegateBridge, () -> getPendingBattleSites(true), this::getPendingBattle);
+        delegateBridge, this::getPendingBattleSitesWithBombing, this::getPendingBattle);
   }
 
   @VisibleForTesting
@@ -1226,7 +1234,7 @@ public class BattleTracker implements Serializable {
       }
     }
 
-    // now that we've done all the air battles, do all the SBR's as a second wave.
+    // now that we've done all the air battles, do all the SBRs as a second wave.
     for (final Territory t : pendingBattleSiteSupplier.get()) {
       final IBattle bombingRaid = pendingBattleFunction.apply(t, BattleType.BOMBING_RAID);
       if (bombingRaid != null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleListing.java
@@ -1,14 +1,17 @@
 package games.strategy.triplea.delegate.data;
 
 import games.strategy.engine.data.Territory;
+import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import lombok.Getter;
 
 /**
@@ -17,31 +20,40 @@ import lombok.Getter;
 @Getter
 public class BattleListing implements Serializable {
   private static final long serialVersionUID = 2700129486225793827L;
-  private final Map<BattleType, Collection<Territory>> battles;
+  private final Map<BattleType, Collection<Territory>> battlesMap;
 
   /**
    * Creates new BattleListing.
    *
    * @param battles battles to list
    */
-  public BattleListing(final Map<BattleType, Collection<Territory>> battles) {
-    this.battles = battles;
+  public BattleListing(final Set<IBattle> battles) {
+    this.battlesMap = new EnumMap<>(BattleType.class);
+    battles.stream()
+        .filter(b -> !b.isEmpty())
+        .forEach(
+            b -> {
+              Collection<Territory> territories = battlesMap.get(b.getBattleType());
+              if (territories == null) {
+                territories = new HashSet<>();
+              }
+              territories.add(b.getTerritory());
+              battlesMap.put(b.getBattleType(), territories);
+            });
   }
 
   public Set<Territory> getNormalBattlesIncludingAirBattles() {
-    final Set<Territory> territories = new HashSet<>();
-    for (final Entry<BattleType, Collection<Territory>> entry : battles.entrySet()) {
-      if (!entry.getKey().isBombingRun()) {
-        territories.addAll(entry.getValue());
-      }
-    }
-    return territories;
+    return getBattlesWith(b -> !b.isBombingRun());
   }
 
   public Set<Territory> getStrategicBombingRaidsIncludingAirBattles() {
+    return getBattlesWith(BattleType::isBombingRun);
+  }
+
+  private Set<Territory> getBattlesWith(Predicate<BattleType> predicate) {
     final Set<Territory> territories = new HashSet<>();
-    for (final Entry<BattleType, Collection<Territory>> entry : battles.entrySet()) {
-      if (entry.getKey().isBombingRun()) {
+    for (final Entry<BattleType, Collection<Territory>> entry : battlesMap.entrySet()) {
+      if (predicate.test(entry.getKey())) {
         territories.addAll(entry.getValue());
       }
     }
@@ -49,11 +61,12 @@ public class BattleListing implements Serializable {
   }
 
   public boolean isEmpty() {
-    return battles.isEmpty();
+    return battlesMap.isEmpty();
   }
 
   public void forEachBattle(BiConsumer<? super BattleType, ? super Territory> action) {
-    for (final Entry<BattleType, Collection<Territory>> battleTypeCollection : battles.entrySet()) {
+    for (final Entry<BattleType, Collection<Territory>> battleTypeCollection :
+        battlesMap.entrySet()) {
       final BattleType battleType = battleTypeCollection.getKey();
       for (final Territory territory : battleTypeCollection.getValue()) {
         action.accept(battleType, territory);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleListing.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import lombok.Getter;
 
 /**
@@ -49,5 +50,14 @@ public class BattleListing implements Serializable {
 
   public boolean isEmpty() {
     return battles.isEmpty();
+  }
+
+  public void forEachBattle(BiConsumer<? super BattleType, ? super Territory> action) {
+    for (final Entry<BattleType, Collection<Territory>> battleTypeCollection : battles.entrySet()) {
+      final BattleType battleType = battleTypeCollection.getKey();
+      for (final Territory territory : battleTypeCollection.getValue()) {
+        action.accept(battleType, territory);
+      }
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
@@ -15,7 +15,7 @@ import org.triplea.java.RemoveOnNextMajorRelease;
 public interface IBattleDelegate extends IRemote, IDelegate {
   /** Returns the battles currently waiting to be fought. */
   @RemoteActionCode(3)
-  BattleListing getBattles();
+  BattleListing getBattleListing();
 
   /**
    * Fight the battle in the given country.

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -32,7 +32,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
 
   private static void fight(final IBattleDelegate battle, final Territory territory) {
     for (final Entry<BattleType, Collection<Territory>> entry :
-        battle.getBattleListing().getBattles().entrySet()) {
+        battle.getBattleListing().getBattlesMap().entrySet()) {
       if (!entry.getKey().isBombingRun() && entry.getValue().contains(territory)) {
         battle.fightBattle(territory, false, entry.getKey());
         return;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -32,7 +32,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
 
   private static void fight(final IBattleDelegate battle, final Territory territory) {
     for (final Entry<BattleType, Collection<Territory>> entry :
-        battle.getBattles().getBattles().entrySet()) {
+        battle.getBattleListing().getBattles().entrySet()) {
       if (!entry.getKey().isBombingRun() && entry.getValue().contains(territory)) {
         battle.fightBattle(territory, false, entry.getKey());
         return;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -800,9 +800,12 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     final IBattle inBrazil =
-        gameData.getBattleDelegate().getBattleTracker().getPendingBattle(brazil);
+        gameData.getBattleDelegate().getBattleTracker().getPendingNonBombingBattle(brazil);
     final IBattle inBrazilSea =
-        gameData.getBattleDelegate().getBattleTracker().getPendingBattle(southBrazilSeaZone);
+        gameData
+            .getBattleDelegate()
+            .getBattleTracker()
+            .getPendingNonBombingBattle(southBrazilSeaZone);
     assertNotNull(inBrazilSea);
     assertNotNull(inBrazil);
     assertEquals(
@@ -837,9 +840,9 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
-        gameData.getBattleDelegate().getBattleTracker().getPendingBattle(finlandNorway);
+        gameData.getBattleDelegate().getBattleTracker().getPendingNonBombingBattle(finlandNorway);
     final IBattle inBalticSeaZone =
-        gameData.getBattleDelegate().getBattleTracker().getPendingBattle(balticSeaZone);
+        gameData.getBattleDelegate().getBattleTracker().getPendingNonBombingBattle(balticSeaZone);
     assertNotNull(balticSeaZone);
     assertNotNull(finlandNorway);
     assertEquals(
@@ -913,9 +916,9 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
-        gameData.getBattleDelegate().getBattleTracker().getPendingBattle(finlandNorway);
+        gameData.getBattleDelegate().getBattleTracker().getPendingNonBombingBattle(finlandNorway);
     final IBattle inBalticSeaZone =
-        gameData.getBattleDelegate().getBattleTracker().getPendingBattle(balticSeaZone);
+        gameData.getBattleDelegate().getBattleTracker().getPendingNonBombingBattle(balticSeaZone);
     assertNotNull(balticSeaZone);
     assertNotNull(finlandNorway);
     assertEquals(
@@ -988,7 +991,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
         karelia.getUnitCollection().getMatches(Matches.isUnitAllied(british)));
     // Set up the battles and the dependent battles
     final IBattle inBalticSeaZone =
-        gameData.getBattleDelegate().getBattleTracker().getPendingBattle(balticSeaZone);
+        gameData.getBattleDelegate().getBattleTracker().getPendingNonBombingBattle(balticSeaZone);
     assertNotNull(balticSeaZone);
     // Add some defending units in case there aren't any
     final List<Unit> defendList = transport.create(1, germans);
@@ -1049,7 +1052,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
         karelia.getUnitCollection().getMatches(Matches.isUnitAllied(british)));
     // Set up the battles and the dependent battles
     final IBattle inBalticSeaZone =
-        gameData.getBattleDelegate().getBattleTracker().getPendingBattle(balticSeaZone);
+        gameData.getBattleDelegate().getBattleTracker().getPendingNonBombingBattle(balticSeaZone);
     assertNotNull(balticSeaZone);
     // Add some defending units in case there aren't any
     final List<Unit> defendList = transport.create(1, germans);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -733,7 +733,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
         moveDelegate.move(sz50.getUnitCollection().getMatches(Matches.unitIsAir()), sz50To45);
     assertNull(error);
     final var battleTracker = AbstractMoveDelegate.getBattleTracker(gameData);
-    assertEquals(1, battleTracker.getPendingBattleSites(false).size());
+    assertEquals(1, battleTracker.getPendingBattleSitesWithoutBombing().size());
     // we should be able to move the sub out of the sz
     final Route sz45To50 = new Route(sz45, sz50);
     final List<Unit> japSub =
@@ -743,14 +743,14 @@ class RevisedTest extends AbstractClientSettingTestCase {
     // make sure no error
     assertNull(error);
     // make sure the battle is still there
-    assertEquals(1, battleTracker.getPendingBattleSites(false).size());
+    assertEquals(1, battleTracker.getPendingBattleSitesWithoutBombing().size());
     // we should be able to undo the move of the sub
     error = moveDelegate.undoMove(1);
     assertNull(error);
     // undo the move of the fighter, should be no battles now
     error = moveDelegate.undoMove(0);
     assertNull(error);
-    assertEquals(0, battleTracker.getPendingBattleSites(false).size());
+    assertEquals(0, battleTracker.getPendingBattleSitesWithoutBombing().size());
   }
 
   @Test
@@ -839,7 +839,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
     assertValid(validResults);
     moveDelegate(gameData).end();
     battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(fic);
+        (MustFightBattle)
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(fic);
     // fight
     whenGetRandom(delegateBridge).thenAnswer(withValues(0)).thenAnswer(withValues(5));
     battle.fight(delegateBridge);
@@ -988,7 +989,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
@@ -1017,7 +1018,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
@@ -1047,7 +1048,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
@@ -1092,7 +1093,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     /*
      * Here are the exact errata clarifications on how REVISED rules subs work:
@@ -1163,7 +1164,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     /*
      * Here are the exact errata clarifications on how REVISED rules subs work:
@@ -1233,7 +1234,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
@@ -1288,7 +1289,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     /*
      * Here are the exact errata clarifications on how REVISED rules subs work:
@@ -1358,7 +1359,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
@@ -1520,7 +1521,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
         new Route(sz6, uk));
     // fight the battle
     moveDelegate(gameData).end();
-    final IBattle battle = AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz6);
+    final IBattle battle =
+        AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(sz6);
     // everything hits, this will kill both transports
     whenGetRandom(bridge).thenAnswer(withValues(0, 0)).thenAnswer(withValues(0, 0));
     battle.fight(bridge);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -392,7 +392,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     // the transport was not removed automatically
     assertEquals(3, sz13.getUnitCollection().size());
     final BattleDelegate bd = battleDelegate(gameData);
-    assertFalse(bd.getBattleTracker().getPendingBattleSites(false).isEmpty());
+    assertFalse(bd.getBattleTracker().getPendingBattleSitesWithoutBombing().isEmpty());
   }
 
   @Test
@@ -535,7 +535,8 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     // we should not be able to retreat to east poland!
     // that territory is still owned by the enemy
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(ukraine);
+        (MustFightBattle)
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(ukraine);
     assertFalse(battle.getAttackerRetreatTerritories().contains(eastPoland));
   }
 
@@ -561,7 +562,8 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     // we should not be able to retreat to east poland!
     // that territory was just conquered
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(ukraine);
+        (MustFightBattle)
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(ukraine);
     assertTrue(battle.getAttackerRetreatTerritories().contains(eastPoland));
   }
 
@@ -1029,7 +1031,8 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     // move again
     move(sz14.getUnitCollection().getMatches(Matches.unitIsNotSeaTransport()), r);
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz12);
+        (MustFightBattle)
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(sz12);
     // only 3 attacking units
     // the battleship and the two cruisers
     assertEquals(3, mfb.getAttackingUnits().size());
@@ -1074,7 +1077,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
@@ -1116,7 +1119,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
@@ -1163,7 +1166,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
@@ -1211,7 +1214,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle)
-            AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
@@ -1278,7 +1281,8 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     battleDelegate(gameData).addBombardmentSources();
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg);
+        (MustFightBattle)
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(eg);
     // only 2 ships are allowed to bombard (there are 1 battleship and 2 cruisers that COULD
     // bombard, but only 2 ships may bombard total)
     assertEquals(2, mfb.getBombardingUnits().size());
@@ -1349,7 +1353,8 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     battleDelegate(gameData).addBombardmentSources();
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg);
+        (MustFightBattle)
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(eg);
     assertNotNull(mfb);
     // Show that bombard casualties can return fire
     // destroyer bombard hit/miss on rolls of 4 & 3
@@ -1402,7 +1407,8 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     battleDelegate(gameData).addBombardmentSources();
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg);
+        (MustFightBattle)
+            AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(eg);
     // only 2 battleships are allowed to bombard
     assertEquals(2, mfb.getBombardingUnits().size());
   }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -151,7 +151,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
 
   private static void fight(final BattleDelegate battle, final Territory territory) {
     for (final Entry<BattleType, Collection<Territory>> entry :
-        battle.getBattleListing().getBattles().entrySet()) {
+        battle.getBattleListing().getBattlesMap().entrySet()) {
       if (!entry.getKey().isBombingRun() && entry.getValue().contains(territory)) {
         battle.fightBattle(territory, false, entry.getKey());
         return;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -151,7 +151,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
 
   private static void fight(final BattleDelegate battle, final Territory territory) {
     for (final Entry<BattleType, Collection<Territory>> entry :
-        battle.getBattles().getBattles().entrySet()) {
+        battle.getBattleListing().getBattles().entrySet()) {
       if (!entry.getKey().isBombingRun() && entry.getValue().contains(territory)) {
         battle.fightBattle(territory, false, entry.getKey());
         return;
@@ -478,7 +478,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     final BattleDelegate battleDelegate = battleDelegate(gameData);
     battleDelegate.setDelegateBridgeAndPlayer(bridge);
     battleDelegate.start();
-    assertTrue(battleDelegate.getBattles().isEmpty());
+    assertTrue(battleDelegate.getBattleListing().isEmpty());
   }
 
   @Test
@@ -1055,7 +1055,10 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     // undo it
     move.undoMove(0);
     // verify both blitz battles were cleared
-    assertTrue(AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattleSites().isEmpty());
+    assertTrue(
+        AbstractMoveDelegate.getBattleTracker(gameData)
+            .getBattleListingFromPendingBattles()
+            .isEmpty());
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -76,7 +76,7 @@ class WW2V3Year42Test {
         new Route(baltic, karrelia));
     final BattleTracker battleTracker = MoveDelegate.getBattleTracker(gameData);
     // we should have a pending land battle, and a pending bombing raid
-    assertNotNull(battleTracker.getPendingBattle(karrelia));
+    assertNotNull(battleTracker.getPendingNonBombingBattle(karrelia));
     assertNotNull(battleTracker.getPendingBombingBattle(karrelia));
     // the territory should not be conquered
     assertEquals(karrelia.getOwner(), russians(gameData));
@@ -100,7 +100,7 @@ class WW2V3Year42Test {
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     // all units in sz5 should be involved in the battle
-    final IBattle battle = MoveDelegate.getBattleTracker(gameData).getPendingBattle(sz5);
+    final IBattle battle = MoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(sz5);
     assertEquals(5, battle.getAttackingUnits().size());
   }
 
@@ -125,7 +125,7 @@ class WW2V3Year42Test {
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     // all units in sz5 should be involved in the battle except the italian carrier
-    final IBattle battle = MoveDelegate.getBattleTracker(gameData).getPendingBattle(sz5);
+    final IBattle battle = MoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(sz5);
     assertEquals(6, battle.getAttackingUnits().size());
   }
 
@@ -149,7 +149,7 @@ class WW2V3Year42Test {
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     // all units in sz5 should be involved in the battle
-    final IBattle battle = MoveDelegate.getBattleTracker(gameData).getPendingBattle(sz5);
+    final IBattle battle = MoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(sz5);
     assertEquals(4, battle.getAttackingUnits().size());
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleTest.java
@@ -79,7 +79,7 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
 
     final IDelegateBridge bridge = performCombatMove(usa, sz33.getUnits(), new Route(sz33, sz40));
     final IBattle battle =
-        AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(sz40);
+        AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingNonBombingBattle(sz40);
     assertNotNull(battle);
 
     // Set first roll to hit (mine AA) and check that both units are killed
@@ -104,7 +104,7 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
     battleDelegate(twwGameData).setDelegateBridgeAndPlayer(bridge);
     BattleDelegate.doInitialize(battleDelegate(twwGameData).getBattleTracker(), bridge);
     final IBattle battle =
-        AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(celebes);
+        AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingNonBombingBattle(celebes);
     assertNotNull(battle);
 
     // Ensure battle ends, both units remain, and has 0 rolls
@@ -145,7 +145,8 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
     final IDelegateBridge bridge =
         performCombatMove(japan(gameData), attackers, new Route(indoChina, burma));
 
-    final IBattle battle = AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(burma);
+    final IBattle battle =
+        AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(burma);
     assertNotNull(battle);
 
     // Attacking infantry roll two dice (both hit, killing the defenders).
@@ -195,7 +196,7 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
         performCombatMove(chinese(gameData), attackers, new Route(china, indoChina));
 
     final IBattle battle =
-        AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(indoChina);
+        AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(indoChina);
     assertNotNull(battle);
 
     whenGetRandom(bridge)
@@ -279,7 +280,8 @@ class MustFightBattleTest extends AbstractClientSettingTestCase {
     final IDelegateBridge bridge =
         performCombatMove(GameDataTestUtil.germany(gameData), attackers, new Route(sz25, sz23));
 
-    final IBattle battle = AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz23);
+    final IBattle battle =
+        AbstractMoveDelegate.getBattleTracker(gameData).getPendingNonBombingBattle(sz23);
     assertNotNull(battle);
     // Attacking battleship rolls a die with a hit, killing the destroyer.
     // Defenders should roll a die with a hit, damaging the battleship.

--- a/game-app/game-core/src/test/resources/required-op-codes.csv
+++ b/game-app/game-core/src/test/resources/required-op-codes.csv
@@ -127,7 +127,7 @@
 15,games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate,setDelegateBridgeAndPlayer,games.strategy.engine.delegate.IDelegateBridge
 0,games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate,delegateCurrentlyRequiresUserInput
 2,games.strategy.triplea.delegate.remote.IBattleDelegate,fightBattle,games.strategy.engine.data.Territory,boolean,games.strategy.triplea.delegate.battle.IBattle$BattleType
-3,games.strategy.triplea.delegate.remote.IBattleDelegate,getBattles
+3,games.strategy.triplea.delegate.remote.IBattleDelegate,getBattleListing
 5,games.strategy.triplea.delegate.remote.IBattleDelegate,getCurrentBattle
 7,games.strategy.triplea.delegate.remote.IBattleDelegate,getName
 1,games.strategy.triplea.delegate.remote.IBattleDelegate,end

--- a/game-app/game-headed/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
@@ -28,7 +28,7 @@ public final class UpdateChecks {
   }
 
   private static boolean shouldRun() {
-    // if we are joining a game online, or hosting, or loading straight into a savegame, do not
+    // if we are joining a game online, or hosting, or loading straight into a save game, do not
     // check
     return !System.getProperty(TRIPLEA_SERVER, "false").equalsIgnoreCase("true")
         && !System.getProperty(TRIPLEA_CLIENT, "false").equalsIgnoreCase("true")

--- a/game-app/game-headed/src/main/java/games/strategy/engine/posted/game/ForumPosterComponent.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/posted/game/ForumPosterComponent.java
@@ -6,7 +6,7 @@ import games.strategy.engine.posted.game.pbem.PbemMessagePoster;
 import games.strategy.engine.random.IRandomStats;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
-import games.strategy.triplea.ui.ActionButtons;
+import games.strategy.triplea.ui.ActionButtonsPanel;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.history.HistoryLog;
 import java.util.Collection;
@@ -120,7 +120,7 @@ public final class ForumPosterComponent extends JPanel {
         new JButtonBuilder()
             .title("Done")
             .actionListener(doneAction)
-            .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
+            .toolTip(ActionButtonsPanel.DONE_BUTTON_TOOLTIP)
             .build());
     validate();
     return this;

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -134,7 +134,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
     }
     if (ui == null) {
       // We will get here if we are loading a save game of a map that we do not have. Caller code
-      // should be doing the error handling, so just return..
+      // should be doing the error handling, so just return.
       return;
     }
     // TODO: parsing which UI thing we should run based on the string name of a possibly extended
@@ -144,7 +144,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
     // This is how we find out our game step: getGameData().getSequence().getStep()
     // The game step contains information, like the exact delegate and the delegate's class,
     // that we can further use if needed. This is how we get our communication bridge for affecting
-    // the gamedata:
+    // the game data:
     // (ISomeDelegate) getPlayerBridge().getRemote()
     // We should never touch the game data directly. All changes to game data are done through the
     // remote, which then changes the game using the DelegateBridge -> change factory
@@ -612,7 +612,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
     if (!soundPlayedAlreadyEndTurn
         && TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(
             this.getGamePlayer(), getGameData().getMap())) {
-      // do not play if we are reloading a savegame from pbem (gets annoying)
+      // do not play if we are reloading a save game from pbem (gets annoying)
       if (!endTurnDelegate.getHasPostedTurnSummary()) {
         playSound(SoundPath.CLIP_PHASE_END_TURN);
       }
@@ -635,7 +635,7 @@ public class TripleAPlayer extends AbstractBasePlayer {
       final Collection<Unit> amphibiousLandAttackers,
       final CasualtyList defaultCasualties,
       final UUID battleId,
-      final Territory battlesite,
+      final Territory battleTerritory,
       final boolean allowMultipleHitsPerUnit) {
     return ui.getBattlePanel()
         .getCasualties(

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -525,15 +525,15 @@ public class TripleAPlayer extends AbstractBasePlayer {
       if (getPlayerBridge().isGameOver()) {
         return;
       }
-      final BattleListing battles = battleDel.getBattles();
-      if (battles.isEmpty()) {
+      final BattleListing battleListing = battleDel.getBattleListing();
+      if (battleListing.isEmpty()) {
         return;
       }
       if (!soundPlayedAlreadyBattle) {
         playSound(SoundPath.CLIP_PHASE_BATTLE);
         soundPlayedAlreadyBattle = true;
       }
-      final FightBattleDetails details = ui.getBattle(gamePlayer, battles.getBattles());
+      final FightBattleDetails details = ui.getBattle(gamePlayer, battleListing);
       if (getPlayerBridge().isGameOver()) {
         return;
       }

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
@@ -82,7 +82,7 @@ public class BattleCalculatorDialog extends JDialog {
           }
         });
 
-    taFrame.getTerritoryDetails().addBattleCalculatorKeyBindings(dialog);
+    taFrame.getTerritoryDetailPanel().addBattleCalculatorKeyBindings(dialog);
     // close when hitting the escape key
     SwingKeyBinding.addKeyBinding(
         dialog,

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/ActionButtonsPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/ActionButtonsPanel.java
@@ -13,7 +13,7 @@ import games.strategy.engine.posted.game.MoveForumPosterPanel;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.attachments.UserActionAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate.MoveType;
-import games.strategy.triplea.delegate.battle.IBattle.BattleType;
+import games.strategy.triplea.delegate.data.BattleListing;
 import games.strategy.triplea.delegate.data.FightBattleDetails;
 import games.strategy.triplea.delegate.data.TechRoll;
 import games.strategy.triplea.delegate.remote.IPoliticsDelegate;
@@ -152,8 +152,7 @@ public class ActionButtonsPanel extends JPanel {
     changeTo(gamePlayer, placePanel);
   }
 
-  public void changeToBattle(
-      final GamePlayer gamePlayer, final Map<BattleType, Collection<Territory>> battles) {
+  public void changeToBattle(final GamePlayer gamePlayer, final BattleListing battles) {
     if (battlePanel != null) {
       battlePanel.setBattlesAndBombing(battles);
     }

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/ActionButtonsPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/ActionButtonsPanel.java
@@ -40,7 +40,7 @@ import org.triplea.swing.key.binding.SwingKeyBinding;
 import org.triplea.util.Tuple;
 
 /** Root panel for all action buttons in a triplea game. */
-public class ActionButtons extends JPanel {
+public class ActionButtonsPanel extends JPanel {
   public static final String DONE_BUTTON_TOOLTIP =
       "Press ctrl+enter or click this button to end the current turn phase";
   private static final long serialVersionUID = 2175685892863042399L;
@@ -64,7 +64,7 @@ public class ActionButtons extends JPanel {
 
   private @Nullable ActionPanel actionPanel;
 
-  public ActionButtons(
+  public ActionButtonsPanel(
       final GameData data,
       final MapPanel map,
       final MovePanel movePanel,
@@ -190,7 +190,7 @@ public class ActionButtons extends JPanel {
     // newCurrent might be null if we are shutting down
     if (newCurrent != null) {
       newCurrent.display(gamePlayer);
-      SwingUtilities.invokeLater(() -> layout.show(ActionButtons.this, newCurrent.toString()));
+      SwingUtilities.invokeLater(() -> layout.show(ActionButtonsPanel.this, newCurrent.toString()));
     }
   }
 

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -126,7 +126,7 @@ public abstract class ActionPanel extends JPanel {
     return new JButtonBuilder()
         .title("Done")
         .actionListener(this::performDone)
-        .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
+        .toolTip(ActionButtonsPanel.DONE_BUTTON_TOOLTIP)
         .build();
   }
 

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -51,9 +51,9 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.AirBattle;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.battle.ScrambleLogic;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
+import games.strategy.triplea.delegate.data.BattleListing;
 import games.strategy.triplea.delegate.data.FightBattleDetails;
 import games.strategy.triplea.delegate.data.TechResults;
 import games.strategy.triplea.delegate.data.TechRoll;
@@ -695,8 +695,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     actionButtonsPanel.waitForEndTurn(this, bridge);
   }
 
-  public FightBattleDetails getBattle(
-      final GamePlayer player, final Map<BattleType, Collection<Territory>> battles) {
+  public FightBattleDetails getBattle(final GamePlayer player, final BattleListing battles) {
     messageAndDialogThreadPool.waitForAll();
     actionButtonsPanel.changeToBattle(player, battles);
     return actionButtonsPanel.waitForBattleSelection();

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -72,7 +72,7 @@ public class HeadlessGameServer {
       log.info("Changed to game map: {}", gameName);
     } else if (AutoSaveFileUtils.getAutoSaveFiles().contains(gameName)) {
       // change to autosave
-      log.info("Loading {} as a savegame", gameName);
+      log.info("Loading {} as a save game", gameName);
       AutoSaveFileUtils.getAutoSavePaths().stream()
           .filter(p -> p.toFile().getName().equals(gameName))
           .findAny()
@@ -84,7 +84,7 @@ public class HeadlessGameServer {
                       gameName,
                       AutoSaveFileUtils.getAutoSavePaths()));
     } else {
-      log.warn("Unable to find save game as either a new map or a savegame: {}", gameName);
+      log.warn("Unable to find save game as either a new map or a save game: {}", gameName);
     }
   }
 


### PR DESCRIPTION
Panel "Actions" has no sorting order for battles. @DanVanAtta mentioned also that the order might change after saving and reloading a game.
This PR is cleaning up the files in order to allow a sorting. The strategy is that `BattleListing` is used and passed around instead of the contained map.
Also the map is now an `EnumMap` build in `BattleListing`.

- tested save & reload game files
