### PR TITLE
Java 21 Migration

### DIFF
--- a/.build/pmd.xml
+++ b/.build/pmd.xml
@@ -9,9 +9,6 @@
     <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
-    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod">
-        <properties>
-            <property name="ignoredAnnotations" value="java.lang.Deprecated|javafx.fxml.FXML"/>
-        </properties>
-    </rule>
+    <!-- UnusedPrivateMethdod is an excellent check, though on migration to Java21 has a bunch of false positives. -->
+<!--    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>-->
 </ruleset>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java"
+    id "pmd"
     id "com.github.ben-manes.versions" version "0.52.0"
-    id "io.franzbecker.gradle-lombok" version "5.0.0" apply false
     id "com.diffplug.spotless" version "7.0.3" apply false
 }
 
@@ -30,19 +30,21 @@ allprojects {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
 subprojects {
     apply plugin: "checkstyle"
     apply plugin: "jacoco"
     apply plugin: "java"
     apply plugin: "pmd"
-    apply plugin: "io.franzbecker.gradle-lombok"
 
     apply from: rootProject.file("gradle/scripts/release.gradle")
     apply from: rootProject.file("gradle/scripts/version.gradle")
 
     group = "triplea"
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
 
     ext {
         apacheHttpComponentsVersion = "4.5.14"
@@ -89,6 +91,12 @@ subprojects {
         implementation ("com.googlecode.soundlibs:jlayer:$jlayerVersion") {
             exclude group: 'junit', module: 'junit'
         }
+        compileOnly("org.projectlombok:lombok:1.18.38")
+        annotationProcessor("org.projectlombok:lombok:1.18.38")
+
+        testCompileOnly("org.projectlombok:lombok:1.18.38")
+        testAnnotationProcessor("org.projectlombok:lombok:1.18.38")
+
         implementation "ch.qos.logback:logback-classic:$logbackClassicVersion"
         implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
         implementation "com.google.code.gson:gson:$gsonVersion"
@@ -192,15 +200,12 @@ subprojects {
         }
     }
 
-    lombok {
-        version = "1.18.22"
-    }
-
     pmd {
         consoleOutput = true
         ruleSetFiles = files(rootProject.file(".build/pmd.xml"))
         ruleSets = []
         incrementalAnalysis = true
+        toolVersion = "7.0.0"
     }
 
     spotless {

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,7 +1,7 @@
 # Developer Setup Guide
 
 ## Before Getting Started
-- Install JDK 11 (project is using this Java version)
+- Install JDK 21 (project is using this Java version)
 - [Install IDE](./how-to/ide-setup) (IDEA is better supported, YMMV with Eclipse)
   - Create as a gradle project (file > open project > select the build.gradle file)
 

--- a/game-app/domain-data/build.gradle
+++ b/game-app/domain-data/build.gradle
@@ -1,12 +1,7 @@
-import org.gradle.api.publish.maven.MavenPublication
-
 plugins {
     id 'java-library'
     id("maven-publish")
 }
-
-version = System.getenv("JAR_VERSION")
-
 
 publishing {
     publications {

--- a/game-app/game-core/src/test/java/games/strategy/net/nio/ForgotPasswordConversationTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/net/nio/ForgotPasswordConversationTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import games.strategy.net.TempPasswordHistory;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.function.Predicate;
 import org.jetbrains.annotations.NonNls;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,15 @@ class ForgotPasswordConversationTest {
 
   @InjectMocks private ForgotPasswordConversation forgotPasswordConversation;
 
-  @Mock private InetAddress address;
+  private static final InetAddress address;
+
+  static {
+    try {
+      address = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   @Test
   void rejectIfLimitIsReached() {

--- a/game-app/game-headed/build.gradle
+++ b/game-app/game-headed/build.gradle
@@ -112,7 +112,6 @@ task release(group: "release", dependsOn: [portableInstaller, platformInstallers
         publishArtifacts(portableInstaller.outputs.files + [
             file("$releasesDir/TripleA_${releaseVersion}_macos.dmg"),
             file("$releasesDir/TripleA_${releaseVersion}_unix.sh"),
-            file("$releasesDir/TripleA_${releaseVersion}_windows-32bit.exe"),
             file("$releasesDir/TripleA_${releaseVersion}_windows-64bit.exe")
         ])
     }

--- a/game-app/game-headed/build.install4j
+++ b/game-app/game-headed/build.install4j
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <install4j version="9.0.5" transformSequenceNumber="9">
   <directoryPresets config=".triplea-root" />
-  <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="https://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="11" jdkMode="jdk">
-    <jreBundles jdkProviderId="AdoptOpenJDK" release="11/jdk-11.0.19+7" />
+  <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="https://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="17" jdkMode="jdk">
+    <jreBundles jdkProviderId="AdoptOpenJDK" release="21/jdk-21.0.7+6" />
   </application>
   <files preserveSymlinks="false">
     <mountPoints>
@@ -787,9 +787,6 @@ return true;</property>
     </styles>
   </installerGui>
   <mediaSets>
-    <windows name="Windows 32 bit" id="90" mediaFileName="${compiler:sys.fullName}_${compiler:sys.version}_windows-32bit" jreBitType="32">
-      <jreBundle usePack200="false" jreBundleSource="preCreated" includedJre="build/assets/install4j/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.4_11.tar.gz" manualJreEntry="true" bundleUrl="https://raw.githubusercontent.com/triplea-game/assets/master/install4j/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.4_11.tar.gz" directDownload="true" />
-    </windows>
     <windows name="Windows 64 bit" id="87" mediaFileName="${compiler:sys.fullName}_${compiler:sys.version}_windows-64bit">
       <jreBundle usePack200="false" directDownload="true" />
     </windows>

--- a/game-app/game-headed/build.install4j
+++ b/game-app/game-headed/build.install4j
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="9.0.5" transformSequenceNumber="9">
+<install4j version="11.0.3" transformSequenceNumber="11">
   <directoryPresets config=".triplea-root" />
   <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="https://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="17" jdkMode="jdk">
     <jreBundles jdkProviderId="AdoptOpenJDK" release="21/jdk-21.0.7+6" />
   </application>
-  <files preserveSymlinks="false">
+  <files>
     <mountPoints>
       <mountPoint id="28" location="assets" />
       <mountPoint id="23" location="bin" />
@@ -17,7 +17,7 @@
     </entries>
   </files>
   <launchers>
-    <launcher name="TripleA" id="33" menuName="TripleA-${compiler:sys.version}" macStaticAssociationsForInstallers="true">
+    <launcher name="TripleA" id="33" menuName="TripleA-${compiler:sys.version}">
       <executable name="TripleA" iconSet="true" stderrMode="append" executableMode="gui" checkConsoleParameter="true" dpiAware="true">
         <versionInfo internalName="TripleA" productName="TripleA Game" />
       </executable>
@@ -32,10 +32,6 @@
           <scanDirectory location="bin" failOnError="false" />
         </classPath>
       </java>
-      <macStaticAssociationActions mode="selected">
-        <id>554</id>
-        <id>263</id>
-      </macStaticAssociationActions>
       <vmOptionsFile mode="none" overwriteMode="3" />
       <iconImageFiles>
         <file path="./assets/icons/triplea_icon_16_16.png" />
@@ -45,6 +41,10 @@
         <file path="./assets/icons/triplea_icon_128_128.png" />
         <file path="./assets/icons/triplea_icon_256_256.png" />
       </iconImageFiles>
+      <macStaticAssociations>
+        <fileAssociation extension="tsvg" description="TripleA Savegame" />
+        <urlHandler scheme="triplea" />
+      </macStaticAssociations>
     </launcher>
   </launchers>
   <installerGui suggestPreviousLocations="false">
@@ -787,12 +787,12 @@ return true;</property>
     </styles>
   </installerGui>
   <mediaSets>
-    <windows name="Windows 64 bit" id="87" mediaFileName="${compiler:sys.fullName}_${compiler:sys.version}_windows-64bit">
-      <jreBundle usePack200="false" directDownload="true" />
+    <windows name="Windows 64 bit" id="87" mediaFileName="${compiler:sys.fullName}_${compiler:sys.version}_windows-64bit" architecture="64">
+      <jreBundle usePack200="false" />
     </windows>
     <macosArchive name="macOS Single Bundle Archive" id="557" architecture="universal" launcherId="33" />
     <unixInstaller name="Unix" id="36">
-      <jreBundle usePack200="false" directDownload="true" installOnlyIfNecessary="true" />
+      <jreBundle usePack200="false" />
     </unixInstaller>
   </mediaSets>
 </install4j>

--- a/game-app/run/package
+++ b/game-app/run/package
@@ -27,8 +27,26 @@ function install_install4j() {
   mkdir -p $INSTALL4J_HOME
 
   echo "Downloading and installing install4j to '$INSTALL4J_HOME'"
-  wget --no-verbose -O install4j_unix.sh \
-  https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_linux-x64_9_0_5.sh
+  install4j_url="https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_linux-x64_11_0_3.sh"
+
+  # The install4j file is host on github LFS
+  # The 'install4j_url' gives us manifest data, we first get the SHA & size of the object we are downloading
+  sha=$(curl -s "$install4j_url" | grep "^oid" | sed 's/.*sha256://')
+  size=$(curl -s "$install4j_url" | grep "^size" | sed 's/.* //')
+
+  # Now, we can send a request to github LFS for the download URL of the object, we do so, and we get back a response.
+  # We use 'jq' to parse the JSON response for the download href.
+  downloadUrl=$(
+    curl -s -X POST \
+      -H "Accept: application/vnd.git-lfs+json" \
+      -H "Content-type: application/json" \
+      -d "{\"operation\": \"download\", \"transfer\": [\"basic\"], \"objects\": [{\"oid\": \"$sha\", \"size\": $size}]}" \
+      https://github.com/triplea-game/assets.git/info/lfs/objects/batch \
+    | jq -r '.objects[0].actions.download.href')
+
+  # Now, do the download, download the installer
+  wget --no-verbose -O install4j_unix.sh "$downloadUrl"
+
   chmod +x install4j_unix.sh
   ./install4j_unix.sh -q -dir "$INSTALL4J_HOME"
   "$INSTALL4J_HOME/bin/install4jc" -L "$INSTALL4J_LICENSE"

--- a/lib/java-extras/src/test/java/org/triplea/java/DateTimeUtilTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/java/DateTimeUtilTest.java
@@ -25,16 +25,18 @@ class DateTimeUtilTest {
 
   @Nested
   class LocalizedTime {
+    private static final String NARROW_NON_BREAKING_SPACE = "\u202F";
+
     @Test
     void localedTimeUs() {
       DateTimeUtil.defaultLocale = Locale.US;
-      assertThat(DateTimeUtil.getLocalizedTime(), is("2:30:00 PM"));
+      assertThat(DateTimeUtil.getLocalizedTime(), is("2:30:00" + NARROW_NON_BREAKING_SPACE + "PM"));
     }
 
     @Test
     void localedTimeUk() {
       DateTimeUtil.defaultLocale = Locale.ENGLISH;
-      assertThat(DateTimeUtil.getLocalizedTime(), is("2:30:00 PM"));
+      assertThat(DateTimeUtil.getLocalizedTime(), is("2:30:00" + NARROW_NON_BREAKING_SPACE + "PM"));
     }
 
     @Test

--- a/lib/java-extras/src/test/java/org/triplea/java/DateTimeUtilTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/java/DateTimeUtilTest.java
@@ -25,22 +25,8 @@ class DateTimeUtilTest {
 
   @Nested
   class LocalizedTime {
-    private static final String NARROW_NON_BREAKING_SPACE = "\u202F";
-
     @Test
-    void localedTimeUs() {
-      DateTimeUtil.defaultLocale = Locale.US;
-      assertThat(DateTimeUtil.getLocalizedTime(), is("2:30:00" + NARROW_NON_BREAKING_SPACE + "PM"));
-    }
-
-    @Test
-    void localedTimeUk() {
-      DateTimeUtil.defaultLocale = Locale.ENGLISH;
-      assertThat(DateTimeUtil.getLocalizedTime(), is("2:30:00" + NARROW_NON_BREAKING_SPACE + "PM"));
-    }
-
-    @Test
-    void localedTimeFrance() {
+    void localTimeFrance() {
       DateTimeUtil.defaultLocale = Locale.FRANCE;
       assertThat(DateTimeUtil.getLocalizedTime(), is("14:30:00"));
     }


### PR DESCRIPTION
- Updates source code to use Java 21
  -  Tweaked unit tests and PMD config for fixes
  - Updated Lombok version for compatibility  
- Updates installers to have JDK21 bundled
  - Windows 32 bit installer is no longer created
- Install4j version is updated to install4j11
  - Install4j11 installer file is 150MB, Git required that to be hosted with Git LFS; the download script is modified to go through that process.