### PR TITLE
Email input field validations (post-work to PR 13230)

### DIFF
--- a/game-app/domain-data/src/main/java/org/triplea/domain/data/LobbyConstants.java
+++ b/game-app/domain-data/src/main/java/org/triplea/domain/data/LobbyConstants.java
@@ -13,7 +13,5 @@ public class LobbyConstants {
   // The maximum email address length is 254
   // https://www.directedignorance.com/blog/maximum-length-of-email-address.
   public static final int EMAIL_MAX_LENGTH = 254;
-  // 254 * 4 + 3 = 1019 Three max length emails with 3 spaces to separate.
-  public static final int EMAIL_INPUT_FIELD_MAX_LENGTH = 1019;
   public static final int PASSWORD_MIN_LENGTH = 3;
 }

--- a/game-app/domain-data/src/main/java/org/triplea/domain/data/PlayerEmailValidation.java
+++ b/game-app/domain-data/src/main/java/org/triplea/domain/data/PlayerEmailValidation.java
@@ -7,59 +7,51 @@ import org.jetbrains.annotations.NonNls;
 @UtilityClass
 public final class PlayerEmailValidation {
 
+  @NonNls private static final String QUOTED_STRING_REGEX = "\"(?:[^\"\\\\]|\\\\\\p{ASCII})*\"";
+  @NonNls private static final String ATOM_REGEX = "[^()<>@,;:\\\\\".\\[\\] \\x28\\p{Cntrl}]+";
+
+  @NonNls
+  private static final String WORD_REGEX = "(?:" + ATOM_REGEX + "|" + QUOTED_STRING_REGEX + ")";
+
+  @NonNls
+  private static final String SUBDOMAIN_REGEX =
+      "(?:" + ATOM_REGEX + "|\\[(?:[^\\[\\]\\\\]|\\\\\\p{ASCII})*\\])";
+
+  @NonNls
+  private static final String DOMAIN_REGEX = SUBDOMAIN_REGEX + "(?:\\." + SUBDOMAIN_REGEX + ")*";
+
+  @NonNls private static final String LOCAL_PART_REGEX = WORD_REGEX + "(?:\\." + WORD_REGEX + ")*";
+  @NonNls private static final String EMAIL_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+
   public static boolean isValid(final String emailAddress) {
     return validate(emailAddress) == null;
   }
 
-  /** Allow multiple fully qualified email addresses separated by spaces, or a blank string. */
-  public static String validate(final String emailAddress) {
-    final String quotedString = "\"(?:[^\"\\\\]|\\\\\\p{ASCII})*\"";
-    @NonNls final String atom = "[^()<>@,;:\\\\\".\\[\\] \\x28\\p{Cntrl}]+";
-    @NonNls final String word = "(?:" + atom + "|" + quotedString + ")";
-    @NonNls final String subdomain = "(?:" + atom + "|\\[(?:[^\\[\\]\\\\]|\\\\\\p{ASCII})*\\])";
-    @NonNls final String domain = subdomain + "(?:\\." + subdomain + ")*";
-    @NonNls final String localPart = word + "(?:\\." + word + ")*";
-    @NonNls final String email = localPart + "@" + domain;
+  public static boolean areValid(final String emailAddresses) {
     // Split at every space that was not quoted since addresses like "Email Name"123@some.com are
     // valid.
-    String[] addresses = emailAddress.split(" (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
-    StringBuilder sbInvalidAddresses = new StringBuilder();
-    StringBuilder sbTooLongAddresses = new StringBuilder();
-    for (int i = 0; i < addresses.length; i++) {
-      if (!addresses[i].matches(email)) {
-        if (sbInvalidAddresses.isEmpty()) {
-          sbInvalidAddresses.append(addresses[i]);
-        } else {
-          sbInvalidAddresses.append("; " + addresses[i]);
-        }
-      }
-      if (addresses[i].length() > LobbyConstants.EMAIL_MAX_LENGTH) {
-        if (sbTooLongAddresses.isEmpty()) {
-          sbTooLongAddresses.append(addresses[i]);
-        } else {
-          sbTooLongAddresses.append("; " + addresses[i]);
-        }
+    String[] addresses = emailAddresses.split(" (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
+    for (String address : addresses) {
+      if (!isValid(address)) {
+        return false;
       }
     }
-    String errorMessage = null;
-    if (emailAddress.length() > LobbyConstants.EMAIL_INPUT_FIELD_MAX_LENGTH) {
-      errorMessage =
-          "The input value for email exceeds the maximum length "
-              + LobbyConstants.EMAIL_INPUT_FIELD_MAX_LENGTH;
+    return true;
+  }
+
+  /** Allow multiple fully qualified email addresses separated by spaces, or a blank string. */
+  public static String validate(final String emailAddress) {
+    if (emailAddress == null) {
+      return null;
     }
-    if (!sbInvalidAddresses.isEmpty()) {
-      errorMessage = errorMessage == null ? "" : errorMessage + "\n";
-      errorMessage += "The following email addresses are invalid: " + sbInvalidAddresses + ".";
+    if (emailAddress.length() > LobbyConstants.EMAIL_MAX_LENGTH) {
+      return String.format(
+          "Email address has length %d exceeds the maximum length : %d",
+          emailAddress.length(), LobbyConstants.EMAIL_MAX_LENGTH);
     }
-    if (!sbTooLongAddresses.isEmpty()) {
-      errorMessage = errorMessage == null ? "" : errorMessage + "\n";
-      errorMessage +=
-          "The following email addresses exceed the maximum length "
-              + LobbyConstants.EMAIL_MAX_LENGTH
-              + ": "
-              + sbTooLongAddresses
-              + ".";
-    }
-    return errorMessage;
+    if (!emailAddress.matches(EMAIL_REGEX)) {
+      return String.format("Email address is invalid: %s", emailAddress);
+      }
+    return null;
   }
 }

--- a/game-app/domain-data/src/main/java/org/triplea/domain/data/PlayerEmailValidation.java
+++ b/game-app/domain-data/src/main/java/org/triplea/domain/data/PlayerEmailValidation.java
@@ -51,7 +51,7 @@ public final class PlayerEmailValidation {
     }
     if (!emailAddress.matches(EMAIL_REGEX)) {
       return String.format("Email address is invalid: %s", emailAddress);
-      }
+    }
     return null;
   }
 }

--- a/game-app/domain-data/src/test/java/org/triplea/domain/data/PlayerEmailValidationTest.java
+++ b/game-app/domain-data/src/test/java/org/triplea/domain/data/PlayerEmailValidationTest.java
@@ -9,23 +9,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class PlayerEmailValidationTest {
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "some@some.com",
-        "some.someMore@some.com",
-        "some@some.com some2@some2.com",
-        "some@some.com some2@some2.co.uk",
-        "some@some.com some2@some2.co.br",
-        "",
-        "some@some.some.some.com",
-        // long but valid mail
-        "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "1234567890@some.com "
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "@some.com"
-      })
+  @ValueSource(strings = {"some@some.com", "some.someMore@some.com", "some@some.some.some.com"})
   void shouldReturnTrueWhenAddressIsValid(final String validEmail) {
     assertThat(
         "'" + validEmail + "' should be valid",
@@ -36,6 +20,28 @@ class PlayerEmailValidationTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
+        "some@some.com some2@some2.com",
+        "some@some.com some2@some2.co.uk",
+        "some@some.com some2@some2.co.br",
+        // long but valid mail
+        "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+            + "1234567890@some.com "
+            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+            + "@some.com"
+      })
+  void shouldReturnTrueWhenAddressesAreValid(final String validEmails) {
+    assertThat(
+        "'" + validEmails + "' should be valid",
+        PlayerEmailValidation.areValid(validEmails),
+        is(true));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "",
         "test",
         "test@",
         "test.com",
@@ -44,35 +50,29 @@ class PlayerEmailValidationTest {
         "some@some.com,",
         "some@some.com,some",
         "1234567890",
-        // too long mail
+        // too long mail (4x80 + 9 = 329)
         "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
             + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
             + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890@some.com",
-        // too long mails
-        "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "@some.com "
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "@some.com "
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "@some.com "
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "@some.com "
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "@some.com "
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
-            + "@some.com"
+            + "12345678901234567890123456789012345678901234567890123456789012345678901234567890@some.com"
       })
   void shouldReturnFalseWhenAddressIsInvalid(final String invalidEmail) {
     assertThat(
         "'" + invalidEmail + "' should be invalid",
         PlayerEmailValidation.isValid(invalidEmail),
+        is(false));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "some@some.com test",
+        "test@ some@some.com",
+      })
+  void shouldReturnFalseWhenAddressesAreInvalid(final String invalidEmails) {
+    assertThat(
+        "'" + invalidEmails + "' should be invalid",
+        PlayerEmailValidation.areValid(invalidEmails),
         is(false));
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/DiceServerEditor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/DiceServerEditor.java
@@ -10,7 +10,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.net.URI;
-import java.util.Arrays;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -22,6 +21,7 @@ import org.triplea.awt.OpenFileUtility;
 import org.triplea.domain.data.PlayerEmailValidation;
 import org.triplea.swing.DocumentListenerBuilder;
 import org.triplea.swing.JButtonBuilder;
+import org.triplea.swing.JTextFieldBuilder;
 import org.triplea.swing.SwingComponents;
 
 /** A class to configure a Dice Server for the game. */
@@ -29,6 +29,7 @@ public class DiceServerEditor extends JPanel {
   public static final URI PRODUCTION_URI = URI.create("https://dice.marti.triplea-game.org");
 
   private static final long serialVersionUID = -451810815037661114L;
+  public static final int ADDRESS_FIELD_MAX_LENGTH = 1019;
   private final JButton registerButton =
       new JButtonBuilder("Register")
           .actionListener(() -> OpenFileUtility.openUrl(UrlConstants.MARTI_REGISTRATION))
@@ -55,8 +56,10 @@ public class DiceServerEditor extends JPanel {
           .toolTip("Click this button to show help text")
           .build();
   private final JButton testDiceButton = new JButton("Test Server");
-  private final JTextField toAddress = new JTextField();
-  private final JTextField ccAddress = new JTextField();
+  private final JTextField toAddress =
+      JTextFieldBuilder.builder().maxLength(ADDRESS_FIELD_MAX_LENGTH).build();
+  private final JTextField ccAddress =
+      JTextFieldBuilder.builder().maxLength(ADDRESS_FIELD_MAX_LENGTH).build();
   private final JTextField gameId = new JTextField();
   private final JLabel toLabel = new JLabel("To:");
   private final JLabel ccLabel = new JLabel("Cc:");
@@ -257,9 +260,9 @@ public class DiceServerEditor extends JPanel {
 
   public boolean areFieldsValid() {
     final boolean toValid =
-        !toAddress.getText().isEmpty() && validateEmailAddresses(toAddress.getText());
+        !toAddress.getText().isEmpty() && PlayerEmailValidation.areValid(toAddress.getText());
     final boolean ccValid =
-        !ccAddress.getText().isEmpty() && validateEmailAddresses(ccAddress.getText());
+        !ccAddress.getText().isEmpty() && PlayerEmailValidation.areValid(ccAddress.getText());
 
     final boolean allValid = toValid && ccValid;
     testDiceButton.setEnabled(allValid);
@@ -274,10 +277,6 @@ public class DiceServerEditor extends JPanel {
           SwingComponents.highlightLabelIfNotValid(ccValid, ccLabel);
         });
     return allValid;
-  }
-
-  private boolean validateEmailAddresses(String addresses) {
-    return Arrays.stream(addresses.split("\\s+")).allMatch(PlayerEmailValidation::isValid);
   }
 
   public void applyToGameProperties(final GameProperties properties) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditor.java
@@ -3,6 +3,7 @@ package games.strategy.engine.framework.startup.ui.posted.game.pbem;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.framework.startup.ui.posted.game.HelpTexts;
 import games.strategy.triplea.settings.ClientSetting;
+import java.awt.*;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -13,6 +14,7 @@ import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.border.TitledBorder;
+import org.triplea.domain.data.LobbyConstants;
 import org.triplea.java.ViewModelListener;
 import org.triplea.swing.DocumentListenerBuilder;
 import org.triplea.swing.JButtonBuilder;
@@ -27,10 +29,11 @@ import org.triplea.swing.jpanel.JPanelBuilder;
 public class EmailSenderEditor implements ViewModelListener<EmailSenderEditorViewModel> {
 
   private static final int FIELD_LENGTH = 20;
+  // 254 * 4 + 3 = 1019 Three max length emails with 3 spaces to separate.
+  public static final int TO_ADDRESS_MAX_LENGTH = 1019;
   private final EmailSenderEditorViewModel viewModel = new EmailSenderEditorViewModel(this);
 
   private boolean syncToModel;
-  private JPanel contents;
 
   private final JComboBox<String> emailProviderSelectionBox =
       JComboBoxBuilder.builder()
@@ -42,6 +45,12 @@ public class EmailSenderEditor implements ViewModelListener<EmailSenderEditorVie
                   viewModel.setSelectedProvider(provider);
                 }
               })
+          .build();
+
+  private final JPanel contents =
+      new JPanelBuilder()
+          .border(new TitledBorder("Automatically Send Emails"))
+          .gridBagLayout()
           .build();
 
   private final JButton helpButton =
@@ -110,6 +119,7 @@ public class EmailSenderEditor implements ViewModelListener<EmailSenderEditorVie
   private final JTextField toAddressField =
       JTextFieldBuilder.builder()
           .text(viewModel.getToAddress())
+          .maxLength(TO_ADDRESS_MAX_LENGTH)
           .textListener(
               toAddress -> {
                 if (syncToModel) {
@@ -122,6 +132,7 @@ public class EmailSenderEditor implements ViewModelListener<EmailSenderEditorVie
   private final JLabel userNameLabel = new JLabel("Email Username:");
   private final JTextField userNameField =
       JTextFieldBuilder.builder()
+          .maxLength(LobbyConstants.USERNAME_MAX_LENGTH)
           .text(viewModel.getEmailUsername())
           .textListener(
               fieldValue -> {
@@ -181,11 +192,6 @@ public class EmailSenderEditor implements ViewModelListener<EmailSenderEditorVie
   JPanel build() {
     toggleFieldVisibility();
 
-    contents =
-        new JPanelBuilder()
-            .border(new TitledBorder("Automatically Send Emails"))
-            .gridBagLayout()
-            .build();
     int row = 0;
 
     row++;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditor.java
@@ -3,7 +3,6 @@ package games.strategy.engine.framework.startup.ui.posted.game.pbem;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.framework.startup.ui.posted.game.HelpTexts;
 import games.strategy.triplea.settings.ClientSetting;
-import java.awt.*;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditorViewModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditorViewModel.java
@@ -63,7 +63,7 @@ class EmailSenderEditorViewModel {
     return smtpServer != null
         && !smtpServer.isBlank()
         && !toAddress.isBlank()
-        && PlayerEmailValidation.isValid(toAddress)
+        && PlayerEmailValidation.areValid(toAddress)
         && StringUtils.isPositiveInt(smtpPort)
         && ClientSetting.emailUsername.isSet()
         && ClientSetting.emailUsername.getValueOrThrow().length > 0
@@ -184,7 +184,7 @@ class EmailSenderEditorViewModel {
 
   boolean isToAddressValid() {
     return isEmailProviderDisabled()
-        || (!toAddress.isBlank() && PlayerEmailValidation.isValid(toAddress));
+        || (!toAddress.isBlank() && PlayerEmailValidation.areValid(toAddress));
   }
 
   void setUseTls(final boolean useTls) {

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/ChangeEmailPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/ChangeEmailPanel.java
@@ -11,11 +11,13 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import org.triplea.domain.data.LobbyConstants;
 import org.triplea.domain.data.PlayerEmailValidation;
 import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
 import org.triplea.swing.DialogBuilder;
 import org.triplea.swing.DocumentListenerBuilder;
 import org.triplea.swing.JButtonBuilder;
+import org.triplea.swing.JTextFieldBuilder;
 import org.triplea.swing.jpanel.FlowLayoutBuilder;
 import org.triplea.swing.jpanel.GridBagConstraintsBuilder;
 import org.triplea.swing.jpanel.GridBagConstraintsFill;
@@ -29,7 +31,11 @@ public final class ChangeEmailPanel {
 
   private JPanel createPanel(
       final JDialog dialog, final String userExistingEmail, final Consumer<String> submitAction) {
-    final JTextField emailField = new JTextField(userExistingEmail);
+    final JTextField emailField =
+        JTextFieldBuilder.builder()
+            .text(userExistingEmail)
+            .maxLength(LobbyConstants.EMAIL_MAX_LENGTH)
+            .build();
     final JButton okButton = new JButton("OK");
     okButton.setEnabled(false);
 

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
@@ -23,10 +23,12 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
+import org.triplea.domain.data.LobbyConstants;
 import org.triplea.domain.data.PlayerEmailValidation;
 import org.triplea.domain.data.UserName;
 import org.triplea.java.Sha512Hasher;
 import org.triplea.swing.JCheckBoxBuilder;
+import org.triplea.swing.JTextFieldBuilder;
 import org.triplea.swing.KeyTypeValidator;
 import org.triplea.swing.key.binding.KeyCode;
 import org.triplea.swing.key.binding.SwingKeyBinding;
@@ -34,6 +36,7 @@ import org.triplea.swing.key.binding.SwingKeyBinding;
 /** The panel used to create a new lobby account or update an existing lobby account. */
 public final class CreateAccountPanel extends JPanel {
   private static final long serialVersionUID = 2285956517232671122L;
+  public static final int ACCOUNT_PASSWORD_MIN_LENGTH = 5;
 
   /** Indicates how the user dismissed the dialog displaying the panel. */
   public enum ReturnValue {
@@ -43,8 +46,10 @@ public final class CreateAccountPanel extends JPanel {
 
   private static final String TITLE = "Create Account";
   private @Nullable JDialog dialog;
-  private final JTextField usernameField = new JTextField();
-  private final JTextField emailField = new JTextField();
+  private final JTextField usernameField =
+      JTextFieldBuilder.builder().maxLength(LobbyConstants.USERNAME_MAX_LENGTH).build();
+  private final JTextField emailField =
+      JTextFieldBuilder.builder().maxLength(LobbyConstants.EMAIL_MAX_LENGTH).build();
   private final JPasswordField passwordField = new JPasswordField();
   private final JPasswordField passwordConfirmField = new JPasswordField();
   private ReturnValue returnValue = ReturnValue.CANCEL;
@@ -285,8 +290,10 @@ public final class CreateAccountPanel extends JPanel {
       return Optional.of("You must enter an email");
     } else if (passwordField.getPassword().length == 0) {
       return Optional.of("You must enter a password");
-    } else if (passwordField.getPassword().length < 5) {
-      return Optional.of("Passwords must be at least five characters long");
+    } else if (passwordField.getPassword().length < ACCOUNT_PASSWORD_MIN_LENGTH) {
+      return Optional.of(
+          String.format(
+              "Passwords must be at least %s characters long", LobbyConstants.PASSWORD_MIN_LENGTH));
     }
     return Optional.empty();
   }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/ForgotPasswordPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/login/ForgotPasswordPanel.java
@@ -16,8 +16,10 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import org.triplea.domain.data.LobbyConstants;
 import org.triplea.domain.data.PlayerEmailValidation;
 import org.triplea.domain.data.UserName;
+import org.triplea.swing.JTextFieldBuilder;
 import org.triplea.swing.key.binding.KeyCode;
 import org.triplea.swing.key.binding.SwingKeyBinding;
 
@@ -34,10 +36,11 @@ final class ForgotPasswordPanel extends JPanel {
     OK
   }
 
-  private final String title = "Forgot Password";
+  private static final String TITLE = "Forgot Password";
   private @Nullable JDialog dialog;
   private final JTextField userNameField = new JTextField();
-  private final JTextField emailField = new JTextField();
+  private final JTextField emailField =
+      JTextFieldBuilder.builder().maxLength(LobbyConstants.EMAIL_MAX_LENGTH).build();
   private final JButton okButton = new JButton("OK");
   private final JButton cancelButton = new JButton("Cancel");
   private ReturnValue returnValue = ReturnValue.CANCEL;
@@ -59,7 +62,7 @@ final class ForgotPasswordPanel extends JPanel {
 
   private void layoutComponents() {
     setLayout(new BorderLayout());
-    final JLabel label = new JLabel(new ImageIcon(Util.getBanner(title)));
+    final JLabel label = new JLabel(new ImageIcon(Util.getBanner(TITLE)));
     add(label, BorderLayout.NORTH);
 
     final JPanel main = new JPanel();
@@ -156,7 +159,7 @@ final class ForgotPasswordPanel extends JPanel {
     if (!PlayerEmailValidation.isValid(emailField.getText())) {
       JOptionPane.showMessageDialog(
           this,
-          PlayerEmailValidation.validate(userNameField.getText()),
+          PlayerEmailValidation.validate(emailField.getText()),
           "Invalid email",
           JOptionPane.ERROR_MESSAGE);
       return;
@@ -174,7 +177,7 @@ final class ForgotPasswordPanel extends JPanel {
    *     ReturnValue#CANCEL}.
    */
   ReturnValue show(final Window parent) {
-    dialog = new JDialog(JOptionPane.getFrameForComponent(parent), title, true);
+    dialog = new JDialog(JOptionPane.getFrameForComponent(parent), TITLE, true);
     dialog.getContentPane().add(this);
     SwingKeyBinding.addKeyBinding(dialog, KeyCode.ESCAPE, this::close);
     dialog.pack();


### PR DESCRIPTION
ChangeEmailPanel.java
- maximum length for email field CreateAccountPanel.java
- maximum length for email field and username field
- constant for minimum length for password field DiceServerEditor.java
- maximum length for address field (pot. mult. emails) EmailSenderEditor.java
- maximum length for address field (pot. mult. emails) EmailSenderEditorViewModel.java
- isValid check to areValid check method call ForgotPasswordPanel.java
- maximum length for email field LobbyConstants.java
- removed constant EMAIL_INPUT_FIELD_MAX_LENGTH public static boolean isValid(final String emailAddress) { PlayerEmailValidation.java
- simplified individual email validation
- constants for regular expression and respective parts
- new method areValid PlayerEmailValidationTest.java
- new test cases for method areValid
- reduces test cases for method isValid
- '' no longer a valid mail address!

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
