### PR TITLE
12637 (relationship of territory owner in taskbar)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -1,5 +1,8 @@
 package games.strategy.triplea.ui;
 
+import static games.strategy.engine.framework.lookandfeel.LookAndFeel.convertColorToHex;
+import static games.strategy.engine.framework.lookandfeel.LookAndFeel.getRelationshipTypeAttachmentColor;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Resource;
@@ -9,12 +12,8 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.events.TerritoryListener;
 import games.strategy.engine.data.events.ZoomMapListener;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.attachments.RelationshipTypeAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.GridBagLayout;
-import java.awt.Image;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.List;
@@ -63,28 +62,28 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
     this.uiContext = uiContext;
     this.resourceBar = new ResourceBar(data, uiContext);
 
-    setLayout(new BorderLayout());
-    add(createCenterPanel(), BorderLayout.CENTER);
-    add(createStepPanel(usingDiceServer), BorderLayout.EAST);
+    setLayout(new java.awt.BorderLayout());
+    add(createCenterPanel(), java.awt.BorderLayout.CENTER);
+    add(createStepPanel(usingDiceServer), java.awt.BorderLayout.EAST);
   }
 
   private JPanel createCenterPanel() {
     final JPanel centerPanel = new JPanel();
-    centerPanel.setLayout(new GridBagLayout());
+    centerPanel.setLayout(new java.awt.GridBagLayout());
     final var gridBuilder =
         new GridBagConstraintsBuilder().weightY(1).fill(GridBagConstraintsFill.BOTH);
 
     centerPanel.add(
         resourceBar, gridBuilder.weightX(0).anchor(GridBagConstraintsAnchor.WEST).build());
 
-    territoryInfo.setPreferredSize(new Dimension(0, 0));
+    territoryInfo.setPreferredSize(new java.awt.Dimension(0, 0));
     territoryInfo.setBorder(new EtchedBorder(EtchedBorder.RAISED));
     centerPanel.add(
         territoryInfo,
         gridBuilder.gridX(1).weightX(1).anchor(GridBagConstraintsAnchor.CENTER).build());
 
     statusMessage.setVisible(false);
-    statusMessage.setPreferredSize(new Dimension(0, 0));
+    statusMessage.setPreferredSize(new java.awt.Dimension(0, 0));
     statusMessage.setBorder(new EtchedBorder(EtchedBorder.RAISED));
 
     zoomLabel.setVisible(false);
@@ -99,7 +98,7 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
 
   private JPanel createStepPanel(boolean usingDiceServer) {
     final JPanel stepPanel = new JPanel();
-    stepPanel.setLayout(new GridBagLayout());
+    stepPanel.setLayout(new java.awt.GridBagLayout());
     final var gridBuilder = new GridBagConstraintsBuilder().fill(GridBagConstraintsFill.BOTH);
     stepPanel.add(playerLabel, gridBuilder.gridX(0).build());
     stepPanel.add(stepLabel, gridBuilder.gridX(1).build());
@@ -116,7 +115,7 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
     return stepPanel;
   }
 
-  public void setStatus(final String msg, final Optional<Image> image) {
+  public void setStatus(final String msg, final Optional<java.awt.Image> image) {
     statusMessage.setVisible(!msg.isEmpty());
     statusMessage.setText(msg);
 
@@ -173,7 +172,7 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
     // Box layout with horizontal glue on both sides achieves the following desirable properties:
     //   1. If the content is narrower than the available space, it will be centered.
     //   2. If the content is wider than the available space, then the beginning will be shown,
-    //      which is the more important information (territory name, income, etc).
+    //      which is the more important information (territory name, income, etc.).
     //   3. Elements are vertically centered.
     territoryInfo.removeAll();
     territoryInfo.setLayout(new BoxLayout(territoryInfo, BoxLayout.LINE_AXIS));
@@ -208,7 +207,7 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
 
     if (!units.isEmpty()) {
       JSeparator separator = new JSeparator(JSeparator.VERTICAL);
-      separator.setMaximumSize(new Dimension(40, getHeight()));
+      separator.setMaximumSize(new java.awt.Dimension(40, getHeight()));
       separator.setPreferredSize(separator.getMaximumSize());
       territoryInfo.add(separator);
       territoryInfo.add(createUnitBar(units));
@@ -222,7 +221,7 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
     String labelTextPattern = getTerritoryLabelTextPattern(territory);
     final JLabel nameLabel =
         new JLabel(MessageFormat.format(labelTextPattern, territory.getName()));
-    nameLabel.setFont(nameLabel.getFont().deriveFont(Font.BOLD));
+    nameLabel.setFont(nameLabel.getFont().deriveFont(java.awt.Font.BOLD));
     // Ensure the text position is always the same, regardless of other components, by padding to
     // fill available height.
     final int labelHeight = nameLabel.getPreferredSize().height;
@@ -233,17 +232,27 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
   private @NotNull String getTerritoryLabelTextPattern(Territory territory) {
     GamePlayer territoryOwner = territory.getOwner();
     GamePlayer currentPlayer = uiContext.getCurrentPlayer();
-    String labelTextPattern;
     if (territoryOwner.equals(currentPlayer)) {
-      labelTextPattern = "<html>{0} (current player)</html>";
-    } else if (territoryOwner.isAtWar(currentPlayer)) {
-      labelTextPattern = "<html>{0} (<font color=red>At War</font>)</html>";
-    } else if (territoryOwner.isAllied(currentPlayer)) {
-      labelTextPattern = "<html>{0} (<font color=green>Allied</font>)</html>";
-    } else {
-      labelTextPattern = "<html>{0}</html>";
+      return "<html>{0} (current player)</html>";
     }
-    return labelTextPattern;
+    final RelationshipTypeAttachment relationshipTypeAttachment =
+        territory
+            .getData()
+            .getRelationshipTracker()
+            .getRelationshipType(territoryOwner, currentPlayer)
+            .getRelationshipTypeAttachment();
+    String strArchType;
+    if (relationshipTypeAttachment.isWar()) {
+      strArchType = "at War";
+    } else if (relationshipTypeAttachment.isAllied()) {
+      strArchType = "Allied";
+    } else {
+      strArchType = relationshipTypeAttachment.getArcheType();
+    }
+    return MessageFormat.format(
+        "<html>'{'0'}' (<font color={0}>{1}</font>)</html>",
+        convertColorToHex(getRelationshipTypeAttachmentColor(relationshipTypeAttachment)),
+        strArchType);
   }
 
   private Border createBorderToFillAvailableHeight(int componentHeight, int availableHeight) {
@@ -261,7 +270,7 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
     // Constrain the preferred size to the available size so that unit images that may not fully fit
     // don't cause layout issues.
     final int unitsWidth = unitBar.getPreferredSize().width;
-    unitBar.setPreferredSize(new Dimension(unitsWidth, getHeight()));
+    unitBar.setPreferredSize(new java.awt.Dimension(unitsWidth, getHeight()));
     return unitBar;
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -18,13 +18,11 @@ import org.triplea.swing.SwingComponents;
 import org.triplea.swing.WrapLayout;
 
 /**
- * A UI component used to display a dice roll. One image is displayed per die in a horizontal
+ * A UI component used to display a roll of dice. One image is displayed per die in a horizontal
  * layout.
  */
 public class DicePanel extends JPanel {
   private static final long serialVersionUID = -7544999867518263506L;
-
-  private static final String DARKER_RED = "#8B0000";
 
   private final UiContext uiContext;
   private final GameData data;
@@ -73,9 +71,7 @@ public class DicePanel extends JPanel {
   }
 
   private static String colorizeHitString(final Object hitsString) {
-    // On a dark theme, use red. Use a darker red with a light theme.
-    final String color = LookAndFeel.isCurrentLookAndFeelDark() ? "red" : DARKER_RED;
-    return "<font color='" + color + "'>" + hitsString + "</font>";
+    return "<font color='" + LookAndFeel.getLookAndFeelColorRed() + "'>" + hitsString + "</font>";
   }
 
   private void add(final JComponent component) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -3,8 +3,7 @@ package games.strategy.triplea.ui;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.RelationshipType;
-import games.strategy.triplea.Constants;
-import java.awt.Color;
+import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -135,7 +134,7 @@ public class PoliticalStateOverview extends JPanel {
     final JPanel panel =
         new JPanelBuilder().add(getRelationshipComponent(player1, player2, relType)).build();
     panel.setOpaque(true);
-    panel.setBackground(getRelationshipTypeColor(relType));
+    panel.setBackground(LookAndFeel.getRelationshipTypeColor(relType));
     return panel;
   }
 
@@ -206,31 +205,8 @@ public class PoliticalStateOverview extends JPanel {
             redrawPolitics();
           }
         });
-    button.setBackground(getRelationshipTypeColor(relType));
+    button.setBackground(LookAndFeel.getRelationshipTypeColor(relType));
     return button;
-  }
-
-  /**
-   * returns a color to represent the relationship.
-   *
-   * @param relType which relationship to get the color for
-   * @return the color to represent this relationship
-   */
-  private static Color getRelationshipTypeColor(final RelationshipType relType) {
-    final String archeType = relType.getRelationshipTypeAttachment().getArcheType();
-    if (archeType.equals(Constants.RELATIONSHIP_ARCHETYPE_ALLIED)) {
-      return Color.green;
-    }
-    if (archeType.equals(Constants.RELATIONSHIP_ARCHETYPE_NEUTRAL)) {
-      return Color.lightGray;
-    }
-    if (archeType.equals(Constants.RELATIONSHIP_ARCHETYPE_WAR)) {
-      return Color.red;
-    }
-    throw new IllegalStateException(
-        "PoliticsUI: RelationshipType: "
-            + relType.getName()
-            + " can only be of archeType Allied, Neutral or War");
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -184,7 +184,7 @@ public class UiContext {
     if (player != null && !player.equals(currentPlayer)
         || player == null && currentPlayer != null) {
       currentPlayer = player;
-      isCurrentPlayerRemote = localPlayers.playing(player);
+      isCurrentPlayerRemote = !localPlayers.playing(player);
       return true;
     }
     return false;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -92,6 +92,8 @@ public class UiContext {
 
   @Getter private boolean isShutDown = false;
 
+  @Getter private GamePlayer currentPlayer;
+  @Getter private boolean isCurrentPlayerRemote;
   private final List<Window> windowsToCloseOnShutdown = new ArrayList<>();
   private final List<Runnable> activeToDeactivate = new ArrayList<>();
   private final CountDownLatchHandler latchesToCloseOnShutdown = new CountDownLatchHandler(false);
@@ -172,6 +174,22 @@ public class UiContext {
     tooltipProperties = new TooltipProperties(this);
   }
 
+  /**
+   * Sets new @param(currentPlayer)
+   *
+   * @param player new current player
+   * @return true if new player has been set, false if player was already set
+   */
+  public boolean setCurrentPlayer(GamePlayer player) {
+    if (player != null && !player.equals(currentPlayer)
+        || player == null && currentPlayer != null) {
+      currentPlayer = player;
+      isCurrentPlayerRemote = localPlayers.playing(player);
+      return true;
+    }
+    return false;
+  }
+
   public JLabel newUnitImageLabel(final ImageKey imageKey) {
     final JLabel label = new JLabel(getUnitImageFactory().getIcon(imageKey));
     MapUnitTooltipManager.setUnitTooltip(label, imageKey.getType(), imageKey.getPlayer(), 1, this);
@@ -221,21 +239,22 @@ public class UiContext {
 
   public void setUnitScaleFactor(final double scaleFactor) {
     unitImageFactory = unitImageFactory.withScaleFactor(scaleFactor);
-    final Preferences prefs =
-        getPreferencesMapOrSkin(Optional.ofNullable(skinName).orElse(mapName));
-    prefs.putDouble(UNIT_SCALE_PREF, scaleFactor);
-    try {
-      prefs.flush();
-    } catch (final BackingStoreException e) {
-      log.error("Failed to flush preferences: " + prefs.absolutePath(), e);
-    }
+    putDoubleToPreferences(UNIT_SCALE_PREF, scaleFactor);
   }
 
   public void setScale(final double scale) {
     this.scale = scale;
+    putDoubleToPreferences(MAP_SCALE_PREF, scale);
+  }
+
+  private void putDoubleToPreferences(String mapScalePref, double scale) {
     final Preferences prefs =
         getPreferencesMapOrSkin(Optional.ofNullable(skinName).orElse(mapName));
-    prefs.putDouble(MAP_SCALE_PREF, scale);
+    prefs.putDouble(mapScalePref, scale);
+    flushPreferences(prefs);
+  }
+
+  private static void flushPreferences(Preferences prefs) {
     try {
       prefs.flush();
     } catch (final BackingStoreException e) {
@@ -261,11 +280,7 @@ public class UiContext {
     } else {
       prefs.remove(MAP_SKIN_PREF);
     }
-    try {
-      prefs.flush();
-    } catch (final BackingStoreException e) {
-      log.error("Failed to flush preferences: " + prefs.absolutePath(), e);
-    }
+    flushPreferences(prefs);
     UiContext uiContext = new UiContext(gameData);
     uiContext.getMapData().verify(gameData);
     return uiContext;
@@ -406,11 +421,7 @@ public class UiContext {
   public void setShowEndOfTurnReport(final boolean value) {
     final Preferences prefs = Preferences.userNodeForPackage(UiContext.class);
     prefs.putBoolean(SHOW_END_OF_TURN_REPORT, value);
-    try {
-      prefs.flush();
-    } catch (final BackingStoreException ex) {
-      log.error("Failed to flush preferences: " + prefs.absolutePath(), ex);
-    }
+    flushPreferences(prefs);
   }
 
   public boolean getShowTriggeredNotifications() {
@@ -421,11 +432,7 @@ public class UiContext {
   public void setShowTriggeredNotifications(final boolean value) {
     final Preferences prefs = Preferences.userNodeForPackage(UiContext.class);
     prefs.putBoolean(SHOW_TRIGGERED_NOTIFICATIONS, value);
-    try {
-      prefs.flush();
-    } catch (final BackingStoreException ex) {
-      log.error("Failed to flush preferences: " + prefs.absolutePath(), ex);
-    }
+    flushPreferences(prefs);
   }
 
   public boolean getShowTriggerChanceSuccessful() {
@@ -436,11 +443,7 @@ public class UiContext {
   public void setShowTriggerChanceSuccessful(final boolean value) {
     final Preferences prefs = Preferences.userNodeForPackage(UiContext.class);
     prefs.putBoolean(SHOW_TRIGGERED_CHANCE_SUCCESSFUL, value);
-    try {
-      prefs.flush();
-    } catch (final BackingStoreException ex) {
-      log.error("Failed to flush preferences: " + prefs.absolutePath(), ex);
-    }
+    flushPreferences(prefs);
   }
 
   public boolean getShowTriggerChanceFailure() {
@@ -451,10 +454,6 @@ public class UiContext {
   public void setShowTriggerChanceFailure(final boolean value) {
     final Preferences prefs = Preferences.userNodeForPackage(UiContext.class);
     prefs.putBoolean(SHOW_TRIGGERED_CHANCE_FAILURE, value);
-    try {
-      prefs.flush();
-    } catch (final BackingStoreException ex) {
-      log.error("Failed to flush preferences: " + prefs.absolutePath(), ex);
-    }
+    flushPreferences(prefs);
   }
 }


### PR DESCRIPTION
issue [12637](https://github.com/triplea-game/triplea/issues/12637) (Show Political relationship of a territory on the Taskbar)

BottomBar.java
- new method getTerritoryLabelTextPattern: return html patterns for different texts (incl. coloring) and determine from relationshipTypeAttachment (archeType)
- change createTerritoryNameLabel: use new patterns

DicePanel.java
- colorizeHitString: extract HTML color text logic into class LookAndFeel

LookAndFeel.java
- new method getLookAndFeelColorRed
- change setupLookAndFeel to avoid throwable in catch statement
- new method convertColorToHex
- new method getRelationshipTypeColor
- new method getRelationshipTypeAttachmentColor

PoliticalStateOverview.java
-extract method getRelationshipTypeColor into class LookAndFeel

TripleAFrame.java
- move member lastPlayer to UiContext as currentPlayer
- replace bottomBar updates via setCurrentPlayer with uiContext.setCurrentPlayer(player) and bottomBar.updateFromCurrentPlayer
- adjust parameters for bottomBar.setStepInfo

UiContext.java
- add members currentPlayer and isCurrentPlayerRemote (incl. Getters)
- new setCurrentPlayer(player): evaluates update for member currentPlayer and sets isCurrentPlayerRemote from member localPlayer
- new method putDoubleToPreferences to avoid duplicated code

UnitStatsTable.java
- getUnitStatsTable: rename color variables to proper color names
- getPlayerUnitsWithImages: extract new method fillPlayerUnitTypesFromProductionAbility
- method getUnitStatsTable: extract method addUnitStatsTableLineColored