### PR TITLE
Auto Close Issues 2.5 Workflow (in Test Mode)

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,25 @@
+name: Auto Close GitHub Issues
+on:
+  issues:
+    types: [opened]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  build:
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run script closeIssues.js
+        run: node closeIssues.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/closeIssues.js
+++ b/.github/workflows/closeIssues.js
@@ -19,12 +19,23 @@ async function closeIssues() {
         for (const issue of issuesToClose) {
             console.log(`Closing issue #${issue.number}...`);
           /*
+            // Add label (if missing)
+            let labelIndex = issue.labels.indexOf('2.5');
+            if (labelIndex < 0 ) {
+                issue.labels.push('2.5');
+            }            
+            await octokit.rest.issues.update({
+                repo: 'triplea',
+                issue_number: issue.number,
+                state: 'closed',
+                labels: issue.labels,
+            });
             await octokit.rest.issues.update({
                 repo: 'triplea',
                 issue_number: issue.number,
                 state: 'closed',
             });
-            */
+        */
             console.log(`Closed issue #${issue.number}.`);
         }
     } catch (error) {

--- a/.github/workflows/closeIssues.js
+++ b/.github/workflows/closeIssues.js
@@ -1,0 +1,35 @@
+import { Octokit } from "@octokit/rest";
+
+const octokit = new Octokit({
+    auth: process.env.GITHUB_TOKEN,
+});
+
+async function closeIssues() {
+    try {
+        console.log('Fetching issues...');
+        const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
+            repo: 'triplea',
+            state: 'open',
+        });
+
+        console.log(`Fetched ${issues.length} issues.`);
+        const issuesToClose = issues.filter(issue => issue.title.startsWith('2.5.') );
+        console.log(`Found ${issuesToClose.length} issues to close.`);
+
+        for (const issue of issuesToClose) {
+            console.log(`Closing issue #${issue.number}...`);
+          /*
+            await octokit.rest.issues.update({
+                repo: 'triplea',
+                issue_number: issue.number,
+                state: 'closed',
+            });
+            */
+            console.log(`Closed issue #${issue.number}.`);
+        }
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+closeIssues();


### PR DESCRIPTION
Add test mode for new workflow to auto close 2.5 issues.
Introducing .`github/workflows/` files
auto-close-issues.yml
closeIssues.js

## Notes to Reviewer
@DanVanAtta Please check and let me know how this can be tested. I do not know how to test-run a workflow (here for file `auto-close-issues.yml`) before the merge, after the merge or simply testing that the main file `closeIssues.js` is working correctly.