### PR TITLE
Fix Typos and grammar in docs/README.md

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -3,11 +3,11 @@
 ## Before Getting Started
 - Install JDK 11 (project is using this Java version)
 - [Install IDE](./how-to/ide-setup) (IDEA is better supported, YMMV with Eclipse)
-  - Create as a gradle project (file > open project > select the build.gradle file))
+  - Create as a gradle project (file > open project > select the build.gradle file)
 
 ## Mac
 
-- Install docker: <https://store.docker.com/editions/community/docker-ce-desktop-mac>
+- Install Docker: <https://store.docker.com/editions/community/docker-ce-desktop-mac>
 
 ## Windows
 
@@ -18,13 +18,13 @@ Set up WSL, this will give you a command line that can be used to run docker, gr
 
 - Fork & Clone: <https://github.com/triplea-game/triplea>
 - Setup IDE: [/docs/development/how-to/ide-setup](how-to/ide-setup)
-- Use a feature-branch workflow, see: [typical git workflow](typical-git-workflow.md))
-- Submit pull request, see: [pull requests process](../project/pull-requests.md).
+- Use a feature-branch workflow, see: [typical git workflow](typical-git-workflow.md)
+- Submit a pull request see: [pull requests process](../project/pull-requests.md)
 
-If you are new to Open Source & Github:
+If you are new to Open Source & GitHub:
   - https://docs.github.com/en/get-started/quickstart/contributing-to-projects
-  - [Create SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
-    (usually you will not need to add the SSH key to your keychain, just create it and add it to github)
+  - [Create an SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+    (usually you will not need to add the SSH key to your keychain, just create it and add it to GitHub)
 
 ## Compile and launch TripleA (CLI)
 
@@ -36,7 +36,7 @@ If you are new to Open Source & Github:
 ./verify
 
 # Run formatting
-./gradew spotlessApply
+./gradlew spotlessApply
 
 # Launch a Postgres DB, build & launch TripleA Servers
 ./gradlew composeUp
@@ -44,7 +44,7 @@ If you are new to Open Source & Github:
 # Connect to locally running database
 ./docker/connect-to-db.sh
 
-# Runs all tests that do not require database
+# Runs all tests that do not require the database
 ./gradlew test
 
 ./gradlew testWithDatabase
@@ -61,7 +61,7 @@ If you are new to Open Source & Github:
 # Run a specific test
 ./gradlew :game-app:game-core:test --tests games.strategy.triplea.UnitUtilsTest
 
-# Runs a specific  test method
+# Runs a specific test method
 ./gradlew :game-app:game-core:test --tests games.strategy.triplea.UnitUtilsTest.multipleTransportedUnitsAreTransferred
 
 # Run specific tests using wildcard (be sure to use quotes around wildcard)
@@ -69,14 +69,14 @@ If you are new to Open Source & Github:
 ```
 
 `gradle` uses caches heavily, thus, if nothing has changed, re-running a test will not actually run the test again.
-To really re-execute a test use the `--rerun-tasks` option:
+To really re-execute a test, use the `--rerun-tasks` option:
 ```
 ./gradlew --rerun-tasks :game-app:game-core:test
 ```
 
 ## Run Formatting
 
-We use 'google java format', be sure to install the plugin in your IDE to properly format from IDE.
+We use 'Google Java Format', be sure to install the plugin in your IDE to properly format from IDE.
 
 
 ## Code Conventions (Style Guide)
@@ -160,11 +160,11 @@ back in properly.
 
 In short:
 - check working directory is 'game-app/game-headed'
-- chect that `./gradlew downloadAssets` has been run and there is an 'assets' folder in the working directory
+- check that `./gradlew downloadAssets` has been run and there is an 'assets' folder in the working directory
 
-### Google formatter does not work
+### Google Formatter does not work
 
-IDEA needs a tweak to overcome a JDk9 problem. The google java format plugin should show a warning dialog about
+IDEA needs a tweak to overcome a JDK9 problem. The Google Java Format plugin should show a warning dialog about
 this if it is a problem.
 
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -7,7 +7,7 @@
 
 ## Mac
 
-- Install Docker: <https://store.docker.com/editions/community/docker-ce-desktop-mac>
+- Install Docker Desktop: <https://store.docker.com/editions/community/docker-ce-desktop-mac>
 
 ## Windows
 


### PR DESCRIPTION
This fix addresses a small typo and several grammar issues in /docs/README.md, including a typo in the gradlew command in the 'Compile and Launch TripleA (CLI)' section
