### PR TITLE
docu update developer guide JDK 17

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -11,7 +11,7 @@
 
 ## Windows
 
-Set up WSL, this will give you a command line that can be used to run docker, gradle and the code check scripts.
+Set up WSL (see [WSL installation guide](https://learn.microsoft.com/de-de/windows/wsl/install)), this will give you a command line that can be used to run docker, gradle and the code check scripts.
 
 
 ## Getting Started

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,7 +1,7 @@
 # Developer Setup Guide
 
 ## Before Getting Started
-- Install JDK 11 (project is using this Java version)
+- Install JDK 17 (project is using this Java version)
 - [Install IDE](./how-to/ide-setup) (IDEA is better supported, YMMV with Eclipse)
   - Create as a gradle project (file > open project > select the build.gradle file)
 

--- a/docs/development/how-to/ide-setup/intellij-setup.md
+++ b/docs/development/how-to/ide-setup/intellij-setup.md
@@ -9,13 +9,14 @@
 Approximate time to complete: 10 - 30 minutes
 
 ### Open Project
-- In IDEA, **File > Open** and select the build.gradle file that is located at
+- In IDEA, `File > Open...`  and select the build.gradle file that is located at
   the top level of the project and run it. (**Tip** by selecting gradle file, IDEA will
   preconfigure the project as a gradle project)
+- Ensure to have the right project settings for the SDK (`File > Project Structure...` and `Project Settings > Project` ) and the bytecode version (`File > Settings...` and `Build, Execution, Deployment > Compiler > Java Compiler`)
 
 ### Plugins:
 
-Note: **Settings** menu is accessible via, `File > Settings`  or (on Mac OS): `IntelliJ IDEA > Preferences`
+Note: **Settings** menu is accessible via, `File > Settings...`  or (on Mac OS): `IntelliJ IDEA > Preferences`
 
 Plugin installation can be initiated from the JetBrains Marketplace web page, by clicking "Install to IDE" link from each plugin's page.
   1. *google-java-format* [plugin](https://plugins.jetbrains.com/plugin/8527-google-java-format)


### PR DESCRIPTION
docut update:
1. JDK 17
2. WSL link
3. intellij SDK and bytecode version
