### PR TITLE
center on capital on player start (issue 13241)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -120,7 +120,7 @@ public class DiceImageFactory {
           2 * DIE_WIDTH / 3 - (pipSize / 2), 3 * DIE_HEIGHT / 4 - (pipSize / 2), pipSize, pipSize);
     }
     if (dieSide > 6) {
-      graphics.setFont(new Font("Arial", Font.BOLD, 16));
+      graphics.setFont(new Font(MapImage.FONT_FAMILY_DEFAULT, Font.BOLD, 16));
       graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
       final String number = Integer.toString(dieSide);
       final int widthOffset =
@@ -140,7 +140,7 @@ public class DiceImageFactory {
     if (i > diceSides) {
       final Image canvas = Util.newImage(DIE_WIDTH, DIE_HEIGHT, true);
       final Graphics graphics = canvas.getGraphics();
-      graphics.setFont(new Font("Arial", Font.BOLD, 16));
+      graphics.setFont(new Font(MapImage.FONT_FAMILY_DEFAULT, Font.BOLD, 16));
       switch (type) {
         case HIT:
           graphics.setColor(Color.RED);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -21,6 +21,7 @@ import lombok.Getter;
  */
 @Getter
 public class MapImage {
+  public static final String FONT_FAMILY_DEFAULT = "Arial";
   private static Font propertyMapFont = null;
   private static Color propertyTerritoryNameAndPuAndCommentColor = null;
   private static Color propertyUnitCountColor = null;
@@ -59,7 +60,7 @@ public class MapImage {
       final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
       propertyMapFont =
           new Font(
-              "Arial",
+              MapImage.FONT_FAMILY_DEFAULT,
               Font.BOLD,
               pref.getInt(PROPERTY_MAP_FONT_SIZE_STRING, MAP_FONT_SIZE_DEFAULT));
     }
@@ -195,7 +196,7 @@ public class MapImage {
 
   public static void resetPropertyMapFont() {
     removeProperty(PROPERTY_MAP_FONT_SIZE_STRING);
-    propertyMapFont = new Font("Arial", Font.BOLD, MAP_FONT_SIZE_DEFAULT);
+    propertyMapFont = new Font(MapImage.FONT_FAMILY_DEFAULT, Font.BOLD, MAP_FONT_SIZE_DEFAULT);
   }
 
   public static void resetPropertyTerritoryNameAndPuAndCommentColor() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
@@ -13,7 +13,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingConstants;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Tuple;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.ui;
 
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.image.MapImage;
 import games.strategy.ui.ScrollableTextFieldListener;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -12,13 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
+import javax.swing.*;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Tuple;
 
@@ -119,9 +114,9 @@ public class IndividualUnitPanelGrouped extends JPanel {
             0));
     selectNoneButton.addActionListener(e -> selectNone());
     autoSelectButton.addActionListener(e -> autoSelect());
-    final JPanel entries = new JPanel();
-    entries.setLayout(new FlowLayout());
-    entries.setBorder(BorderFactory.createEmptyBorder());
+    final JPanel entriesPanel = new JPanel();
+    entriesPanel.setLayout(new FlowLayout());
+    entriesPanel.setBorder(BorderFactory.createEmptyBorder());
     for (final Map.Entry<String, Collection<Unit>> entry : unitsToChooseFrom.entrySet()) {
       final String miniTitle = entry.getKey();
       final Collection<Unit> possibleTargets = entry.getValue();
@@ -129,8 +124,8 @@ public class IndividualUnitPanelGrouped extends JPanel {
       panelChooser.setLayout(new BoxLayout(panelChooser, BoxLayout.Y_AXIS));
       panelChooser.setBorder(BorderFactory.createLineBorder(getBackground()));
       final JLabel chooserTitle = new JLabel("Choose Per Unit");
-      chooserTitle.setHorizontalAlignment(JLabel.LEFT);
-      chooserTitle.setFont(new Font("Arial", Font.BOLD, 12));
+      chooserTitle.setHorizontalAlignment(SwingConstants.LEFT);
+      chooserTitle.setFont(new Font(MapImage.FONT_FAMILY_DEFAULT, Font.BOLD, 12));
       panelChooser.add(chooserTitle);
       panelChooser.add(new JLabel(" "));
       final IndividualUnitPanel chooser =
@@ -158,10 +153,10 @@ public class IndividualUnitPanelGrouped extends JPanel {
                   : (chooserScrollPane.getPreferredSize().width > 220
                       ? chooserScrollPane.getPreferredSize().height + 20
                       : chooserScrollPane.getPreferredSize().height))));
-      entries.add(chooserScrollPane);
+      entriesPanel.add(chooserScrollPane);
     }
     add(
-        entries,
+        entriesPanel,
         new GridBagConstraints(
             0,
             1,

--- a/game-app/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-app/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.triplea.ResourceLoader;
+import games.strategy.triplea.image.MapImage;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -301,7 +302,7 @@ public final class DecorationPlacer {
               repaint();
             }
           });
-      locationLabel.setFont(new Font("Arial", Font.BOLD, 16));
+      locationLabel.setFont(new Font(MapImage.FONT_FAMILY_DEFAULT, Font.BOLD, 16));
       /*
        * Add a mouse listener to monitor for right mouse button being clicked.
        */
@@ -676,26 +677,26 @@ public final class DecorationPlacer {
 
     private void fillCurrentImagePointsBasedOnTextFile(final boolean fillInAllTerritories) {
       staticImageForPlacing = null;
-      Path image =
+      Path imagePath =
           mapFolderLocation
               .resolve(imagePointType.getFolderName())
               .resolve(imagePointType.getImageName());
-      if (!Files.exists(image)) {
-        image =
+      if (!Files.exists(imagePath)) {
+        imagePath =
             ClientFileSystemHelper.getRootFolder()
                 .resolve(ResourceLoader.ASSETS_FOLDER)
                 .resolve(imagePointType.getFolderName())
                 .resolve(imagePointType.getImageName());
       }
-      if (!Files.exists(image)) {
-        image = null;
+      if (!Files.exists(imagePath)) {
+        imagePath = null;
       }
       while (staticImageForPlacing == null) {
         final FileOpen imageSelection =
             new FileOpen(
                 "Select Example Image To Use",
-                image == null ? mapFolderLocation : image.getParent(),
-                image,
+                imagePath == null ? mapFolderLocation : imagePath.getParent(),
+                imagePath,
                 ".gif",
                 ".png");
         if (imageSelection.getFile() == null || !Files.exists(imageSelection.getFile())) {
@@ -751,7 +752,7 @@ public final class DecorationPlacer {
         }
         final String imageName = path.getFileName().toString();
         final String possibleTerritoryName = imageName.substring(0, imageName.length() - 4);
-        final Image image = FileHelper.newImage(path);
+        final Image territoryImage = FileHelper.newImage(path);
         List<Point> points =
             (currentPoints != null
                 ? currentPoints.get(
@@ -766,8 +767,10 @@ public final class DecorationPlacer {
           } else {
             p =
                 new Point(
-                    p.x - (image.getWidth(null) / 2),
-                    p.y + addY + ((showFromTopLeft ? -1 : 1) * (image.getHeight(null) / 2)));
+                    p.x - (territoryImage.getWidth(null) / 2),
+                    p.y
+                        + addY
+                        + ((showFromTopLeft ? -1 : 1) * (territoryImage.getHeight(null) / 2)));
             points.add(p);
             allTerritories.remove(possibleTerritoryName);
             log.info("Found point for: " + possibleTerritoryName);
@@ -777,7 +780,7 @@ public final class DecorationPlacer {
         }
         currentImagePoints.put(
             (pointsAreExactlyTerritoryNames ? possibleTerritoryName : imageName),
-            Tuple.of(image, points));
+            Tuple.of(territoryImage, points));
       }
       if (!allTerritories.isEmpty() && imagePointType == ImagePointType.name_place) {
         JOptionPane.showMessageDialog(

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Round;
+import games.strategy.triplea.image.MapImage;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
@@ -144,7 +145,7 @@ public final class ScreenshotExporter {
         titleY = 15;
         titleSize = 15;
       }
-      mapGraphics.setFont(new Font("Arial", Font.BOLD, titleSize));
+      mapGraphics.setFont(new Font(MapImage.FONT_FAMILY_DEFAULT, Font.BOLD, titleSize));
       mapGraphics.setColor(titleColor);
       if (uiContext.getMapData().getBooleanProperty(MapData.PROPERTY_SCREENSHOT_TITLE_ENABLED)) {
         mapGraphics.drawString(gameData.getGameName() + " Round " + round, titleX, titleY);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -55,7 +55,6 @@ final class ViewMenu extends JMenu {
   private static final long serialVersionUID = -4703734404422047487L;
 
   private JCheckBoxMenuItem showMapDetails;
-  private JCheckBoxMenuItem showMapBlends;
 
   private final List<Territory> gameMapTerritories;
   private final TripleAFrame frame;
@@ -293,6 +292,7 @@ final class ViewMenu extends JMenu {
   }
 
   private void addShowMapBlends() {
+    JCheckBoxMenuItem showMapBlends;
     showMapBlends = new JCheckBoxMenuItem("Show Map Blends");
     showMapBlends.setMnemonic(KeyEvent.VK_B);
     if (uiContext.getMapData().getHasRelief()
@@ -336,9 +336,7 @@ final class ViewMenu extends JMenu {
     final JCheckBoxMenuItem showMapZoomBox = new JCheckBoxMenuItem("Show Zoom Percentage");
 
     showMapZoomBox.addActionListener(
-        e -> {
-          this.frame.getBottomBar().setMapZoomEnabled(showMapZoomBox.isSelected());
-        });
+        e -> this.frame.getBottomBar().setMapZoomEnabled(showMapZoomBox.isSelected()));
 
     add(showMapZoomBox);
   }
@@ -434,7 +432,8 @@ final class ViewMenu extends JMenu {
                 MapImage.resetPropertyUnitHitDamageOutline();
                 frame.getMapPanel().resetMap();
               } else if (result == 0) {
-                MapImage.setPropertyMapFont(new Font("Arial", Font.BOLD, fontsize.getValue()));
+                MapImage.setPropertyMapFont(
+                    new Font(MapImage.FONT_FAMILY_DEFAULT, Font.BOLD, fontsize.getValue()));
                 MapImage.setPropertyTerritoryNameAndPuAndCommentColor(
                     territoryNameColor.getValue());
                 MapImage.setPropertyUnitCountColor(unitCountColor.getValue());
@@ -529,10 +528,14 @@ final class ViewMenu extends JMenu {
           }
 
           @Override
-          public void menuDeselected(final MenuEvent e) {}
+          public void menuDeselected(final MenuEvent e) {
+            // not needed interface method
+          }
 
           @Override
-          public void menuCanceled(final MenuEvent e) {}
+          public void menuCanceled(final MenuEvent e) {
+            // not needed interface method
+          }
         });
     add(flagDisplayMenu);
   }


### PR DESCRIPTION
[issue 13241](https://github.com/triplea-game/triplea/issues/13241) Visual Do Not Center on Capital if First Phase is Inactive (2.7.14934)

TripleAFrame.java
- avoid setting lastPlayer in method updateStepFromEdt (only in method requiredTurnSeries)
- rename from lastStepPlayer to lastPlayer

MapImage.java
- new constant FONT_FAMILY_DEFAULT (='Arial')

DecorationPlacer.java
DiceImageFactory.java
IndividualUnitPanelGrouped.java
ScreenshotExporter.java
ViewMenu.java
- replace text with constant MapImage.FONT_FAMILY_DEFAULT

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
