### PR TITLE
NoReturnNull for Route

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
@@ -296,19 +297,45 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *
    * @param cond condition that covered territories of the route must match
    */
-  public @Nullable Route getRoute(
+  public Optional<Route> getRoute(
       @Nonnull final Territory start,
       @Nonnull final Territory end,
       final Predicate<Territory> cond) {
     checkNotNull(start);
     checkNotNull(end);
-    return new RouteFinder(this, Matches.territoryIs(end).or(cond))
-        .findRouteByDistance(start, end)
-        .orElse(null);
+    return new RouteFinder(this, Matches.territoryIs(end).or(cond)).findRouteByDistance(start, end);
+  }
+
+  /**
+   * Calls getRoute and throws IllegalStateException in case no Route instance could be found. Only
+   * use this method in case it is supposed to be assumed such a Route can be found. See {@link
+   * #getRoute(Territory, Territory, Predicate)}.
+   */
+  public Route getRouteOrElseThrow(
+      @Nonnull final Territory start,
+      @Nonnull final Territory end,
+      final Predicate<Territory> cond) {
+    return getRoute(start, end, cond)
+        .orElseThrow(() -> new IllegalStateException("Route expected to be returned"));
+  }
+
+  /**
+   * Calls getRouteForUnits and throws IllegalStateException in case no Route instance could be
+   * found. Only use this method in case it is supposed to be assumed such a Route can be found. See
+   * {@link #getRouteForUnits(Territory, Territory, Predicate, Collection, GamePlayer)}.
+   */
+  public Route getRouteForUnitOrElseThrow(
+      @Nonnull final Territory start,
+      @Nonnull final Territory end,
+      final Predicate<Territory> cond,
+      final Unit unit,
+      final GamePlayer player) {
+    return getRouteForUnits(start, end, cond, List.of(unit), player)
+        .orElseThrow(() -> new IllegalStateException("Route expected to be returned"));
   }
 
   /** See {@link #getRouteForUnits(Territory, Territory, Predicate, Collection, GamePlayer)}. */
-  public @Nullable Route getRouteForUnit(
+  public Optional<Route> getRouteForUnit(
       @Nonnull final Territory start,
       @Nonnull final Territory end,
       final Predicate<Territory> cond,
@@ -328,7 +355,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param units checked against canals and for movement costs
    * @param player player used to check canal ownership
    */
-  public @Nullable Route getRouteForUnits(
+  public Optional<Route> getRouteForUnits(
       @Nonnull final Territory start,
       @Nonnull final Territory end,
       final Predicate<Territory> cond,
@@ -337,8 +364,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     checkNotNull(start);
     checkNotNull(end);
     return new RouteFinder(this, Matches.territoryIs(end).or(cond), units, player)
-        .findRouteByCost(start, end)
-        .orElse(null);
+        .findRouteByCost(start, end);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
@@ -79,9 +80,9 @@ public class Route implements Serializable, Iterable<Territory> {
    * @return a new Route starting at r1.start() going to r2.end() along r1, r2, or null if the
    *     routes can't be joined it the joining would form a loop
    */
-  public static @Nullable Route join(final @Nullable Route r1, final @Nullable Route r2) {
+  public static Optional<Route> join(final @Nullable Route r1, final @Nullable Route r2) {
     if (r1 == null || r2 == null) {
-      return null;
+      return Optional.empty();
     }
     if (r1.numberOfSteps() == 0) {
       if (!r1.getStart().equals(r2.getStart())) {
@@ -97,7 +98,7 @@ public class Route implements Serializable, Iterable<Territory> {
     final Collection<Territory> c1 = new ArrayList<>(r1.steps);
     c1.add(r1.getStart());
     if (!CollectionUtils.intersection(c1, r2.steps).isEmpty()) {
-      return null;
+      return Optional.empty();
     }
     final Route joined = new Route(r1.getStart());
     for (final Territory t : r1.getSteps()) {
@@ -106,7 +107,7 @@ public class Route implements Serializable, Iterable<Territory> {
     for (final Territory t : r2.getSteps()) {
       joined.add(t);
     }
-    return joined;
+    return Optional.of(joined);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -1745,7 +1745,7 @@ class ProPurchaseAi {
         if (enemySeaUnits.isEmpty()) {
           continue;
         }
-        final Route route =
+        final Optional<Route> optionalRoute =
             data.getMap()
                 .getRouteForUnits(
                     t,
@@ -1753,10 +1753,10 @@ class ProPurchaseAi {
                     Matches.territoryIsWater(),
                     enemySeaUnits,
                     enemySeaUnits.get(0).getOwner());
-        if (route == null) {
+        if (optionalRoute.isEmpty()) {
           continue;
         }
-        final int routeLength = route.numberOfSteps();
+        final int routeLength = optionalRoute.get().numberOfSteps();
         if (routeLength <= enemyDistance) {
           enemyUnitsInSeaTerritories.addAll(enemySeaUnits);
         }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -228,10 +229,11 @@ final class ProTechAi {
               continue;
             }
             if (!t4.equals(waterCheck)) {
-              final Route seaRoute =
+              final Optional<Route> optionalSeaRoute =
                   getMaxSeaRoute(
                       data, t4, waterCheck, transports, enemyPlayer, maxTransportDistance);
-              if (seaRoute == null || !seaRoute.getEnd().equals(waterCheck)) {
+              if (optionalSeaRoute.isEmpty()
+                  || !optionalSeaRoute.get().getEnd().equals(waterCheck)) {
                 continue;
               }
             }
@@ -557,7 +559,7 @@ final class ProTechAi {
     return airStrength;
   }
 
-  private static Route getMaxSeaRoute(
+  private static Optional<Route> getMaxSeaRoute(
       final GameState data,
       final Territory start,
       final Territory destination,
@@ -579,18 +581,20 @@ final class ProTechAi {
             .build();
     final Predicate<Territory> routeCond =
         Matches.territoryHasUnitsThatMatch(unitCond).negate().and(Matches.territoryIsWater());
-    Route r = data.getMap().getRouteForUnits(start, destination, routeCond, units, player);
-    if (r == null) {
-      return null;
+    final Optional<Route> optionalRoute =
+        data.getMap().getRouteForUnits(start, destination, routeCond, units, player);
+    if (optionalRoute.isEmpty()) {
+      return optionalRoute;
     }
-    final int routeDistance = r.numberOfSteps();
+    Route route = optionalRoute.get();
+    final int routeDistance = route.numberOfSteps();
     if (routeDistance > maxDistance) {
       final List<Territory> territories = new ArrayList<>();
       territories.add(start);
-      territories.addAll(r.getSteps().subList(0, maxDistance));
-      r = new Route(territories);
+      territories.addAll(route.getSteps().subList(0, maxDistance));
+      route = new Route(territories);
     }
-    return r;
+    return Optional.of(route);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -763,13 +763,13 @@ public class ProTerritoryManager {
 
         for (final Territory potentialTerritory : potentialTerritories) {
           // Find route over water
-          final Route myRoute =
+          final Optional<Route> optionalRoute =
               gameMap.getRouteForUnit(
                   myUnitTerritory, potentialTerritory, canMove, mySeaUnit, player);
-          if (myRoute == null) {
+          if (optionalRoute.isEmpty()) {
             continue;
           }
-          final BigDecimal myRouteLength = myRoute.getMovementCost(mySeaUnit);
+          final BigDecimal myRouteLength = optionalRoute.get().getMovementCost(mySeaUnit);
           if (myRouteLength.compareTo(range) > 0) {
             continue;
           }
@@ -867,19 +867,21 @@ public class ProTerritoryManager {
       final Territory to,
       final BigDecimal range,
       final Predicate<Territory> canMove) {
-    Route r = player.getData().getMap().getRouteForUnit(from, to, canMove, u, player);
-    if (r == null) {
+    final Optional<Route> optionalRoute =
+        player.getData().getMap().getRouteForUnit(from, to, canMove, u, player);
+    if (optionalRoute.isEmpty()) {
       return false;
     }
-    if (r.hasMoreThanOneStep()
-        && r.getMiddleSteps().stream().anyMatch(Matches.isTerritoryEnemy(player))
+    final Route route = optionalRoute.get();
+    if (route.hasMoreThanOneStep()
+        && route.getMiddleSteps().stream().anyMatch(Matches.isTerritoryEnemy(player))
         && Matches.unitIsOfTypes(
-                TerritoryEffectHelper.getUnitTypesThatLostBlitz(r.getAllTerritories()))
+                TerritoryEffectHelper.getUnitTypesThatLostBlitz(route.getAllTerritories()))
             .test(u)) {
       // If blitzing then make sure none of the territories cause blitz ability to be lost
       return false;
     }
-    if (r.getMovementCost(u).compareTo(range) > 0) {
+    if (route.getMovementCost(u).compareTo(range) > 0) {
       return false;
     }
 
@@ -970,13 +972,13 @@ public class ProTerritoryManager {
         }
 
         for (final Territory potentialTerritory : potentialTerritories) {
-          final Route myRoute =
+          final Optional<Route> optionalRoute =
               gameMap.getRouteForUnit(
                   myUnitTerritory, potentialTerritory, canFlyOverMatch, myAirUnit, player);
-          if (myRoute == null) {
+          if (optionalRoute.isEmpty()) {
             continue;
           }
-          final BigDecimal myRouteLength = myRoute.getMovementCost(myAirUnit);
+          final BigDecimal myRouteLength = optionalRoute.get().getMovementCost(myAirUnit);
           final BigDecimal remainingMoves = range.subtract(myRouteLength);
           if (remainingMoves.compareTo(BigDecimal.ZERO) < 0) {
             continue;
@@ -1209,13 +1211,13 @@ public class ProTerritoryManager {
         potentialTerritories.retainAll(unloadFromTerritories);
         for (final Territory bombardFromTerritory : potentialTerritories) {
           // Find route over water with no enemy units blocking
-          final Route myRoute =
+          final Optional<Route> optionalRoute =
               gameMap.getRouteForUnit(
                   myUnitTerritory, bombardFromTerritory, canMove, mySeaUnit, player);
-          if (myRoute == null) {
+          if (optionalRoute.isEmpty()) {
             continue;
           }
-          final BigDecimal myRouteLength = myRoute.getMovementCost(mySeaUnit);
+          final BigDecimal myRouteLength = optionalRoute.get().getMovementCost(mySeaUnit);
           if (myRouteLength.compareTo(range) > 0) {
             continue;
           }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import org.triplea.java.collections.CollectionUtils;
@@ -332,7 +333,7 @@ public final class ProBattleUtils {
       if (enemySeaUnits.isEmpty()) {
         continue;
       }
-      final Route route =
+      final Optional<Route> optionalRoute =
           data.getMap()
               .getRouteForUnits(
                   t,
@@ -340,10 +341,10 @@ public final class ProBattleUtils {
                   Matches.territoryIsWater(),
                   enemySeaUnits,
                   enemySeaUnits.get(0).getOwner());
-      if (route == null) {
+      if (optionalRoute.isEmpty()) {
         continue;
       }
-      final int routeLength = route.numberOfSteps();
+      final int routeLength = optionalRoute.get().numberOfSteps();
       if (routeLength <= enemyDistance) {
         final double strength = estimateStrength(t, myUnits, enemySeaUnits, false);
         if (strength > strongestEnemyDefenseFleetStrength) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
@@ -11,8 +11,8 @@ import games.strategy.triplea.delegate.Matches;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
-import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
 
 final class Utils {
@@ -45,18 +45,19 @@ final class Utils {
     return strength;
   }
 
-  static @Nullable Route findNearest(
+  static Optional<Route> findNearest(
       final Territory start,
       final Predicate<Territory> endCondition,
       final Predicate<Territory> routeCondition,
       final GameState data) {
-    Route shortestRoute = null;
+    Optional<Route> shortestRoute = Optional.empty();
     for (final Territory t : data.getMap().getTerritories()) {
       if (endCondition.test(t)) {
-        final Route r = data.getMap().getRoute(start, t, routeCondition);
-        if (r != null
-            && r.hasSteps()
-            && (shortestRoute == null || r.numberOfSteps() < shortestRoute.numberOfSteps())) {
+        final Optional<Route> r = data.getMap().getRoute(start, t, routeCondition);
+        if (r.isPresent()
+            && r.get().hasSteps()
+            && (shortestRoute.isEmpty()
+                || r.get().numberOfSteps() < shortestRoute.get().numberOfSteps())) {
           shortestRoute = r;
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
@@ -61,14 +62,14 @@ public class WeakAi extends AbstractAi {
   protected void tech(
       final ITechDelegate techDelegate, final GameData data, final GamePlayer player) {}
 
-  private static Route getAmphibRoute(final GamePlayer player, final GameState data) {
+  private static Optional<Route> getAmphibRoute(final GamePlayer player, final GameState data) {
     if (!isAmphibAttack(player, data)) {
-      return null;
+      return Optional.empty();
     }
     final Territory ourCapitol =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     if (ourCapitol == null) {
-      return null;
+      return Optional.empty();
     }
     final Predicate<Territory> endMatch =
         o -> {
@@ -80,34 +81,35 @@ public class WeakAi extends AbstractAi {
         };
     final Predicate<Territory> routeCond =
         Matches.territoryIsWater().and(Matches.territoryHasNoEnemyUnits(player));
-    final @Nullable Route withNoEnemy = Utils.findNearest(ourCapitol, endMatch, routeCond, data);
-    if (withNoEnemy != null && withNoEnemy.numberOfSteps() > 0) {
-      return withNoEnemy;
+    final Optional<Route> optionalWithNoEnemy =
+        Utils.findNearest(ourCapitol, endMatch, routeCond, data);
+    if (optionalWithNoEnemy.isPresent() && optionalWithNoEnemy.get().hasSteps()) {
+      return optionalWithNoEnemy;
     }
     // this will fail if our capitol is not next to water, c'est la vie.
-    final @Nullable Route route =
+    final Optional<Route> optionalRoute =
         Utils.findNearest(ourCapitol, endMatch, Matches.territoryIsWater(), data);
-    if (route != null && route.numberOfSteps() == 0) {
-      return null;
+    if (optionalRoute.isPresent() && optionalRoute.get().hasSteps()) {
+      return optionalRoute;
     }
-    return route;
+    return Optional.empty();
   }
 
   private static boolean isAmphibAttack(final GamePlayer player, final GameState data) {
     final Territory capitol =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
-    // we dont own our own capitol
+    // we don't own our own capitol
     if (capitol == null || !capitol.isOwnedBy(player)) {
       return false;
     }
     // find a land route to an enemy territory from our capitol
-    final Route invasionRoute =
+    final Optional<Route> invasionRoute =
         Utils.findNearest(
             capitol,
             Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player),
             Matches.territoryIsLand().and(Matches.territoryIsNeutralButNotWater().negate()),
             data);
-    return invasionRoute == null;
+    return invasionRoute.isEmpty();
   }
 
   @Override
@@ -203,10 +205,11 @@ public class WeakAi extends AbstractAi {
 
   private static List<MoveDescription> calculateTransportUnloadNonCombat(
       final GameState data, final GamePlayer player) {
-    final Route amphibRoute = getAmphibRoute(player, data);
-    if (amphibRoute == null) {
+    final Optional<Route> optionalAmphibRoute = getAmphibRoute(player, data);
+    if (optionalAmphibRoute.isEmpty()) {
       return List.of();
     }
+    final Route amphibRoute = optionalAmphibRoute.get();
     final Territory lastSeaZoneOnAmphib =
         amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     final Territory landOn = amphibRoute.getEnd();
@@ -240,10 +243,11 @@ public class WeakAi extends AbstractAi {
     // we want to move loaded transports before we try to fight our battles
     final List<MoveDescription> moves = calculateNonCombatSea(false, data, player);
     // find second amphib target
-    final Route amphibRoute = getAlternativeAmphibRoute(player, data);
-    if (amphibRoute == null) {
+    final Optional<Route> optionalAmphibRoute = getAlternativeAmphibRoute(player, data);
+    if (optionalAmphibRoute.isEmpty()) {
       return moves;
     }
+    final Route amphibRoute = optionalAmphibRoute.get();
     // TODO workaround - should check if amphibRoute is in moves
     if (moves.size() == 2) {
       moves.remove(1);
@@ -263,22 +267,23 @@ public class WeakAi extends AbstractAi {
       unitsToMove.addAll(transports.subList(0, 1));
     }
     final List<Unit> landUnits = load2Transports(unitsToMove);
-    final @Nullable Route r =
-        getMaxSeaRoute(data, firstSeaZoneOnAmphib, lastSeaZoneOnAmphib, player);
-    if (r != null) {
-      unitsToMove.addAll(landUnits);
-      moves.add(new MoveDescription(unitsToMove, r));
-    }
+    getMaxSeaRoute(data, firstSeaZoneOnAmphib, lastSeaZoneOnAmphib, player)
+        .ifPresent(
+            route -> {
+              unitsToMove.addAll(landUnits);
+              moves.add(new MoveDescription(unitsToMove, route));
+            });
     return moves;
   }
 
   /** prepares moves for transports. */
   private static List<MoveDescription> calculateNonCombatSea(
       final boolean nonCombat, final GameData data, final GamePlayer player) {
-    final Route amphibRoute = getAmphibRoute(player, data);
-    Territory firstSeaZoneOnAmphib = null;
-    Territory lastSeaZoneOnAmphib = null;
-    if (amphibRoute != null) {
+    final Optional<Route> optionalAmphibRoute = getAmphibRoute(player, data);
+    @Nullable Territory firstSeaZoneOnAmphib = null;
+    @Nullable Territory lastSeaZoneOnAmphib = null;
+    if (optionalAmphibRoute.isPresent()) {
+      final Route amphibRoute = optionalAmphibRoute.get();
       firstSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(1);
       lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     }
@@ -292,25 +297,25 @@ public class WeakAi extends AbstractAi {
         // and move along amphib route
         if (t.anyUnitsMatch(Matches.unitIsLand()) && lastSeaZoneOnAmphib != null) {
           // two move route to end
-          final @Nullable Route r = getMaxSeaRoute(data, t, lastSeaZoneOnAmphib, player);
-          if (r != null) {
-            final List<Unit> unitsToMove = t.getMatches(Matches.unitIsOwnedBy(player));
-            moves.add(new MoveDescription(unitsToMove, r));
-          }
+          getMaxSeaRoute(data, t, lastSeaZoneOnAmphib, player)
+              .ifPresent(
+                  route -> {
+                    final List<Unit> unitsToMove = t.getMatches(Matches.unitIsOwnedBy(player));
+                    moves.add(new MoveDescription(unitsToMove, route));
+                  });
         }
         // move toward the start of the amphib route
         if (nonCombat && t.anyUnitsMatch(ownedAndNotMoved) && firstSeaZoneOnAmphib != null) {
-          final @Nullable Route r = getMaxSeaRoute(data, t, firstSeaZoneOnAmphib, player);
-          if (r != null) {
-            moves.add(new MoveDescription(t.getMatches(ownedAndNotMoved), r));
-          }
+          getMaxSeaRoute(data, t, firstSeaZoneOnAmphib, player)
+              .ifPresent(
+                  route -> moves.add(new MoveDescription(t.getMatches(ownedAndNotMoved), route)));
         }
       }
     }
     return moves;
   }
 
-  private static @Nullable Route getMaxSeaRoute(
+  private static Optional<Route> getMaxSeaRoute(
       final GameData data,
       final Territory start,
       final Territory destination,
@@ -319,14 +324,17 @@ public class WeakAi extends AbstractAi {
         Matches.territoryIsWater()
             .and(Matches.territoryHasEnemyUnits(player).negate())
             .and(territoryHasNonAllowedCanal(player, data).negate());
-    Route r = data.getMap().getRoute(start, destination, routeCond);
-    if (r == null || r.hasNoSteps() || !routeCond.test(destination)) {
-      return null;
+    final Optional<Route> optionalRoute = data.getMap().getRoute(start, destination, routeCond);
+    if (optionalRoute.isEmpty()
+        || optionalRoute.get().hasNoSteps()
+        || !routeCond.test(destination)) {
+      return Optional.empty();
     }
-    if (r.numberOfSteps() > 2) {
-      r = new Route(start, r.getAllTerritories().get(1), r.getAllTerritories().get(2));
+    if (optionalRoute.get().numberOfSteps() > 2) {
+      final List<Territory> allRouteTerritories = optionalRoute.get().getAllTerritories();
+      return Optional.of(new Route(start, allRouteTerritories.get(1), allRouteTerritories.get(2)));
     }
-    return r;
+    return optionalRoute;
   }
 
   private static Predicate<Territory> territoryHasNonAllowedCanal(
@@ -379,7 +387,8 @@ public class WeakAi extends AbstractAi {
   }
 
   // searches for amphibious attack on empty territory
-  private static Route getAlternativeAmphibRoute(final GamePlayer player, final GameState data) {
+  private static Optional<Route> getAlternativeAmphibRoute(
+      final GamePlayer player, final GameState data) {
     if (!isAmphibAttack(player, data)) {
       return null;
     }
@@ -397,7 +406,7 @@ public class WeakAi extends AbstractAi {
             .and(Matches.territoryIsLand())
             .and(Matches.territoryIsNeutralButNotWater().negate())
             .and(Matches.territoryIsEmpty());
-    Route altRoute = null;
+    Optional<Route> altRoute = Optional.empty();
     final int length = Integer.MAX_VALUE;
     for (final Territory t : data.getMap()) {
       if (!transportOnSea.test(t)) {
@@ -405,9 +414,10 @@ public class WeakAi extends AbstractAi {
       }
       final int trans = t.getUnitCollection().countMatches(ownedTransports);
       if (trans > 0) {
-        final Route newRoute = Utils.findNearest(t, enemyTerritory, routeCondition, data);
-        if (newRoute != null && length > newRoute.numberOfSteps()) {
-          altRoute = newRoute;
+        final Optional<Route> optionalNewRoute =
+            Utils.findNearest(t, enemyTerritory, routeCondition, data);
+        if (optionalNewRoute.isPresent() && length > optionalNewRoute.get().numberOfSteps()) {
+          altRoute = optionalNewRoute;
         }
       }
     }
@@ -450,42 +460,45 @@ public class WeakAi extends AbstractAi {
         continue;
       }
       int minDistance = Integer.MAX_VALUE;
-      Territory to = null;
+      Optional<Territory> to = Optional.empty();
       // find the nearest enemy owned capital
       for (final GamePlayer otherPlayer : data.getPlayerList().getPlayers()) {
         final Territory capital =
             TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(
                 otherPlayer, data.getMap());
-        if (capital != null && !player.isAllied(capital.getOwner())) {
-          final Route route = data.getMap().getRoute(t, capital, moveThrough);
-          if (route != null && moveThrough.test(capital)) {
-            final int distance = route.numberOfSteps();
+        if (capital != null && !player.isAllied(capital.getOwner()) && moveThrough.test(capital)) {
+          Optional<Route> optionalRoute = data.getMap().getRoute(t, capital, moveThrough);
+          if (optionalRoute.isPresent()) {
+            final int distance = optionalRoute.get().numberOfSteps();
             if (distance != 0 && distance < minDistance) {
               minDistance = distance;
-              to = capital;
+              to = Optional.of(capital);
             }
           }
         }
       }
-      if (to != null) {
-        if (!units.isEmpty()) {
-          final Route routeToCapitol = data.getMap().getRoute(t, to, moveThrough);
-          final Territory firstStep = routeToCapitol.getAllTerritories().get(1);
-          final Route route = new Route(t, firstStep);
-          moves.add(new MoveDescription(units, route));
-        }
+      final Optional<Route> optionalRouteToCapitol;
+      if (to.isPresent()) {
+        optionalRouteToCapitol = data.getMap().getRoute(t, to.get(), moveThrough);
+      } else {
+        optionalRouteToCapitol = Optional.empty();
+      }
+      if (optionalRouteToCapitol.isPresent()) {
+        final Territory firstStep = optionalRouteToCapitol.get().getAllTerritories().get(1);
+        final Route route = new Route(t, firstStep);
+        moves.add(new MoveDescription(units, route));
       } else { // if we cant move to a capitol, move towards the enemy
         final Predicate<Territory> routeCondition =
             Matches.territoryIsLand().and(Matches.territoryIsImpassable().negate());
-        @Nullable
-        Route newRoute =
+        Optional<Route> optionalNewRoute =
             Utils.findNearest(t, Matches.territoryHasEnemyLandUnits(player), routeCondition, data);
         // move to any enemy territory
-        if (newRoute == null) {
-          newRoute = Utils.findNearest(t, Matches.isTerritoryEnemy(player), routeCondition, data);
+        if (optionalNewRoute.isEmpty()) {
+          optionalNewRoute =
+              Utils.findNearest(t, Matches.isTerritoryEnemy(player), routeCondition, data);
         }
-        if (newRoute != null && newRoute.numberOfSteps() != 0) {
-          final Territory firstStep = newRoute.getAllTerritories().get(1);
+        if (optionalNewRoute.isPresent() && optionalNewRoute.get().hasSteps()) {
+          final Territory firstStep = optionalNewRoute.get().getAllTerritories().get(1);
           final Route route = new Route(t, firstStep);
           moves.add(new MoveDescription(units, route));
         }
@@ -508,20 +521,16 @@ public class WeakAi extends AbstractAi {
             .and(Matches.territoryIsImpassable().negate());
     final var moves = new ArrayList<MoveDescription>();
     for (final Territory t : delegateRemote.getTerritoriesWhereAirCantLand()) {
-      final @Nullable Route noAaRoute = Utils.findNearest(t, canLand, routeCondition, data);
-      final @Nullable Route aaRoute =
+      final Optional<Route> noAaRoute = Utils.findNearest(t, canLand, routeCondition, data);
+      final Optional<Route> aaRoute =
           Utils.findNearest(t, canLand, Matches.territoryIsImpassable().negate(), data);
       final Collection<Unit> airToLand =
           t.getMatches(Matches.unitIsAir().and(Matches.unitIsOwnedBy(player)));
       // don't bother to see if all the air units have enough movement points to move without aa
       // guns firing
       // simply move first over no aa, then with aa one (but hopefully not both) will be rejected
-      if (noAaRoute != null) {
-        moves.add(new MoveDescription(airToLand, noAaRoute));
-      }
-      if (aaRoute != null) {
-        moves.add(new MoveDescription(airToLand, aaRoute));
-      }
+      noAaRoute.ifPresent(route -> moves.add(new MoveDescription(airToLand, route)));
+      aaRoute.ifPresent(route -> moves.add(new MoveDescription(airToLand, route)));
     }
     return moves;
   }
@@ -709,10 +718,8 @@ public class WeakAi extends AbstractAi {
         continue;
       }
       final Predicate<Territory> routeCond = Matches.territoryHasEnemyAaForFlyOver(player).negate();
-      final @Nullable Route bombRoute = Utils.findNearest(t, enemyFactory, routeCond, data);
-      if (bombRoute != null) {
-        moves.add(new MoveDescription(bombers, bombRoute));
-      }
+      Utils.findNearest(t, enemyFactory, routeCond, data)
+          .ifPresent(route -> moves.add(new MoveDescription(bombers, route)));
     }
     return moves;
   }
@@ -789,12 +796,18 @@ public class WeakAi extends AbstractAi {
       return;
     }
     final boolean isAmphib = isAmphibAttack(player, data);
-    final Route amphibRoute = getAmphibRoute(player, data);
     final int transportCount = countTransports(data, player);
     final int landUnitCount = countLandUnits(data, player);
     int defUnitsAtAmpibRoute = 0;
-    if (isAmphib && amphibRoute != null) {
-      defUnitsAtAmpibRoute = amphibRoute.getEnd().getUnitCollection().getUnitCount();
+    final Optional<Route> optionalAmphibRoute;
+    if (!isAmphib) {
+      optionalAmphibRoute = Optional.empty();
+    } else {
+      optionalAmphibRoute = getAmphibRoute(player, data);
+      if (optionalAmphibRoute.isPresent()) {
+        defUnitsAtAmpibRoute =
+            optionalAmphibRoute.get().getEnd().getUnitCollection().getUnitCount();
+      }
     }
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final int totalPu = player.getResources().getQuantity(pus);
@@ -987,7 +1000,7 @@ public class WeakAi extends AbstractAi {
         // transports
         int goodNumberOfTransports = 0;
         final boolean isTransport = transportCapacity > 0;
-        if (amphibRoute != null) {
+        if (optionalAmphibRoute.isPresent()) {
           // 25% transports - can be more if frontier is far away
           goodNumberOfTransports = (landUnitCount / 4);
           // boost for transport production
@@ -1058,10 +1071,10 @@ public class WeakAi extends AbstractAi {
     }
     final List<Unit> seaUnits = new ArrayList<>(player.getMatches(Matches.unitIsSea()));
     if (!seaUnits.isEmpty()) {
-      final Route amphibRoute = getAmphibRoute(player, data);
       Territory seaPlaceAt = null;
-      if (amphibRoute != null) {
-        seaPlaceAt = amphibRoute.getAllTerritories().get(1);
+      final Optional<Route> optionalAmphibRoute = getAmphibRoute(player, data);
+      if (optionalAmphibRoute.isPresent()) {
+        seaPlaceAt = optionalAmphibRoute.get().getAllTerritories().get(1);
       } else {
         final Set<Territory> seaNeighbors =
             data.getMap().getNeighbors(placeAt, Matches.territoryIsWater());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import org.triplea.java.PredicateBuilder;
@@ -231,9 +232,9 @@ public class RocketsFireHelper implements Serializable {
     final Predicate<Unit> attackableUnits =
         Matches.enemyUnit(player).and(Matches.unitIsBeingTransported().negate());
     for (final Territory current : possible) {
-      final Route route = data.getMap().getRoute(territory, current, allowed);
-      if (route != null
-          && route.numberOfSteps() <= maxDistance
+      final Optional<Route> optionalRoute = data.getMap().getRoute(territory, current, allowed);
+      if (optionalRoute.isPresent()
+          && optionalRoute.get().numberOfSteps() <= maxDistance
           && current.anyUnitsMatch(
               attackableUnits.and(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(current).negate()))) {
         hasFactory.add(current);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -51,6 +51,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -722,7 +723,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         if (battleTracker.hasPendingNonBombingBattle(to)) {
           defender = AbstractBattle.findDefender(to, player, data);
         }
-        // find possible scrambling defending in the from territories
+        // find possible scrambling defending in the from-territories
         if (defender.isNull()) {
           defender =
               scramblers.keySet().stream()
@@ -1491,7 +1492,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                 Matches.airCanFlyOver(alliedPlayer, areNeutralsPassableByAir));
     final Iterator<Territory> possibleIter = possibleTerrs.iterator();
     while (possibleIter.hasNext()) {
-      final Route route =
+      final Optional<Route> optionalRoute =
           data.getMap()
               .getRouteForUnit(
                   currentTerr,
@@ -1499,8 +1500,12 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                   Matches.airCanFlyOver(alliedPlayer, areNeutralsPassableByAir),
                   strandedAir,
                   alliedPlayer);
-      if ((route == null)
-          || (route.getMovementCost(strandedAir).compareTo(new BigDecimal(maxDistance)) > 0)) {
+      if ((optionalRoute.isEmpty())
+          || (optionalRoute
+                  .get()
+                  .getMovementCost(strandedAir)
+                  .compareTo(new BigDecimal(maxDistance))
+              > 0)) {
         possibleIter.remove();
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
@@ -182,7 +182,9 @@ public class ScrambleLogic {
         }
         // TODO: consider movement cost and canals by checking each air unit separately
         final Route toBattleRoute =
-            data.getMap().getRoute(from, to, Matches.territoryIsNotImpassable());
+            data.getMap()
+                .getRoute(from, to, Matches.territoryIsNotImpassable())
+                .orElseThrow(() -> new IllegalStateException("Route object should be found"));
         final Collection<Unit> canScrambleAir =
             fromUnits.getMatches(
                 unitCanScramble.and(Matches.unitCanScrambleOnRouteDistance(toBattleRoute)));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -425,7 +426,7 @@ public final class AirMovementValidator {
             landingSpotsWithCarrierCapacity.put(carrierSpot, carrierSpotCapacity);
           }
         }
-        final Route toLandingSpot =
+        final Optional<Route> optionalToLandingSpot =
             data.getMap()
                 .getRouteForUnits(
                     carrierSpot,
@@ -433,12 +434,13 @@ public final class AirMovementValidator {
                     Matches.seaCanMoveOver(player),
                     ownedCarriersInCarrierSpot,
                     player);
-        if (toLandingSpot == null) {
+        if (optionalToLandingSpot.isEmpty()) {
           continue;
         }
         final List<Unit> carriersThatCanReach =
             CollectionUtils.getMatches(
-                ownedCarriersInCarrierSpot, Matches.unitHasEnoughMovementForRoute(toLandingSpot));
+                ownedCarriersInCarrierSpot,
+                Matches.unitHasEnoughMovementForRoute(optionalToLandingSpot.get()));
         if (carriersThatCanReach.isEmpty()) {
           // none can reach
           continue;
@@ -639,7 +641,7 @@ public final class AirMovementValidator {
       final BigDecimal movementLeft,
       final Territory landingSpot,
       final boolean areNeutralsPassableByAir) {
-    final Route route =
+    final Optional<Route> optionalRoute =
         data.getMap()
             .getRouteForUnit(
                 currentSpot,
@@ -647,10 +649,11 @@ public final class AirMovementValidator {
                 Matches.airCanFlyOver(player, areNeutralsPassableByAir),
                 unit,
                 player);
-    return (route != null)
-        && (route.getMovementCost(unit).compareTo(movementLeft) <= 0)
+    return (optionalRoute.isPresent())
+        && (optionalRoute.get().getMovementCost(unit).compareTo(movementLeft) <= 0)
         && (!areNeutralsPassableByAir
-            || getNeutralCharge(data, route) <= player.getResources().getQuantity(Constants.PUS));
+            || getNeutralCharge(data, optionalRoute.get())
+                <= player.getResources().getQuantity(Constants.PUS));
   }
 
   /**

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/MapTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/MapTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -124,7 +125,7 @@ class MapTest {
 
   @Test
   void testImpossibleConditionRoute() {
-    assertNull(map.getRoute(aa, ca, it -> false));
+    assertTrue(map.getRoute(aa, ca, it -> false).isEmpty());
   }
 
   @Test
@@ -164,14 +165,14 @@ class MapTest {
 
   @Test
   void testRouteSizeOne() {
-    final Route rt = map.getRoute(aa, ab, it -> true);
+    final Route rt = map.getRouteOrElseThrow(aa, ab, it -> true);
     assertEquals(1, rt.numberOfSteps());
   }
 
   @Test
   void testImpossibleRoute() {
-    final Route rt = map.getRoute(aa, nowhere, it -> true);
-    assertNull(rt);
+    final Optional<Route> rt = map.getRoute(aa, nowhere, it -> true);
+    assertTrue(rt.isEmpty());
   }
 
   @Test
@@ -182,7 +183,7 @@ class MapTest {
 
   @Test
   void testMultiplePossible() {
-    final Route rt = map.getRoute(aa, dd, it -> true);
+    final Route rt = map.getRouteOrElseThrow(aa, dd, it -> true);
     assertEquals(aa, rt.getStart());
     assertEquals(dd, rt.getEnd());
     assertEquals(6, rt.numberOfSteps());

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -144,7 +144,7 @@ class LhtrTest extends AbstractClientSettingTestCase {
     final BattleTracker tracker = new BattleTracker();
     final IBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     battle.addAttackChange(
-        gameData.getMap().getRoute(uk, germany, it -> true),
+        gameData.getMap().getRouteOrElseThrow(uk, germany, it -> true),
         uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()),
         null);
     addTo(germany, uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
@@ -182,7 +182,7 @@ class LhtrTest extends AbstractClientSettingTestCase {
     final BattleTracker tracker = new BattleTracker();
     final IBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     battle.addAttackChange(
-        gameData.getMap().getRoute(uk, germany, it -> true),
+        gameData.getMap().getRouteOrElseThrow(uk, germany, it -> true),
         uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()),
         null);
     addTo(germany, uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.triplea.java.collections.CollectionUtils;
@@ -1269,8 +1270,8 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
 
   @Test
   void testRoute() {
-    final Route route = gameData.getMap().getRoute(angola, russia, it -> true);
-    assertNotNull(route);
-    assertEquals(route.getEnd(), russia);
+    final Optional<Route> optionalRoute = gameData.getMap().getRoute(angola, russia, it -> true);
+    assertTrue(optionalRoute.isPresent());
+    assertEquals(optionalRoute.get().getEnd(), russia);
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -860,7 +860,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final IBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     final List<Unit> bombers = uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber());
     addTo(germany, bombers);
-    battle.addAttackChange(gameData.getMap().getRoute(uk, germany, it -> true), bombers, null);
+    battle.addAttackChange(
+        gameData.getMap().getRouteOrElseThrow(uk, germany, it -> true), bombers, null);
     tracker
         .getBattleRecords()
         .addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
@@ -888,7 +889,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final IBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     final List<Unit> bombers = bomber(gameData).create(2, british);
     addTo(germany, bombers);
-    battle.addAttackChange(gameData.getMap().getRoute(uk, germany, it -> true), bombers, null);
+    battle.addAttackChange(
+        gameData.getMap().getRouteOrElseThrow(uk, germany, it -> true), bombers, null);
     tracker
         .getBattleRecords()
         .addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
@@ -924,7 +926,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final IBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     final List<Unit> bombers = bomber(gameData).create(7, british);
     addTo(germany, bombers);
-    battle.addAttackChange(gameData.getMap().getRoute(uk, germany, it -> true), bombers, null);
+    battle.addAttackChange(
+        gameData.getMap().getRouteOrElseThrow(uk, germany, it -> true), bombers, null);
     tracker
         .getBattleRecords()
         .addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
@@ -951,7 +954,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final BattleTracker tracker = new BattleTracker();
     final IBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     battle.addAttackChange(
-        gameData.getMap().getRoute(uk, germany, it -> true),
+        gameData.getMap().getRouteOrElseThrow(uk, germany, it -> true),
         uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()),
         null);
     addTo(germany, uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -87,7 +87,8 @@ class VictoryTest {
     moveDelegate.start();
     final String error =
         moveDelegate.move(
-            libya.getUnits(), gameData.getMap().getRoute(libya, belgianCongo, it -> true));
+            libya.getUnits(),
+            gameData.getMap().getRouteOrElseThrow(libya, belgianCongo, it -> true));
     moveDelegate.end();
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
   }
@@ -101,7 +102,7 @@ class VictoryTest {
     final String error =
         moveDelegate.move(
             frenchWestAfrica.getUnits(),
-            gameData.getMap().getRoute(frenchWestAfrica, belgianCongo, it -> true));
+            gameData.getMap().getRouteOrElseThrow(frenchWestAfrica, belgianCongo, it -> true));
     moveDelegate.end();
     assertNull(error);
   }
@@ -146,7 +147,8 @@ class VictoryTest {
     moveDelegate.start();
     final String error =
         moveDelegate.move(
-            libya.getUnits(), gameData.getMap().getRoute(libya, belgianCongo, it -> true));
+            libya.getUnits(),
+            gameData.getMap().getRouteOrElseThrow(libya, belgianCongo, it -> true));
     moveDelegate.end();
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
   }
@@ -182,7 +184,7 @@ class VictoryTest {
     final List<Unit> infantryUnit = infantry.create(1, italians);
     final List<Unit> tankUnit = armour.create(1, italians);
     final List<Unit> tankAndInfantry = List.of(tankUnit.get(0), infantryUnit.get(0));
-    final Route route = gameData.getMap().getRoute(angloEgypt, transJordan, it -> true);
+    final Route route = gameData.getMap().getRouteOrElseThrow(angloEgypt, transJordan, it -> true);
 
     @BeforeEach
     void setUp() {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -96,7 +96,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -1446,7 +1445,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     addTo(sz40, carrier(gameData).create(1, germans));
     addTo(sz40, fighter(gameData).create(1, italians(gameData)));
     addTo(madagascar, fighter(gameData).create(2, germans));
-    final Route route = gameData.getMap().getRoute(madagascar, sz40, it -> true);
+    final Route route = gameData.getMap().getRouteOrElseThrow(madagascar, sz40, it -> true);
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -1793,7 +1792,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
 
     move(
         uk.getUnitCollection().getMatches(Matches.unitIsAir()),
-        Objects.requireNonNull(gameData.getMap().getRoute(uk, sz5, it -> true)));
+        gameData.getMap().getRouteOrElseThrow(uk, sz5, it -> true));
     // move units for amphibious assault
     moveDelegate(gameData).end();
     advanceToStep(bridge, "Combat");


### PR DESCRIPTION
Replace Nullable Route returns from methods with Optionals and adjust respective handling

Major files are
GameMap.java
- methods getRoute / getRouteForUnit / getRouteForUnits:  Return Optional instead of Nullable
- new methods getRouteOrElseThrow/getRouteForUnitOrElseThrow: Call similar named methods that return Optionals and throw IllegalStateException if it is empty

MovePanel.java
- methods getRoute/getRouteForced/getRouteNonForced: Return Optional instead of Nullable

Route.java
- method join: Return Optional instead of Nullable

ProTechAi.java
- method getMaxSeaRoute: Return Optional instead of Nullable

ALSO:
ProTerritoryValueUtils.java
- method findSeaTerritoryValues: Change data from GameState to GameData; Extract/use new method calculateTerritoryValueToTargets

## Notes to Reviewer
The other affected files for the change are not listed here.