### PR TITLE
fix 13372 (NPE RelationshipTracker#getRelationshipType)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A collection of relationships between any two players. Provides methods that determine whether
@@ -47,7 +48,8 @@ public class RelationshipTracker extends GameDataComponent {
     relationships.put(new RelatedPlayers(p1, p2), new Relationship(r, roundValue));
   }
 
-  public RelationshipType getRelationshipType(final GamePlayer p1, final GamePlayer p2) {
+  public RelationshipType getRelationshipType(
+      @NotNull final GamePlayer p1, @NotNull final GamePlayer p2) {
     return getRelationship(p1, p2).getRelationshipType();
   }
 
@@ -59,11 +61,11 @@ public class RelationshipTracker extends GameDataComponent {
     return relationships.get(p1p2);
   }
 
-  public Relationship getRelationship(final GamePlayer p1, final GamePlayer p2) {
+  public Relationship getRelationship(@NotNull final GamePlayer p1, @NotNull final GamePlayer p2) {
     return getRelationship(new RelatedPlayers(p1, p2));
   }
 
-  public Set<Relationship> getRelationships(final GamePlayer player1) {
+  public Set<Relationship> getRelationships(@NotNull final GamePlayer player1) {
     final Set<Relationship> relationships = new HashSet<>();
     for (final GamePlayer player2 : getData().getPlayerList().getPlayers()) {
       if (player2 == null || player2.equals(player1)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -14,6 +14,7 @@ import games.strategy.engine.data.events.ZoomMapListener;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.RelationshipTypeAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
+import java.awt.Image;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.List;
@@ -115,15 +116,24 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
     return stepPanel;
   }
 
-  public void setStatus(final String msg, final Optional<java.awt.Image> image) {
+  private void setStatus(final String msg) {
     statusMessage.setVisible(!msg.isEmpty());
     statusMessage.setText(msg);
+  }
 
-    if (!msg.isEmpty() && image.isPresent()) {
-      statusMessage.setIcon(new ImageIcon(image.get()));
+  public void setStatus(final String msg, final Image image) {
+    setStatus(msg);
+
+    if (!msg.isEmpty()) {
+      statusMessage.setIcon(new ImageIcon(image));
     } else {
       statusMessage.setIcon(null);
     }
+  }
+
+  public void setStatusAndClearIcon(final String msg) {
+    setStatus(msg);
+    statusMessage.setIcon(null);
   }
 
   public void setTerritory(final @Nullable Territory territory) {
@@ -231,12 +241,15 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
 
   private @NotNull String getTerritoryLabelTextPattern(Territory territory) {
     GamePlayer territoryOwner = territory.getOwner();
+    if (territoryOwner == null) return "";
     GamePlayer currentPlayer = uiContext.getCurrentPlayer();
+    if (currentPlayer == null)
+      currentPlayer = territoryOwner.getData().getPlayerList().getNullPlayer();
     if (territoryOwner.equals(currentPlayer)) {
       return "<html>{0} (current player)</html>";
     }
     final RelationshipTypeAttachment relationshipTypeAttachment =
-        territory
+        territoryOwner
             .getData()
             .getRelationshipTracker()
             .getRelationshipType(territoryOwner, currentPlayer)

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -629,15 +629,19 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   }
 
   void clearStatusMessage() {
-    bottomBar.setStatus("", Optional.empty());
+    bottomBar.setStatusAndClearIcon("");
   }
 
   public void setStatusErrorMessage(final String msg) {
-    bottomBar.setStatus(msg, mapPanel.getErrorImage());
+    final Optional<Image> errorImage = mapPanel.getErrorImage();
+    if (errorImage.isPresent()) bottomBar.setStatus(msg, errorImage.get());
+    else bottomBar.setStatusAndClearIcon(msg);
   }
 
   public void setStatusWarningMessage(final String msg) {
-    bottomBar.setStatus(msg, mapPanel.getWarningImage());
+    final Optional<Image> warningImage = mapPanel.getWarningImage();
+    if (warningImage.isPresent()) bottomBar.setStatus(msg, warningImage.get());
+    else bottomBar.setStatusAndClearIcon(msg);
   }
 
   public IntegerMap<ProductionRule> getProduction(


### PR DESCRIPTION
GameProperties.java
- method getPlayerProperty: Change (nullable) return value to Optional

BottomBar.java
- rework method setStatus with Optional: setStatus with and without Image parameter and new method setStatusAndClearIcon
- method getTerritoryLabelTextPattern: handle cases of territoryOwner/currentPlayer = null
 
RelationshipTracker.java
- method setStatus with Optional: Split into setStatus with Image parameter and without and new method setStatusAndClearIcon
- method getTerritoryLabelTextPattern: Handle null cases for territoryOwner and current Player; use getData from territoryOwner

RelationshipTracker.java
- methods getRelationshipType/getRelationship: annotated GamePlayer parameter as NotNull

TripleAFrame.java
- methods clearStatusMessage/setStatusErrorMessage/setStatusWarningMessage: reworked usage of BottomBar.setStatus
