### PR TITLE
fix 13390 and 13387 (List UnsupportedOperationException)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -53,7 +53,10 @@ public class PlayerUnitsPanel extends JPanel {
   }
 
   public List<Unit> getUnits() {
-    return unitPanels.stream().map(UnitPanel::getUnits).flatMap(Collection::stream).toList();
+    return unitPanels.stream()
+        .map(UnitPanel::getUnits)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
   }
 
   /** Sets up components to an initial state. */


### PR DESCRIPTION
fix issue https://github.com/triplea-game/triplea/issues/13390
fix issue https://github.com/triplea-game/triplea/issues/13387

introduced by
fix 12868 (NPE UnitSeparator#getComparatorUnitCategories) (#13374)

PlayerUnitsPanel.java
- method getUnits: revert to Collectors.toList() to have modifiable list again
