### PR TITLE
Fix build warning, update config property for spotless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
             target "*"
             targetExclude "gradlew.bat"
             endWithNewline()
-            indentWithSpaces()
+            leadingTabsToSpaces()
             trimTrailingWhitespace()
         }
     }


### PR DESCRIPTION
Per the warning message in gradle build output:

> 'indentWithSpaces' is deprecated, use 'leadingTabsToSpaces' in your gradle build script instead.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
