### PR TITLE
NoReturnNullRoute

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NonNls;
 import org.triplea.java.collections.IntegerMap;
 
 /**
@@ -30,6 +31,10 @@ import org.triplea.java.collections.IntegerMap;
 @Slf4j
 public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachment {
   private static final long serialVersionUID = 7224407193725789143L;
+
+  public static final @NonNls String MOVEMENT_RESTRICTION_TYPE_ALLOWED = "allowed";
+  public static final @NonNls String MOVEMENT_RESTRICTION_TYPE_DISALLOWED = "disallowed";
+
   // Please do not add new things to this class. Any new Player-Rules type of stuff should go in
   // "PlayerAttachment".
   // These variables are related to a "rulesAttachment" that changes certain rules for the attached
@@ -130,12 +135,21 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     movementRestrictionTerritories = null;
   }
 
-  private void setMovementRestrictionType(final String value) throws GameParseException {
-    if (!(value.equals("disallowed") || value.equals("allowed"))) {
+  private void setMovementRestrictionType(final @NonNls String value) throws GameParseException {
+    if (!(MOVEMENT_RESTRICTION_TYPE_DISALLOWED.equals(value)
+        || MOVEMENT_RESTRICTION_TYPE_ALLOWED.equals(value))) {
       throw new GameParseException(
           "movementRestrictionType must be allowed or disallowed" + thisErrorMsg());
     }
     movementRestrictionType = value.intern();
+  }
+
+  public boolean isMovementRestrictionTypeAllowed() {
+    return MOVEMENT_RESTRICTION_TYPE_ALLOWED.equals(movementRestrictionType);
+  }
+
+  public boolean isMovementRestrictionTypeDisallowed() {
+    return MOVEMENT_RESTRICTION_TYPE_DISALLOWED.equals(movementRestrictionType);
   }
 
   public @Nullable String getMovementRestrictionType() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
@@ -116,9 +117,6 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   }
 
   @Override
-  public abstract String performMove(MoveDescription move);
-
-  @Override
   public Collection<Territory> getTerritoriesWhereAirCantLand(final GamePlayer player) {
     return new AirThatCantLandUtil(bridge).getTerritoriesWhereAirCantLand(player);
   }
@@ -139,7 +137,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
    * @param unit referring unit.
    * @param end target territory
    */
-  public Route getRouteUsedToMoveInto(final Unit unit, final Territory end) {
+  public Optional<Route> getRouteUsedToMoveInto(final Unit unit, final Territory end) {
     return AbstractMoveDelegate.getRouteUsedToMoveInto(movesToUndo, unit, end);
   }
 
@@ -151,7 +149,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
    * @param end target territory
    * @return the route that a unit used to move into the given territory.
    */
-  public static @Nullable Route getRouteUsedToMoveInto(
+  public static Optional<Route> getRouteUsedToMoveInto(
       final List<UndoableMove> undoableMoves, final Unit unit, final Territory end) {
     final ListIterator<UndoableMove> iter = undoableMoves.listIterator(undoableMoves.size());
     while (iter.hasPrevious()) {
@@ -160,10 +158,10 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
         continue;
       }
       if (move.getRoute().getEnd().equals(end)) {
-        return move.getRoute();
+        return Optional.of(move.getRoute());
       }
     }
-    return null;
+    return Optional.empty();
   }
 
   public static BattleTracker getBattleTracker(final GameData data) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -989,10 +989,9 @@ public final class Matches {
       if (ra == null || ra.getMovementRestrictionTerritories() == null) {
         return true;
       }
-      final String movementRestrictionType = ra.getMovementRestrictionType();
       final Collection<Territory> listedTerritories =
           ra.getListedTerritories(ra.getMovementRestrictionTerritories(), true, true);
-      return (movementRestrictionType.equals("allowed") == listedTerritories.contains(t));
+      return (ra.isMovementRestrictionTypeAllowed() == listedTerritories.contains(t));
     };
   }
 
@@ -1037,10 +1036,9 @@ public final class Matches {
       if (Properties.getMovementByTerritoryRestricted(properties)) {
         final RulesAttachment ra = playerWhoOwnsAllTheUnitsMoving.getRulesAttachment();
         if (ra != null && ra.getMovementRestrictionTerritories() != null) {
-          final String movementRestrictionType = ra.getMovementRestrictionType();
           final Collection<Territory> listedTerritories =
               ra.getListedTerritories(ra.getMovementRestrictionTerritories(), true, true);
-          if (!(movementRestrictionType.equals("allowed") == listedTerritories.contains(t))) {
+          if (!(ra.isMovementRestrictionTypeAllowed() == listedTerritories.contains(t))) {
             return false;
           }
         }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -21,6 +21,7 @@ import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.data.MoveValidationResult;
+import games.strategy.triplea.delegate.move.validation.AirMovementValidator;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
@@ -626,11 +627,11 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
     // confirm kamikaze moves, and remove them from unresolved units
     if (getKamikazeAir || move.getUnits().stream().anyMatch(Matches.unitIsKamikaze())) {
-      kamikazeUnits = result.getUnresolvedUnits(MoveValidator.NOT_ALL_AIR_UNITS_CAN_LAND);
+      kamikazeUnits = result.getUnresolvedUnits(AirMovementValidator.NOT_ALL_AIR_UNITS_CAN_LAND);
       if (!kamikazeUnits.isEmpty() && bridge.getRemotePlayer().confirmMoveKamikaze()) {
         for (final Unit unit : kamikazeUnits) {
           if (getKamikazeAir || Matches.unitIsKamikaze().test(unit)) {
-            result.removeUnresolvedUnit(MoveValidator.NOT_ALL_AIR_UNITS_CAN_LAND, unit);
+            result.removeUnresolvedUnit(AirMovementValidator.NOT_ALL_AIR_UNITS_CAN_LAND, unit);
             isKamikaze = true;
           }
         }


### PR DESCRIPTION
Replace Nullable Route returns from methods with Optionals and adjust respective handling

AbstractMoveDelegate.java
- methods getRouteUsedToMoveInto / getRouteUsedToMoveInto:  Return Optional instead of Nullable

MovePerformer.java
- new method populateStack.preAaFire.execute: Replace weird check battle!=null with Optional<Route>.isPresent

MoveValidator.java
- removed constant NOT_ALL_AIR_UNITS_CAN_LAND (replaced by AirMovementValidator.NOT_ALL_AIR_UNITS_CAN_LAND)
- cleanups

UndoableMove.java
- methods undoSpecific: Avoid additional filter on battles from battleTracker.getPendingBattles; use Optional<Route>;
move battle.addAttackChange into if-block with Optional<Route>.isPresent

AbstractPlayerRulesAttachment.java
- add constants MOVEMENT_RESTRICTION_TYPE_ALLOWED / MOVEMENT_RESTRICTION_TYPE_DISALLOWED
- new methods isMovementRestrictionTypeAllowed / isMovementRestrictionTypeDisallowed
