### PR TITLE
RepairRule as subclass to ProductionRule

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
@@ -8,8 +8,8 @@ import org.triplea.java.collections.IntegerMap;
 public class ProductionRule extends DefaultNamed implements Rule {
   private static final long serialVersionUID = -6598296283127741307L;
 
-  private IntegerMap<Resource> costs = new IntegerMap<>();
-  private IntegerMap<NamedAttachable> results = new IntegerMap<>();
+  protected IntegerMap<Resource> costs = new IntegerMap<>();
+  protected IntegerMap<NamedAttachable> results = new IntegerMap<>();
 
   public ProductionRule(final String name, final GameData data) {
     super(name, data);
@@ -41,7 +41,7 @@ public class ProductionRule extends DefaultNamed implements Rule {
 
   @Override
   public String toString() {
-    return "ProductionRule:" + getName();
+    return "ProductionRule: " + getName();
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
@@ -5,11 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import org.triplea.java.collections.IntegerMap;
 
 /** A repair rule. */
-public class RepairRule extends DefaultNamed implements Rule {
+public class RepairRule extends ProductionRule {
   private static final long serialVersionUID = -45646671022993959L;
-
-  private final IntegerMap<Resource> costs;
-  private final IntegerMap<NamedAttachable> results;
 
   public RepairRule(final String name, final GameData data) {
     this(name, data, new IntegerMap<>(), new IntegerMap<>());
@@ -20,31 +17,14 @@ public class RepairRule extends DefaultNamed implements Rule {
       final GameData data,
       final IntegerMap<NamedAttachable> results,
       final IntegerMap<Resource> costs) {
-    super(name, data);
+    super(name, data, results, costs);
 
     checkNotNull(results);
     checkNotNull(costs);
-
-    this.costs = new IntegerMap<>(costs);
-    this.results = new IntegerMap<>(results);
-  }
-
-  public void addCost(final Resource resource, final int quantity) {
-    costs.put(resource, quantity);
-  }
-
-  @Override
-  public IntegerMap<Resource> getCosts() {
-    return new IntegerMap<>(costs);
-  }
-
-  @Override
-  public IntegerMap<NamedAttachable> getResults() {
-    return results;
   }
 
   @Override
   public String toString() {
-    return "RepairRule:" + getName();
+    return "RepairRule: " + getName();
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRules.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRules.java
@@ -8,21 +8,21 @@ import java.util.Map;
 public class RepairRules extends GameDataComponent {
   private static final long serialVersionUID = 8153102637443800391L;
 
-  private final Map<String, RepairRule> repairRules = new HashMap<>();
+  private final Map<String, RepairRule> mapRepairRules = new HashMap<>();
 
   public RepairRules(final GameData data) {
     super(data);
   }
 
   public void addRepairRule(final RepairRule pf) {
-    repairRules.put(pf.getName(), pf);
+    mapRepairRules.put(pf.getName(), pf);
   }
 
   public RepairRule getRepairRule(final String name) {
-    return repairRules.get(name);
+    return mapRepairRules.get(name);
   }
 
   public Collection<RepairRule> getRepairRules() {
-    return repairRules.values();
+    return mapRepairRules.values();
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -149,7 +149,7 @@ public final class GameParser {
             log.warn("Game engine not compatible with: " + xmlFile, e);
             return null;
           } catch (final Exception e) {
-            log.error("Could not parse:" + xmlFile + ", " + e.getMessage(), e);
+            log.error("Could not parse: " + xmlFile + ", " + e.getMessage(), e);
             return null;
           }
         });
@@ -261,7 +261,7 @@ public final class GameParser {
 
   private GamePlayer getPlayerId(final String name) throws GameParseException {
     return getPlayerIdOptional(name)
-        .orElseThrow(() -> new GameParseException("Could not find player name:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find player name: " + name));
   }
 
   private Optional<GamePlayer> getPlayerIdOptional(final String name) {
@@ -270,34 +270,34 @@ public final class GameParser {
 
   private RelationshipType getRelationshipType(final String name) throws GameParseException {
     return Optional.ofNullable(data.getRelationshipTypeList().getRelationshipType(name))
-        .orElseThrow(() -> new GameParseException("Could not find relationship type:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find relationship type: " + name));
   }
 
   private TerritoryEffect getTerritoryEffect(final String name) throws GameParseException {
     return Optional.ofNullable(data.getTerritoryEffectList().get(name))
-        .orElseThrow(() -> new GameParseException("Could not find territoryEffect:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find territoryEffect: " + name));
   }
 
   /** If the productionRule cannot be found an exception will be thrown. */
   private ProductionRule getProductionRule(final String name) throws GameParseException {
     return Optional.ofNullable(data.getProductionRuleList().getProductionRule(name))
-        .orElseThrow(() -> new GameParseException("Could not find production rule:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find production rule: " + name));
   }
 
   /** If the repairRule cannot be found an exception will be thrown. */
   private RepairRule getRepairRule(final String name) throws GameParseException {
     return Optional.ofNullable(data.getRepairRules().getRepairRule(name))
-        .orElseThrow(() -> new GameParseException("Could not find repair rule:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find repair rule: " + name));
   }
 
   private Territory getTerritory(final String name) throws GameParseException {
     return Optional.ofNullable(data.getMap().getTerritory(name))
-        .orElseThrow(() -> new GameParseException("Could not find territory:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find territory: " + name));
   }
 
   private UnitType getUnitType(final String name) throws GameParseException {
     return getUnitTypeOptional(name)
-        .orElseThrow(() -> new GameParseException("Could not find unitType:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find unitType: " + name));
   }
 
   /** If mustfind is true and cannot find the unitType an exception will be thrown. */
@@ -309,18 +309,18 @@ public final class GameParser {
     final TechnologyFrontier frontier = data.getTechnologyFrontier();
     return Optional.ofNullable(frontier.getAdvanceByName(name))
         .or(() -> Optional.ofNullable(frontier.getAdvanceByProperty(name)))
-        .orElseThrow(() -> new GameParseException("Could not find technology:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find technology: " + name));
   }
 
   /** If the Delegate cannot be found an exception will be thrown. */
   private IDelegate getDelegate(final String name) throws GameParseException {
     return Optional.ofNullable(data.getDelegate(name))
-        .orElseThrow(() -> new GameParseException("Could not find delegate:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find delegate: " + name));
   }
 
   private Resource getResource(final String name) throws GameParseException {
     return getResourceOptional(name)
-        .orElseThrow(() -> new GameParseException("Could not find resource:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find resource: " + name));
   }
 
   /** If mustfind is true and cannot find the Resource an exception will be thrown. */
@@ -331,13 +331,13 @@ public final class GameParser {
   /** If the productionFrontier cannot be found an exception will be thrown. */
   private ProductionFrontier getProductionFrontier(final String name) throws GameParseException {
     return Optional.ofNullable(data.getProductionFrontierList().getProductionFrontier(name))
-        .orElseThrow(() -> new GameParseException("Could not find production frontier:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find production frontier: " + name));
   }
 
   /** If the repairFrontier cannot be found an exception will be thrown. */
   private RepairFrontier getRepairFrontier(final String name) throws GameParseException {
     return Optional.ofNullable(data.getRepairFrontierList().getRepairFrontier(name))
-        .orElseThrow(() -> new GameParseException("Could not find repair frontier:" + name));
+        .orElseThrow(() -> new GameParseException("Could not find repair frontier: " + name));
   }
 
   private void parseTerritories(
@@ -616,7 +616,7 @@ public final class GameParser {
 
   private void parseRepairRules(final List<Production.RepairRule> elements)
       throws GameParseException {
-    for (final Production.ProductionRule current : elements) {
+    for (final Production.RepairRule current : elements) {
       final RepairRule rule = new RepairRule(current.getName(), data);
       parseCosts(rule, current.getCosts());
       parseResults(rule, current.getResults());
@@ -765,7 +765,7 @@ public final class GameParser {
         ta = data.getTechnologyFrontier().getAdvanceByName(current.getName());
       }
       if (ta == null) {
-        throw new GameParseException("Technology not found :" + current.getName());
+        throw new GameParseException("Technology not found : " + current.getName());
       }
       frontier.addAdvance(ta);
     }

--- a/game-app/map-data/src/main/java/org/triplea/map/data/elements/Production.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/data/elements/Production.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
@@ -41,7 +42,7 @@ public class Production {
   private List<PlayerRepair> playerRepairs;
 
   @Getter
-  @Builder
+  @SuperBuilder
   @NoArgsConstructor
   @AllArgsConstructor
   public static class ProductionRule {
@@ -74,39 +75,8 @@ public class Production {
     }
   }
 
-  @Getter
-  @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class RepairRule {
-    @XmlAttribute @Attribute private String name;
-
-    @XmlElement(name = "cost")
-    @TagList
-    private List<ProductionRule.Cost> costs;
-
-    @XmlElement(name = "result")
-    @TagList
-    private List<ProductionRule.Result> results;
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Cost {
-      @XmlAttribute @Attribute private String resource;
-      @XmlAttribute @Attribute private String quantity;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Result {
-      @XmlAttribute @Attribute private String resourceOrUnit;
-      @XmlAttribute @Attribute private String quantity;
-    }
-  }
+  @SuperBuilder
+  public static class RepairRule extends ProductionRule {}
 
   @Getter
   @Builder

--- a/game-app/map-data/src/main/java/org/triplea/map/data/elements/Production.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/data/elements/Production.java
@@ -75,8 +75,39 @@ public class Production {
     }
   }
 
-  @SuperBuilder
-  public static class RepairRule extends ProductionRule {}
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class RepairRule {
+    @XmlAttribute @Attribute private String name;
+
+    @XmlElement(name = "cost")
+    @TagList
+    private List<ProductionRule.Cost> costs;
+
+    @XmlElement(name = "result")
+    @TagList
+    private List<ProductionRule.Result> results;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Cost {
+      @XmlAttribute @Attribute private String resource;
+      @XmlAttribute @Attribute private String quantity;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Result {
+      @XmlAttribute @Attribute private String resourceOrUnit;
+      @XmlAttribute @Attribute private String quantity;
+    }
+  }
 
   @Getter
   @Builder


### PR DESCRIPTION
GameParser.java
- use method replace instead of replaceAll
- remove methods parseRepairCosts and parseRepairResults
- parseRepairRules to reuse methods parseCosts and parseResults

Production.java
- reverted in 2nd commit: let inner class RepairRule extend from inner class ProductionRule

ProductionRule.java
- make private fields protected for visibility after inheritance

RepairRule.java
- inherit from ProductionRule and remove duplicates