### PR TITLE
Github actions: update ubuntu version to 'latest'

### DIFF
--- a/.github/workflows/upload-game-installers.yml
+++ b/.github/workflows/upload-game-installers.yml
@@ -13,7 +13,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build:
-    runs-on: Ubuntu-20.04
+    runs-on: Ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/upload-http-client-jars.yml
+++ b/.github/workflows/upload-http-client-jars.yml
@@ -15,7 +15,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build:
-    runs-on: Ubuntu-20.04
+    runs-on: Ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
The version specified is deprecated and no longer runs. Latest is a better choice as version of ubuntu is not important. We specify 'latest' in other build actions, this is now consistent after this update.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
