### PR TITLE
no flyover with multi moves (issue 13244)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -515,15 +515,17 @@ public class MoveValidator {
     }
 
     // check aircraft
-    if (units.stream().anyMatch(Matches.unitIsAir())
-        && route.hasSteps()
+    if (route.hasSteps()
+        && units.stream().anyMatch(Matches.unitIsAir())
         && (!Properties.getNeutralFlyoverAllowed(data.getProperties())
             || Properties.getNeutralsImpassable(data.getProperties()))
-        && route.getMiddleSteps().stream().anyMatch(Matches.territoryIsNeutralButNotWater())) {
+        && (route.getMiddleSteps().stream().anyMatch(Matches.territoryIsNeutralButNotWater())
+            || Matches.territoryIsNeutralButNotWater().test(route.getStart())
+                && units.stream().anyMatch(Matches.unitIsAir().and(Matches.unitHasMoved())))) {
       return result.setErrorReturnResult("Air units cannot fly over neutral territories");
     }
     // make sure no conquered territories on route
-    // unless we are all air or we are in non combat OR the route is water (was a bug in convoy
+    // unless we are all air, or we are in non combat OR the route is water (was a bug in convoy
     // zone movement)
     if (hasConqueredNonBlitzedNonWaterOnRoute(route, data)
         && !units.stream().allMatch(Matches.unitIsAir())) {
@@ -799,13 +801,12 @@ public class MoveValidator {
       }
     }
     // if we are water make sure no land
-    if (units.stream().anyMatch(Matches.unitIsSea())) {
-      if (route.hasLand()) {
+    if (units.stream().anyMatch(Matches.unitIsSea()) && route.hasLand()) {
         for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitIsSea())) {
           result.addDisallowedUnit("Sea units cannot go on land", unit);
         }
       }
-    }
+
     // test for stack limits per unit
     final PlayerAttachment pa = PlayerAttachment.get(player);
     final Set<Triple<Integer, String, Set<UnitType>>> playerMovementLimit =
@@ -1190,10 +1191,11 @@ public class MoveValidator {
                     ENEMY_SUBMARINE_PREVENTING_UNESCORTED_AMPHIBIOUS_ASSAULT_LANDING, unit);
               }
             }
-          } else if (!AbstractMoveDelegate.getBattleTracker(data).wasConquered(routeEnd)) {
-            // this is an unload to a friendly territory
-            if (isScramblingOrKamikazeAttacksEnabled
-                || !Matches.territoryIsEmptyOfCombatUnits(player).test(routeStart)) {
+          } else if (!AbstractMoveDelegate.getBattleTracker(data).wasConquered(routeEnd)
+              &&
+              // this is an unload to a friendly territory
+              (isScramblingOrKamikazeAttacksEnabled
+                  || !Matches.territoryIsEmptyOfCombatUnits(player).test(routeStart))) {
               // Unloading a transport from a sea zone with a battle, to a friendly land territory,
               // during combat move phase, is illegal and in addition to being illegal, it is also
               // causing problems if
@@ -1205,7 +1207,7 @@ public class MoveValidator {
                     unit);
               }
             }
-          }
+
         }
         // TODO This is very sensitive to the order of the transport collection. The users may need
         // to modify the order in which they perform their actions. check whether transport has
@@ -1247,14 +1249,15 @@ public class MoveValidator {
     // go sea land sea
     if (!isEditMode
         && route.hasLand()
-        && !(route.getStart().isWater() || route.getEnd().isWater())) {
-      // needs to include all land and air to work, since it makes sure the land units can be
-      // carried by the air and that the air has enough capacity
-      if (nonParatroopersPresent(player, landAndAir)) {
+        && !(route.getStart().isWater() || route.getEnd().isWater())
+        &&
+        // needs to include all land and air to work, since it makes sure the land units can be
+        // carried by the air and that the air has enough capacity
+        nonParatroopersPresent(player, landAndAir)) {
         return result.setErrorReturnResult(
             "Invalid move, only start or end can be land when route has water.");
       }
-    }
+
     // simply because I don't want to handle it yet checks are done at the start and end, don't want
     // to worry about just using a transport as a bridge yet
     // TODO handle this
@@ -1647,17 +1650,18 @@ public class MoveValidator {
     for (final Unit plane : selectFrom) {
       final UnitAttachment planeAttachment = plane.getUnitAttachment();
       final int cost = planeAttachment.getCarrierCost();
-      if (available >= cost) {
-        // this is to test if they started in the same sea zone or not, and its not a very good way
-        // of testing it.
-        if ((carrier.getAlreadyMoved().compareTo(plane.getAlreadyMoved()) == 0)
-            || (Matches.unitHasNotMoved().test(plane) && Matches.unitHasNotMoved().test(carrier))
-            || (Matches.unitIsOwnedBy(playerWhoIsDoingTheMovement).negate().test(plane)
-                && Matches.alliedUnit(playerWhoIsDoingTheMovement).test(plane))) {
+      if (available >= cost
+          &&
+          // this is to test if they started in the same sea zone or not, and its not a very good
+          // way of testing it.
+          ((carrier.getAlreadyMoved().compareTo(plane.getAlreadyMoved()) == 0)
+              || (Matches.unitHasNotMoved().test(plane) && Matches.unitHasNotMoved().test(carrier))
+              || (Matches.unitIsOwnedBy(playerWhoIsDoingTheMovement).negate().test(plane)
+                  && Matches.alliedUnit(playerWhoIsDoingTheMovement).test(plane)))) {
           available -= cost;
           canCarry.add(plane);
         }
-      }
+
       if (available == 0) {
         break;
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -802,10 +802,10 @@ public class MoveValidator {
     }
     // if we are water make sure no land
     if (units.stream().anyMatch(Matches.unitIsSea()) && route.hasLand()) {
-        for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitIsSea())) {
-          result.addDisallowedUnit("Sea units cannot go on land", unit);
-        }
+      for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitIsSea())) {
+        result.addDisallowedUnit("Sea units cannot go on land", unit);
       }
+    }
 
     // test for stack limits per unit
     final PlayerAttachment pa = PlayerAttachment.get(player);
@@ -1196,18 +1196,17 @@ public class MoveValidator {
               // this is an unload to a friendly territory
               (isScramblingOrKamikazeAttacksEnabled
                   || !Matches.territoryIsEmptyOfCombatUnits(player).test(routeStart))) {
-              // Unloading a transport from a sea zone with a battle, to a friendly land territory,
-              // during combat move phase, is illegal and in addition to being illegal, it is also
-              // causing problems if
-              // the sea transports get killed (the land units are not dying)
-              // TODO: should we use the battle tracker for this instead?
-              for (final Unit unit : transport.getTransporting()) {
-                result.addDisallowedUnit(
-                    TRANSPORT_MAY_NOT_UNLOAD_TO_FRIENDLY_TERRITORIES_UNTIL_AFTER_COMBAT_IS_RESOLVED,
-                    unit);
-              }
+            // Unloading a transport from a sea zone with a battle, to a friendly land territory,
+            // during combat move phase, is illegal and in addition to being illegal, it is also
+            // causing problems if
+            // the sea transports get killed (the land units are not dying)
+            // TODO: should we use the battle tracker for this instead?
+            for (final Unit unit : transport.getTransporting()) {
+              result.addDisallowedUnit(
+                  TRANSPORT_MAY_NOT_UNLOAD_TO_FRIENDLY_TERRITORIES_UNTIL_AFTER_COMBAT_IS_RESOLVED,
+                  unit);
             }
-
+          }
         }
         // TODO This is very sensitive to the order of the transport collection. The users may need
         // to modify the order in which they perform their actions. check whether transport has
@@ -1254,9 +1253,9 @@ public class MoveValidator {
         // needs to include all land and air to work, since it makes sure the land units can be
         // carried by the air and that the air has enough capacity
         nonParatroopersPresent(player, landAndAir)) {
-        return result.setErrorReturnResult(
-            "Invalid move, only start or end can be land when route has water.");
-      }
+      return result.setErrorReturnResult(
+          "Invalid move, only start or end can be land when route has water.");
+    }
 
     // simply because I don't want to handle it yet checks are done at the start and end, don't want
     // to worry about just using a transport as a bridge yet
@@ -1658,9 +1657,9 @@ public class MoveValidator {
               || (Matches.unitHasNotMoved().test(plane) && Matches.unitHasNotMoved().test(carrier))
               || (Matches.unitIsOwnedBy(playerWhoIsDoingTheMovement).negate().test(plane)
                   && Matches.alliedUnit(playerWhoIsDoingTheMovement).test(plane)))) {
-          available -= cost;
-          canCarry.add(plane);
-        }
+        available -= cost;
+        canCarry.add(plane);
+      }
 
       if (available == 0) {
         break;


### PR DESCRIPTION
[issue 13244](https://github.com/triplea-game/triplea/issues/13244) Neutral Territories Can Be Flown Over in Multiple Steps (2.7.14934) 

MoveValidator.java
- add check for route start territory when being NeutralButNotWater for units that have already moved to avoid neutral flyover (when respective property is set)

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->
