### PR TITLE
13372 npe relationship tracker

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -149,9 +148,7 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
         territoryEffectNames = List.of();
       } else {
         territoryEffectNames =
-            ta.getTerritoryEffect().stream()
-                .map(TerritoryEffect::getName)
-                .collect(Collectors.toList());
+            ta.getTerritoryEffect().stream().map(TerritoryEffect::getName).toList();
         final int production = ta.getProduction();
         if (production > 0) {
           resources.add(new Resource(Constants.PUS, territory.getData()), production);
@@ -194,7 +191,7 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
 
     territoryInfo.add(createTerritoryNameLabel(territory));
 
-    if (territoryEffectText.length() > 0) {
+    if (!territoryEffectText.isEmpty()) {
       territoryEffectText.setLength(territoryEffectText.length() - 2);
       final JLabel territoryEffectTextLabel = new JLabel(" (" + territoryEffectText + ")");
       territoryInfo.add(territoryEffectTextLabel);
@@ -236,7 +233,7 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
       return "<html>{0} (current player)</html>";
     }
     final RelationshipTypeAttachment relationshipTypeAttachment =
-        territory
+        territoryOwner
             .getData()
             .getRelationshipTracker()
             .getRelationshipType(territoryOwner, currentPlayer)
@@ -333,10 +330,14 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
   }
 
   @Override
-  public void ownerChanged(Territory territory) {}
+  public void ownerChanged(Territory territory) {
+    /*interface method*/
+  }
 
   @Override
-  public void attachmentChanged(Territory territory) {}
+  public void attachmentChanged(Territory territory) {
+    /*interface method*/
+  }
 
   @Override
   public void zoomMapChanged(Integer newZoom) {


### PR DESCRIPTION
additional fix 13372 (NPE RelationshipTracker#getRelationshipType) 

BottomBar.java
- method getTerritoryLabelTextPattern: Switch territory to territoryOwner to get data
- method updateTerritoryInfo: From .length() > 0 to !.isEmpty()
- methods ownerChanged and attachmentChanged: comment for why empty

