### PR TITLE
No return null territory attachment get

### DIFF
--- a/game-app/ai/src/main/java/org/triplea/ai/flowfield/influence/InfluenceMapBuilder.java
+++ b/game-app/ai/src/main/java/org/triplea/ai/flowfield/influence/InfluenceMapBuilder.java
@@ -28,6 +28,9 @@ import org.triplea.ai.flowfield.odds.BattleDetails;
 @Builder(builderMethodName = "setup")
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class InfluenceMapBuilder {
+  public static final @Nonnull String RELATIONSHIP_ALLY = "ALLY";
+  public static final @Nonnull String RELATIONSHIP_UNKNOWN = "UNKNOWN";
+  public static final @Nonnull String RELATIONSHIP_ENEMY = "ENEMY";
   @Nonnull GamePlayer gamePlayer;
   @Nonnull PlayerList playerList;
   @Nonnull ResourceList resourceList;
@@ -78,23 +81,25 @@ public class InfluenceMapBuilder {
                   Collectors.groupingBy(
                       unit -> {
                         if (allies.contains(unit.getOwner())) {
-                          return "ALLY";
+                          return RELATIONSHIP_ALLY;
                         } else if (enemies.contains(unit.getOwner())) {
-                          return "ENEMY";
+                          return RELATIONSHIP_ENEMY;
                         } else {
-                          return "UNKNOWN";
+                          return RELATIONSHIP_UNKNOWN;
                         }
                       }));
-      if (!unitsGroupedByRelationship.containsKey("ALLY")
-          && !unitsGroupedByRelationship.containsKey("ENEMY")) {
+      if (!unitsGroupedByRelationship.containsKey(RELATIONSHIP_ALLY)
+          && !unitsGroupedByRelationship.containsKey(RELATIONSHIP_ENEMY)) {
         return BattleDetails.EMPTY_DETAILS;
       }
       return new BattleDetails(
-          unitsGroupedByRelationship.getOrDefault("ALLY", List.of()),
-          unitsGroupedByRelationship.getOrDefault("ENEMY", List.of()),
+          unitsGroupedByRelationship.getOrDefault(RELATIONSHIP_ALLY, List.of()),
+          unitsGroupedByRelationship.getOrDefault(RELATIONSHIP_ENEMY, List.of()),
           offenseCombatBuilder,
           defenseCombatBuilder,
-          TerritoryAttachment.get(territory).getTerritoryEffect());
+          TerritoryAttachment.get(territory)
+              .map(TerritoryAttachment::getTerritoryEffect)
+              .orElse(List.of()));
     };
   }
 }

--- a/game-app/ai/src/main/java/org/triplea/ai/flowfield/influence/ResourceValue.java
+++ b/game-app/ai/src/main/java/org/triplea/ai/flowfield/influence/ResourceValue.java
@@ -20,11 +20,11 @@ public class ResourceValue {
   public Function<Territory, Long> territoryToResourceValue(final Resource resource) {
     return territory -> {
       if (resource.getName().equals(Constants.PUS)) {
-        return Optional.ofNullable(TerritoryAttachment.get(territory))
+        return TerritoryAttachment.get(territory)
             .map(territoryAttachment -> (long) territoryAttachment.getProduction())
             .orElse(0L);
       } else {
-        return Optional.ofNullable(TerritoryAttachment.get(territory))
+        return TerritoryAttachment.get(territory)
             .map(
                 territoryAttachment ->
                     Optional.ofNullable(territoryAttachment.getResources())

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.NonNls;
 import org.triplea.java.collections.IntegerMap;
 
 /**
@@ -36,7 +37,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
   private static final Splitter COLON_SPLITTER = Splitter.on(':');
 
   @Setter private Attachable attachedTo;
-  private @Nullable String name;
+  private @NonNls @Nullable String name;
 
   protected DefaultAttachment(
       final String name, final Attachable attachable, final GameData gameData) {
@@ -97,7 +98,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
   }
 
   protected String thisErrorMsg() {
-    return ",   for: " + this;
+    return ", for: " + this;
   }
 
   /** Returns null or the toString() of the field value. */
@@ -120,7 +121,11 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
    */
   @Override
   public String toString() {
-    return getClass().getSimpleName() + " attached to: " + attachedTo + " with name: " + name;
+    return getClass().getSimpleName()
+        + " attached to: "
+        + attachedTo
+        + " with name: "
+        + Optional.ofNullable(name).orElse("<no name>");
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionFrontier.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionFrontier.java
@@ -2,15 +2,21 @@ package games.strategy.engine.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import org.jetbrains.annotations.NonNls;
 
 /** A collection of {@link ProductionRule}s. */
 public class ProductionFrontier extends DefaultNamed implements Iterable<ProductionRule> {
-  private static final long serialVersionUID = -5967251608158552892L;
+  public static final @NonNls String PRODUCTION = "production";
+  public static final @NonNls String PRODUCTION_INDUSTRIAL_TECHNOLOGY =
+      "productionIndustrialTechnology";
+  public static final @NonNls String PRODUCTION_SHIPYARDS = "productionShipyards";
+  @Serial private static final long serialVersionUID = -5967251608158552892L;
 
   private final List<ProductionRule> rules;
   private List<ProductionRule> cachedRules;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
@@ -1,12 +1,20 @@
 package games.strategy.engine.data;
 
 import games.strategy.triplea.Constants;
+import java.io.Serial;
 import java.util.Map.Entry;
+import org.jetbrains.annotations.NonNls;
 import org.triplea.java.collections.IntegerMap;
 
 /** A production rule. */
 public class ProductionRule extends DefaultNamed implements Rule {
-  private static final long serialVersionUID = -6598296283127741307L;
+  public static final @NonNls String BUY_ARTILLERY = "buyArtillery";
+  public static final @NonNls String BUY_DESTROYER = "buyDestroyer";
+  public static final @NonNls String BUY_ARTILLERY_INDUSTRIAL_TECHNOLOGY =
+      "buyArtilleryIndustrialTechnology";
+  public static final @NonNls String BUY_DESTROYER_INDUSTRIAL_TECHNOLOGY =
+      "buyDestroyerIndustrialTechnology";
+  @Serial private static final long serialVersionUID = -6598296283127741307L;
 
   private IntegerMap<Resource> costs = new IntegerMap<>();
   private IntegerMap<NamedAttachable> results = new IntegerMap<>();

--- a/game-app/game-core/src/main/java/games/strategy/engine/stats/VictoryCityStat.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/stats/VictoryCityStat.java
@@ -5,7 +5,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.mapdata.MapData;
-import java.util.Objects;
+import java.util.Optional;
 
 public class VictoryCityStat implements IStat {
   @Override
@@ -19,7 +19,8 @@ public class VictoryCityStat implements IStat {
     return data.getMap().getTerritories().stream()
         .filter(Matches.isTerritoryOwnedBy(player))
         .map(TerritoryAttachment::get)
-        .filter(Objects::nonNull)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
         .mapToInt(TerritoryAttachment::getVictoryCity)
         .sum();
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
@@ -15,6 +15,7 @@ import games.strategy.triplea.delegate.TechTracker;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -103,12 +104,13 @@ public class UnitUtils {
       return 0;
     }
     final UnitAttachment ua = unit.getUnitAttachment();
-    final TerritoryAttachment ta = TerritoryAttachment.get(producer);
     int territoryProduction = 0;
     int territoryUnitProduction = 0;
-    if (ta != null) {
-      territoryProduction = ta.getProduction();
-      territoryUnitProduction = ta.getUnitProduction();
+    final Optional<TerritoryAttachment> optionalTerritoryAttachment =
+        TerritoryAttachment.get(producer);
+    if (optionalTerritoryAttachment.isPresent()) {
+      territoryProduction = optionalTerritoryAttachment.get().getProduction();
+      territoryUnitProduction = optionalTerritoryAttachment.get().getUnitProduction();
     }
     int productionCapacity;
     final GameProperties properties = producer.getData().getProperties();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -528,14 +528,10 @@ class ProNonCombatMoveAi {
       }
 
       // Determine production value and if it is an enemy capital
-      int production = 0;
-      int isEnemyOrAlliedCapital = 0;
-      final TerritoryAttachment ta = TerritoryAttachment.get(t);
-      if (ta != null) {
-        production = ta.getProduction();
-        if (ta.isCapital() && !t.equals(proData.getMyCapital())) {
-          isEnemyOrAlliedCapital = 1;
-        }
+      ProCombatMoveAi.ProductionAndIsCapital productionAndIsEnemyOrAlliedCapital =
+          ProCombatMoveAi.getProductionAndIsCapital(t);
+      if (t.equals(proData.getMyCapital())) {
+        productionAndIsEnemyOrAlliedCapital.production = 0;
       }
 
       // Determine neighbor value
@@ -570,12 +566,12 @@ class ProNonCombatMoveAi {
       // Calculate defense value for prioritization
       final double territoryValue =
           unitOwnerMultiplier
-              * (2.0 * production
+              * (2.0 * productionAndIsEnemyOrAlliedCapital.production
                   + 10.0 * isFactory
                   + 0.5 * cantMoveUnitValue
                   + 0.5 * neighborValue)
               * (1 + 10.0 * isMyCapital)
-              * (1 + 4.0 * isEnemyOrAlliedCapital);
+              * (1 + 4.0 * productionAndIsEnemyOrAlliedCapital.isCapital);
       proTerritory.setValue(territoryValue);
     }
 
@@ -2280,7 +2276,7 @@ class ProNonCombatMoveAi {
 
         // Find value by checking if territory is not conquered and doesn't already have a
         // factory
-        final int production = TerritoryAttachment.get(t).getProduction();
+        final int production = TerritoryAttachment.getProduction(t);
         double value = 0.1 * proTerritory.getValue();
         if (ProMatches.territoryIsNotConqueredOwnedLand(player).test(t)
             && combinedStream(proTerritory.getCantMoveUnits(), proTerritory.getUnits())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -675,11 +675,7 @@ class ProPurchaseAi {
       }
 
       // Determine production value and if it is an enemy capital
-      int production = 0;
-      final TerritoryAttachment ta = TerritoryAttachment.get(t);
-      if (ta != null) {
-        production = ta.getProduction();
-      }
+      int production = TerritoryAttachment.get(t).map(TerritoryAttachment::getProduction).orElse(0);
 
       // Determine defending unit value
       double defendingUnitValue =
@@ -1259,7 +1255,8 @@ class ProPurchaseAi {
 
       // Only consider territories with production of at least 3 unless there are still remaining
       // PUs
-      final int production = TerritoryAttachment.get(t).getProduction();
+      final int production =
+          TerritoryAttachment.get(t).map(TerritoryAttachment::getProduction).orElse(0);
       if ((production < 3 && !hasExtraPUs) || production < 2) {
         continue;
       }
@@ -1332,7 +1329,8 @@ class ProPurchaseAi {
     double maxValue = 0.0;
     Territory maxTerritory = null;
     for (final Territory t : purchaseFactoryTerritories) {
-      final int production = TerritoryAttachment.get(t).getProduction();
+      final int production =
+          TerritoryAttachment.get(t).map(TerritoryAttachment::getProduction).orElse(0);
       final double value = territoryValueMap.get(t) * production + 0.1 * production;
       final boolean isAdjacentToSea =
           Matches.territoryHasNeighborMatching(data.getMap(), Matches.territoryIsWater()).test(t);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
@@ -67,27 +67,22 @@ class ProRetreatAi {
             proData, battleTerritory, attackers, defenders, new HashSet<>());
 
     // Determine if it has a factory
-    int isFactory = 0;
-    if (ProMatches.territoryHasInfraFactoryAndIsLand().test(battleTerritory)) {
-      isFactory = 1;
-    }
+    int isFactory = (ProMatches.territoryHasInfraFactoryAndIsLand().test(battleTerritory) ? 1 : 0);
 
     // Determine production value and if it is a capital
-    int production = 0;
-    int isCapital = 0;
-    final TerritoryAttachment ta = TerritoryAttachment.get(battleTerritory);
-    if (ta != null) {
-      production = ta.getProduction();
-      if (ta.isCapital()) {
-        isCapital = 1;
-      }
-    }
+    ProCombatMoveAi.ProductionAndIsCapital productionAndIsCapital =
+        ProCombatMoveAi.getProductionAndIsCapital(battleTerritory);
 
     // Calculate current attack value
     double territoryValue = 0;
     if (result.isHasLandUnitRemaining() || attackers.stream().noneMatch(Matches.unitIsAir())) {
       territoryValue =
-          result.getWinPercentage() / 100 * (2.0 * production * (1 + isFactory) * (1 + isCapital));
+          result.getWinPercentage()
+              / 100
+              * (2.0
+                  * productionAndIsCapital.production
+                  * (1 + isFactory)
+                  * (1 + productionAndIsCapital.isCapital));
     }
     double battleValue = result.getTuvSwing() + territoryValue;
     if (!isAttacker) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -187,13 +187,10 @@ public class ProTerritoryManager {
       }
 
       // Check strafing and using allied attack if enemy capital/factory
-      boolean isEnemyCapitalOrFactory = false;
-      final TerritoryAttachment ta = TerritoryAttachment.get(t);
-      if (!ProUtils.isNeutralLand(t)
-          && ((ta != null && ta.isCapital())
-              || ProMatches.territoryHasInfraFactoryAndIsLand().test(t))) {
-        isEnemyCapitalOrFactory = true;
-      }
+      boolean isEnemyCapitalOrFactory =
+          !ProUtils.isNeutralLand(t)
+              && (TerritoryAttachment.get(t).map(TerritoryAttachment::isCapital).orElse(false)
+                  || ProMatches.territoryHasInfraFactoryAndIsLand().test(t));
       if (patd.getMaxBattleResult().getWinPercentage() < proData.getMinWinPercentage()
           && isEnemyCapitalOrFactory
           && alliedAttackOptions.getMax(t) != null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
 
@@ -225,15 +226,14 @@ public final class ProSimulateTurnUtils {
       final GamePlayer player,
       final IDelegateBridge delegateBridge) {
 
-    final @Nullable GamePlayer terrOrigOwner = OriginalOwnerTracker.getOriginalOwner(t);
+    final Optional<GamePlayer> optionalTerrOrigOwner = OriginalOwnerTracker.getOriginalOwner(t);
     final RelationshipTracker relationshipTracker = data.getRelationshipTracker();
-    final TerritoryAttachment ta = TerritoryAttachment.get(t);
-    if (ta != null
-        && ta.getCapital() != null
-        && terrOrigOwner != null
-        && TerritoryAttachment.getAllCapitals(terrOrigOwner, data.getMap()).contains(t)
-        && relationshipTracker.isAllied(terrOrigOwner, player)) {
-
+    if (TerritoryAttachment.get(t).map(TerritoryAttachment::isCapital).orElse(false)
+        && optionalTerrOrigOwner.isPresent()
+        && TerritoryAttachment.getAllCapitals(optionalTerrOrigOwner.get(), data.getMap())
+            .contains(t)
+        && relationshipTracker.isAllied(optionalTerrOrigOwner.get(), player)) {
+      final GamePlayer terrOrigOwner = optionalTerrOrigOwner.get();
       // Give capital and any allied territories back to original owner
       final Collection<Territory> originallyOwned =
           OriginalOwnerTracker.getOriginallyOwned(data, terrOrigOwner);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -204,8 +204,10 @@ public final class ProPurchaseUtils {
             .and(Matches.unitIsBeingTransported().negate())
             .and((territory.isWater() ? Matches.unitIsLand() : Matches.unitIsSea()).negate());
     final Collection<Unit> factoryUnits = territory.getMatches(factoryMatch);
-    final TerritoryAttachment ta = TerritoryAttachment.get(territory);
-    final boolean originalFactory = (ta != null && ta.getOriginalFactory());
+    final boolean originalFactory =
+        TerritoryAttachment.get(territory)
+            .map(TerritoryAttachment::getOriginalFactory)
+            .orElse(false);
     final boolean playerIsOriginalOwner =
         !factoryUnits.isEmpty() && player.equals(getOriginalFactoryOwner(territory, player));
     final RulesAttachment ra = player.getRulesAttachment();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
@@ -256,11 +256,8 @@ public final class ProPurchaseValidationUtils {
       if (Properties.getUnlimitedConstructions(data.getProperties())) {
         maxConstructionType = Integer.MAX_VALUE;
       } else if (Properties.getMoreConstructionsWithFactory(data.getProperties())) {
-        int production = 0;
-        final TerritoryAttachment terrAttachment = TerritoryAttachment.get(territory);
-        if (terrAttachment != null) {
-          production = terrAttachment.getProduction();
-        }
+        int production =
+            TerritoryAttachment.get(territory).map(TerritoryAttachment::getProduction).orElse(0);
         maxConstructionType = Math.max(maxConstructionType, production);
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -239,8 +239,7 @@ public final class ProTerritoryValueUtils {
 
       // Get player production if capital
       double playerProduction = 0;
-      final TerritoryAttachment ta = TerritoryAttachment.get(t);
-      if (ta != null && ta.isCapital()) {
+      if (TerritoryAttachment.get(t).map(TerritoryAttachment::isCapital).orElse(false)) {
         playerProduction = ProUtils.getPlayerProduction(t.getOwner(), data);
       }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -618,7 +618,6 @@ public class TerritoryAttachment extends DefaultAttachment {
         || !optionalTerritoryAttachment.get().getConvoyRoute()) {
       return new HashSet<>();
     }
-    final TerritoryAttachment territoryAttachment = optionalTerritoryAttachment.get();
 
     final Collection<Territory> territories = new HashSet<>();
     // already checked above

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1699,12 +1699,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
           // covers TerritoryAttachment, CanalAttachment
           if (t.getTerritoryAttachmentName().getFirst().equals("TerritoryAttachment")) {
             final TerritoryAttachment attachment =
-                TerritoryAttachment.get(territory, t.getTerritoryAttachmentName().getSecond());
-            if (attachment == null) {
-              // water territories may not have an attachment, so this could be null
-              throw new IllegalStateException(
-                  "Triggers: No territory attachment for: " + territory.getName());
-            }
+                TerritoryAttachment.get(territory, t.getTerritoryAttachmentName().getSecond())
+                    .orElseThrow(
+                        () ->
+                            // water territories may not have an attachment, so this could be null
+                            new IllegalStateException(
+                                "Triggers: No territory attachment for: " + territory.getName()));
 
             getPropertyChangeHistoryStartEvent(
                     t,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1139,8 +1139,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       return 0;
     }
     // if it's an original factory then unlimited production
-    // Can be null!
-    final TerritoryAttachment ta = TerritoryAttachment.get(producer);
     final Predicate<Unit> factoryMatch =
         Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player)
             .and(Matches.unitIsBeingTransported().negate())
@@ -1149,7 +1147,10 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     // boolean placementRestrictedByFactory = isPlacementRestrictedByFactory();
     final boolean unitPlacementPerTerritoryRestricted =
         Properties.getUnitPlacementPerTerritoryRestricted(properties);
-    final boolean originalFactory = (ta != null && ta.getOriginalFactory());
+    final boolean originalFactory =
+        TerritoryAttachment.get(producer)
+            .map(TerritoryAttachment::getOriginalFactory)
+            .orElse(false);
     final boolean playerIsOriginalOwner =
         !factoryUnits.isEmpty() && this.player.equals(getOriginalFactoryOwner(producer));
     final RulesAttachment ra = player.getRulesAttachment();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -42,7 +42,7 @@ final class EditValidator {
   static String validateChangeTerritoryOwner(final GameData data, final Territory territory) {
     if (territory.isWater()
         && territory.getOwner().isNull()
-        && TerritoryAttachment.get(territory) == null) {
+        && TerritoryAttachment.get(territory).isEmpty()) {
       return "Territory is water and has no attachment";
     }
     return validateTerritoryBasic(data, territory);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -241,10 +241,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       int teamVCs = 0;
       for (final Territory t : territories) {
         if (Matches.isTerritoryOwnedByAnyOf(teamMembers).test(t)) {
-          final TerritoryAttachment ta = TerritoryAttachment.get(t);
-          if (ta != null) {
-            teamVCs += ta.getVictoryCity();
-          }
+          teamVCs += TerritoryAttachment.get(t).map(TerritoryAttachment::getVictoryCity).orElse(0);
         }
       }
       if (teamVCs >= vcAmount) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -422,10 +422,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
       final Collection<Territory> territories, final GameState data) {
     final IntegerMap<Resource> resources = new IntegerMap<>();
     for (final Territory current : territories) {
-      final TerritoryAttachment attachment = TerritoryAttachment.get(current);
-      if (attachment == null) {
-        throw new IllegalStateException("No attachment for owned territory: " + current.getName());
-      }
+      final TerritoryAttachment attachment = TerritoryAttachment.getOrThrow(current);
       final ResourceCollection toAdd = attachment.getResources();
       if (toAdd == null) {
         continue;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -198,7 +198,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
 
   private static void initSkipUnusedBids(final GameState data) {
     // we have a lot of bid steps, 12 for pact of steel
-    // in multi player this can be time consuming, since each vm
+    // in multi-player this can be time-consuming, since each vm
     // must be notified (and have its ui) updated for each step,
     // so remove the bid steps that aren't used
     for (final GameStep step : data.getSequence()) {
@@ -233,11 +233,11 @@ public class InitializationDelegate extends BaseTripleADelegate {
     if (!Properties.getWW2V2(data.getProperties()) && addArtilleryAndDestroyers) {
       final CompositeChange change = new CompositeChange();
       final ProductionRule artillery =
-          data.getProductionRuleList().getProductionRule("buyArtillery");
+          data.getProductionRuleList().getProductionRule(ProductionRule.BUY_ARTILLERY);
       final ProductionRule destroyer =
-          data.getProductionRuleList().getProductionRule("buyDestroyer");
+          data.getProductionRuleList().getProductionRule(ProductionRule.BUY_DESTROYER);
       final ProductionFrontier frontier =
-          data.getProductionFrontierList().getProductionFrontier("production");
+          data.getProductionFrontierList().getProductionFrontier(ProductionFrontier.PRODUCTION);
       if (artillery != null && !frontier.getRules().contains(artillery)) {
         change.add(ChangeFactory.addProductionRule(artillery, frontier));
       }
@@ -245,11 +245,14 @@ public class InitializationDelegate extends BaseTripleADelegate {
         change.add(ChangeFactory.addProductionRule(destroyer, frontier));
       }
       final ProductionRule artilleryIndustrialTechnology =
-          data.getProductionRuleList().getProductionRule("buyArtilleryIndustrialTechnology");
+          data.getProductionRuleList()
+              .getProductionRule(ProductionRule.BUY_ARTILLERY_INDUSTRIAL_TECHNOLOGY);
       final ProductionRule destroyerIndustrialTechnology =
-          data.getProductionRuleList().getProductionRule("buyDestroyerIndustrialTechnology");
+          data.getProductionRuleList()
+              .getProductionRule(ProductionRule.BUY_DESTROYER_INDUSTRIAL_TECHNOLOGY);
       final ProductionFrontier frontierIndustrialTechnology =
-          data.getProductionFrontierList().getProductionFrontier("productionIndustrialTechnology");
+          data.getProductionFrontierList()
+              .getProductionFrontier(ProductionFrontier.PRODUCTION_INDUSTRIAL_TECHNOLOGY);
       if (artilleryIndustrialTechnology != null
           && !frontierIndustrialTechnology.getRules().contains(artilleryIndustrialTechnology)) {
         change.add(
@@ -275,12 +278,13 @@ public class InitializationDelegate extends BaseTripleADelegate {
     if (useShipyards) {
       final CompositeChange change = new CompositeChange();
       final ProductionFrontier frontierShipyards =
-          data.getProductionFrontierList().getProductionFrontier("productionShipyards");
+          data.getProductionFrontierList()
+              .getProductionFrontier(ProductionFrontier.PRODUCTION_SHIPYARDS);
       /*
        * Find the productionRules, if the unit is NOT a sea unit, add it to the ShipYards prod rule.
        */
       final ProductionFrontier frontierNonShipyards =
-          data.getProductionFrontierList().getProductionFrontier("production");
+          data.getProductionFrontierList().getProductionFrontier(ProductionFrontier.PRODUCTION);
       final Collection<ProductionRule> rules = frontierNonShipyards.getRules();
       for (final ProductionRule rule : rules) {
         final NamedAttachable named = rule.getAnyResultKey();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -328,11 +328,8 @@ public class InitializationDelegate extends BaseTripleADelegate {
     final CompositeChange changes = new CompositeChange();
     for (final Territory current : data.getMap()) {
       if (!current.getOwner().isNull()) {
-        final TerritoryAttachment territoryAttachment = TerritoryAttachment.get(current);
-        if (territoryAttachment == null) {
-          throw new IllegalStateException("No territory attachment for " + current);
-        }
-        if (territoryAttachment.getOriginalOwner() == null) {
+        final TerritoryAttachment territoryAttachment = TerritoryAttachment.getOrThrow(current);
+        if (territoryAttachment.getOriginalOwner().isEmpty()) {
           changes.add(OriginalOwnerTracker.addOriginalOwnerChange(current, current.getOwner()));
         }
         final Collection<Unit> factoryAndInfrastructure =
@@ -341,10 +338,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
             OriginalOwnerTracker.addOriginalOwnerChange(
                 factoryAndInfrastructure, current.getOwner()));
       } else if (!current.isWater()) {
-        final TerritoryAttachment territoryAttachment = TerritoryAttachment.get(current);
-        if (territoryAttachment == null) {
-          throw new IllegalStateException("No territory attachment for " + current);
-        }
+        final TerritoryAttachment territoryAttachment = TerritoryAttachment.getOrThrow(current);
       }
     }
     bridge.getHistoryWriter().startEvent("Adding original owners");

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -22,6 +22,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.util.BonusIncomeUtils;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.CollectionUtils;
@@ -30,12 +31,6 @@ import org.triplea.java.collections.CollectionUtils;
 @Slf4j
 public class InitializationDelegate extends BaseTripleADelegate {
   private boolean needToInitialize = true;
-
-  @Override
-  public void initialize(final String name, final String displayName) {
-    this.name = name;
-    this.displayName = displayName;
-  }
 
   @Override
   public void start() {
@@ -292,8 +287,11 @@ public class InitializationDelegate extends BaseTripleADelegate {
         if (!(named instanceof UnitType)) {
           continue;
         }
-        final UnitType unit = data.getUnitTypeList().getUnitType(named.getName());
-        final boolean isSea = unit.getUnitAttachment().isSea();
+        Optional<UnitAttachment> optionalUnitAttachment =
+            Optional.ofNullable(data.getUnitTypeList().getUnitType(named.getName()))
+                .map(UnitType::getUnitAttachment);
+        final boolean isSea =
+            optionalUnitAttachment.isPresent() && optionalUnitAttachment.get().isSea();
         if (!isSea) {
           final ProductionRule prodRule =
               data.getProductionRuleList().getProductionRule(rule.getName());
@@ -337,8 +335,6 @@ public class InitializationDelegate extends BaseTripleADelegate {
         changes.add(
             OriginalOwnerTracker.addOriginalOwnerChange(
                 factoryAndInfrastructure, current.getOwner()));
-      } else if (!current.isWater()) {
-        final TerritoryAttachment territoryAttachment = TerritoryAttachment.getOrThrow(current);
       }
     }
     bridge.getHistoryWriter().startEvent("Adding original owners");

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1336,7 +1336,7 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryIsNotUnownedWater() {
-    return t -> !(t.isWater() && TerritoryAttachment.get(t) == null && t.getOwner().isNull());
+    return t -> !(t.isWater() && TerritoryAttachment.get(t).isEmpty() && t.getOwner().isNull());
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
@@ -42,7 +42,7 @@ public class OriginalOwnerTracker implements Serializable {
   }
 
   public static Optional<GamePlayer> getOriginalOwner(final Territory t) {
-    return TerritoryAttachment.get(t).map(TerritoryAttachment::getOriginalOwner).orElse(null);
+    return TerritoryAttachment.get(t).flatMap(TerritoryAttachment::getOriginalOwner);
   }
 
   public static GamePlayer getOriginalOwnerOrThrow(final Territory t) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
@@ -9,21 +9,23 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TerritoryAttachment;
+import java.io.Serial;
 import java.io.Serializable;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
-import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * Tracks the original owner of things. Needed since territories and factories must revert to their
  * original owner when captured from the enemy.
  */
 public class OriginalOwnerTracker implements Serializable {
-  private static final long serialVersionUID = 8462432412106180906L;
+  @Serial private static final long serialVersionUID = 8462432412106180906L;
 
   public static Change addOriginalOwnerChange(final Territory t, final GamePlayer player) {
     return ChangeFactory.attachmentPropertyChange(
-        TerritoryAttachment.get(t), player, Constants.ORIGINAL_OWNER);
+        TerritoryAttachment.getOrThrow(t), player, Constants.ORIGINAL_OWNER);
   }
 
   public static Change addOriginalOwnerChange(final Unit unit, final GamePlayer player) {
@@ -39,12 +41,17 @@ public class OriginalOwnerTracker implements Serializable {
     return change;
   }
 
-  public static @Nullable GamePlayer getOriginalOwner(final Territory t) {
-    final TerritoryAttachment ta = TerritoryAttachment.get(t);
-    if (ta == null) {
-      return null;
-    }
-    return ta.getOriginalOwner();
+  public static Optional<GamePlayer> getOriginalOwner(final Territory t) {
+    return TerritoryAttachment.get(t).map(TerritoryAttachment::getOriginalOwner).orElse(null);
+  }
+
+  public static GamePlayer getOriginalOwnerOrThrow(final Territory t) {
+    return TerritoryAttachment.getOrThrow(t)
+        .getOriginalOwner()
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    MessageFormat.format("GamePlayer expected for Territory {0}", t.getName())));
   }
 
   /** Returns the territories originally owned by the specified player. */
@@ -52,10 +59,7 @@ public class OriginalOwnerTracker implements Serializable {
       final GameState data, final GamePlayer player) {
     final Collection<Territory> territories = new ArrayList<>();
     for (final Territory t : data.getMap()) {
-      GamePlayer originalOwner = getOriginalOwner(t);
-      if (originalOwner == null) {
-        originalOwner = data.getPlayerList().getNullPlayer();
-      }
+      GamePlayer originalOwner = getOriginalOwner(t).orElse(data.getPlayerList().getNullPlayer());
       if (originalOwner.equals(player)) {
         territories.add(t);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -676,13 +676,13 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
           continue;
         }
         for (final Territory t : data.getMap().getTerritoriesOwnedBy(p1)) {
-          final GamePlayer original = OriginalOwnerTracker.getOriginalOwner(t);
-          if (original == null) {
-            continue;
-          }
-          if (original.equals(p2)) {
-            change.add(ChangeFactory.changeOwner(t, original));
-          }
+          OriginalOwnerTracker.getOriginalOwner(t)
+              .ifPresent(
+                  originalOwner -> {
+                    if (originalOwner.equals(p2)) {
+                      change.add(ChangeFactory.changeOwner(t, originalOwner));
+                    }
+                  });
         }
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
@@ -20,8 +20,9 @@ public final class TerritoryEffectHelper {
   private TerritoryEffectHelper() {}
 
   public static Collection<TerritoryEffect> getEffects(final Territory location) {
-    final TerritoryAttachment ta = TerritoryAttachment.get(location);
-    return (ta != null) ? ta.getTerritoryEffect() : new ArrayList<>();
+    return TerritoryAttachment.get(location)
+        .map(TerritoryAttachment::getTerritoryEffect)
+        .orElse(new ArrayList<>());
   }
 
   public static int getTerritoryCombatBonus(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -1216,13 +1216,15 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     // create a list of all kamikaze zones, listed by enemy
     final Map<GamePlayer, Collection<Territory>> kamikazeZonesByEnemy = new HashMap<>();
     for (final Territory t : data.getMap().getTerritories()) {
-      final TerritoryAttachment ta = TerritoryAttachment.get(t);
-      if (ta == null || !ta.getKamikazeZone()) {
+      final Optional<TerritoryAttachment> optionalTerritoryAttachment = TerritoryAttachment.get(t);
+      if (optionalTerritoryAttachment.isEmpty()
+          || !optionalTerritoryAttachment.get().getKamikazeZone()) {
         continue;
       }
+      final TerritoryAttachment territoryAttachment = optionalTerritoryAttachment.get();
       final GamePlayer owner =
           !Properties.getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(data.getProperties())
-              ? ta.getOriginalOwner()
+              ? territoryAttachment.getOriginalOwner().orElse(null)
               : t.getOwner();
       if (owner == null) {
         continue;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
@@ -114,7 +114,7 @@ class UnitInformation {
 
   private int getCostInformation(final UnitType type, final GameData data) {
     final ProductionFrontier production =
-        data.getProductionFrontierList().getProductionFrontier("production");
+        data.getProductionFrontierList().getProductionFrontier(ProductionFrontier.PRODUCTION);
     if (production != null) {
       for (final ProductionRule currentRule : production.getRules()) {
         final NamedAttachable currentType = currentRule.getAnyResultKey();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BottomBar.java
@@ -151,12 +151,14 @@ public class BottomBar extends JPanel implements TerritoryListener, ZoomMapListe
     try (GameData.Unlocker ignored = territory.getData().acquireReadLock()) {
       final Collection<Unit> units =
           uiContext.isShowUnitsInStatusBar() ? territory.getUnits() : List.of();
-      final TerritoryAttachment ta = TerritoryAttachment.get(territory);
       final IntegerMap<Resource> resources = new IntegerMap<>();
       final List<String> territoryEffectNames;
-      if (ta == null) {
+      final Optional<TerritoryAttachment> optionalTerritoryAttachment =
+          TerritoryAttachment.get(territory);
+      if (optionalTerritoryAttachment.isEmpty()) {
         territoryEffectNames = List.of();
       } else {
+        final TerritoryAttachment ta = optionalTerritoryAttachment.get();
         territoryEffectNames =
             ta.getTerritoryEffect().stream().map(TerritoryEffect::getName).toList();
         final int production = ta.getProduction();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -266,11 +266,13 @@ public class TileManager {
       drawUnits(territory, mapData, drawnOn, drawing);
     }
     drawing.add(new BattleDrawable(territory.getName()));
-    final TerritoryAttachment ta = TerritoryAttachment.get(territory);
+    final Optional<TerritoryAttachment> optionalTerritoryAttachment =
+        TerritoryAttachment.get(territory);
     if (!territory.isWater()) {
       drawing.add(new LandTerritoryDrawable(territory));
     } else {
-      if (ta != null) {
+      if (optionalTerritoryAttachment.isPresent()) {
+        final TerritoryAttachment ta = optionalTerritoryAttachment.get();
         // Kamikaze Zones
         if (ta.getKamikazeZone()) {
           drawing.add(new KamikazeZoneDrawable(territory, uiContext));
@@ -291,11 +293,13 @@ public class TileManager {
       drawing.add(new SeaZoneOutlineDrawable(territory.getName()));
     }
     drawing.add(new TerritoryNameDrawable(territory.getName(), uiContext));
-    if (ta != null && ta.isCapital() && mapData.drawCapitolMarkers()) {
-      final GamePlayer capitalOf = data.getPlayerList().getPlayerId(ta.getCapital());
+    if (optionalTerritoryAttachment.map(TerritoryAttachment::isCapital).orElse(false)
+        && mapData.drawCapitolMarkers()) {
+      final GamePlayer capitalOf =
+          data.getPlayerList().getPlayerId(optionalTerritoryAttachment.get().getCapital());
       drawing.add(new CapitolMarkerDrawable(capitalOf, territory, uiContext));
     }
-    if (ta != null && (ta.getVictoryCity() != 0)) {
+    if (optionalTerritoryAttachment.map(TerritoryAttachment::getVictoryCity).orElse(0) != 0) {
       drawing.add(new VcDrawable(territory));
     }
     // add to the relevant tiles

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
@@ -11,6 +11,7 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.util.Optional;
 
 /**
  * Draws the faded flag image of the original owner for the associated territory. Intended only for
@@ -33,7 +34,6 @@ public class KamikazeZoneDrawable extends AbstractDrawable {
       final MapData mapData) {
     // Change so only original owner gets the kamikaze zone marker
     final Territory terr = data.getMap().getTerritory(location);
-    final TerritoryAttachment ta = TerritoryAttachment.get(terr);
     GamePlayer owner;
     if (Properties.getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(data.getProperties())) {
       owner = terr.getOwner();
@@ -41,13 +41,16 @@ public class KamikazeZoneDrawable extends AbstractDrawable {
         owner = data.getPlayerList().getNullPlayer();
       }
     } else {
-      if (ta == null) {
+      final Optional<TerritoryAttachment> optionalTerritoryAttachment =
+          TerritoryAttachment.get(terr);
+      if (optionalTerritoryAttachment.isEmpty()) {
         owner = data.getPlayerList().getNullPlayer();
       } else {
-        owner = ta.getOriginalOwner();
-        if (owner == null) {
-          owner = data.getPlayerList().getNullPlayer();
-        }
+        owner =
+            optionalTerritoryAttachment
+                .get()
+                .getOriginalOwner()
+                .orElse(data.getPlayerList().getNullPlayer());
       }
     }
     final Image img = uiContext.getFlagImageFactory().getFadedFlag(owner);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
@@ -33,10 +33,8 @@ public class LandTerritoryDrawable extends TerritoryDrawable {
       final Graphics2D graphics,
       final MapData mapData,
       final float saturation) {
-    final TerritoryAttachment ta = TerritoryAttachment.get(territory);
-
     final Color territoryColor =
-        (ta != null && ta.getIsImpassable())
+        (TerritoryAttachment.get(territory).map(TerritoryAttachment::getIsImpassable).orElse(false))
             ? mapData.impassableColor()
             : mapData.getPlayerColor(territory.getOwner().getName());
 

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
@@ -10,7 +10,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Preconditions;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.attachments.TerritoryAttachment;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -71,6 +74,13 @@ class RouteFinderTest {
             territory6,
             territory7,
             territory8);
+
+    final TerritoryAttachment ta = mock(TerritoryAttachment.class);
+    Mockito.when(ta.getTerritoryEffect()).thenReturn(new ArrayList<>());
+    territories.forEach(
+        territory -> {
+          Mockito.when(territory.getAttachment(Constants.TERRITORY_ATTACHMENT_NAME)).thenReturn(ta);
+        });
   }
 
   private void configureNeighbors(final Territory territory, final Territory... neighbors) {

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.RulesAttachment;
@@ -81,7 +82,9 @@ final class GameParserTest {
                 .getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
 
     assertThat(spartaTerritoryAttachment.getVictoryCity(), is(1));
-    assertThat(spartaTerritoryAttachment.getOriginalOwner().getName(), is("RomanRepublic"));
+    assertThat(
+        spartaTerritoryAttachment.getOriginalOwner().map(GamePlayer::getName).orElse(""),
+        is("RomanRepublic"));
     assertThat(spartaTerritoryAttachment.getIsImpassable(), is(true));
 
     final var romaTerritoryAttachment =

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -390,7 +390,8 @@ class TriggerAttachmentTest {
     void testTriggerProductionChange() throws Exception {
       final GameData gameData = bridge.getData();
 
-      final ProductionFrontier startingFrontier = new ProductionFrontier("production", gameData);
+      final ProductionFrontier startingFrontier =
+          new ProductionFrontier(ProductionFrontier.PRODUCTION, gameData);
       final ProductionFrontier newFrontier =
           new ProductionFrontier("Americans_Super_Carrier_production", gameData);
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -190,7 +190,7 @@ final class MatchesTest {
       assertTrue(TerritoryAttachment.get(seaTerritory).isEmpty());
       TerritoryAttachment.add(
           seaTerritory, new TerritoryAttachment("name", seaTerritory, gameData));
-      assertTrue(TerritoryAttachment.get(seaTerritory).isEmpty());
+      assertTrue(TerritoryAttachment.get(seaTerritory).isPresent());
     }
 
     @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -5,8 +5,7 @@ import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
 import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
@@ -184,14 +183,14 @@ final class MatchesTest {
 
       landTerritory = gameData.getMap().getTerritory("Germany");
       landTerritory.setOwner(player);
-      assertThat(TerritoryAttachment.get(landTerritory), is(notNullValue()));
+      assertTrue(TerritoryAttachment.get(landTerritory).isPresent());
 
       seaTerritory = gameData.getMap().getTerritory("Baltic Sea Zone");
       seaTerritory.setOwner(player);
-      assertThat(TerritoryAttachment.get(seaTerritory), is(nullValue()));
+      assertTrue(TerritoryAttachment.get(seaTerritory).isEmpty());
       TerritoryAttachment.add(
           seaTerritory, new TerritoryAttachment("name", seaTerritory, gameData));
-      assertThat(TerritoryAttachment.get(seaTerritory), is(notNullValue()));
+      assertTrue(TerritoryAttachment.get(seaTerritory).isEmpty());
     }
 
     @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -350,7 +350,7 @@ class PacificTest {
     assertMoveError(GameDataTestUtil.getUnits(map, toSz30.getStart()), toSz30);
 
     // Finally, adding a naval base in Canada shouldn't boost movement further.
-    TerritoryAttachment.get(canada).getPropertyOrThrow("navalBase").setValue(true);
+    TerritoryAttachment.getOrThrow(canada).getPropertyOrThrow("navalBase").setValue(true);
     assertThat(TerritoryAttachment.hasNavalBase(canada), is(true));
     // Should still fail to move 4.
     assertMoveError(GameDataTestUtil.getUnits(map, toSz30.getStart()), toSz30);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -836,7 +836,7 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     assertValid(response);
     // placeUnits performPlace
     // get production and unit production values
-    final TerritoryAttachment ta = TerritoryAttachment.get(egypt);
+    final TerritoryAttachment ta = TerritoryAttachment.getOrThrow(egypt);
     assertEquals(ta.getUnitProduction(), ta.getProduction());
   }
 
@@ -1998,8 +1998,8 @@ class WW2V3Year41Test extends AbstractClientSettingTestCase {
     final Territory kiangsu = getTerritory("Kiangsu");
     final Territory mongolia = getTerritory("Mongolia");
     // Remove original capital
-    final TerritoryAttachment taMongolia = TerritoryAttachment.get(mongolia);
-    final TerritoryAttachment taKiangsu = TerritoryAttachment.get(kiangsu);
+    final TerritoryAttachment taMongolia = TerritoryAttachment.getOrThrow(mongolia);
+    final TerritoryAttachment taKiangsu = TerritoryAttachment.getOrThrow(kiangsu);
     taMongolia.getProperty("capital").get().resetValue();
     // Set as NEW capital
     taKiangsu.setCapital(Constants.PLAYER_NAME_CHINESE);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/BattleTrackerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/BattleTrackerTest.java
@@ -15,6 +15,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.attachments.TerritoryAttachment;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -48,6 +49,9 @@ class BattleTrackerTest {
   @Test
   void verifyRaids() {
     final Territory territory = new Territory("terrName", mockGameData);
+    territory.addAttachment(
+        Constants.TERRITORY_ATTACHMENT_NAME,
+        new TerritoryAttachment("name", territory, mockGameData));
     final Route route = new Route(territory);
     final GamePlayer gamePlayer = new GamePlayer("name", mockGameData);
 

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -249,8 +249,9 @@ class EditPanel extends ActionPanel {
         @Override
         public void territorySelected(final Territory territory, final MouseDetails md) {
           if (currentAction == changeTerritoryOwnerAction) {
-            final TerritoryAttachment ta = TerritoryAttachment.get(territory);
-            if (ta == null) {
+            final Optional<TerritoryAttachment> optionalTerritoryAttachment =
+                TerritoryAttachment.get(territory);
+            if (optionalTerritoryAttachment.isEmpty()) {
               JOptionPane.showMessageDialog(
                   getTopLevelAncestor(),
                   "No TerritoryAttachment for " + territory + ".",
@@ -258,11 +259,14 @@ class EditPanel extends ActionPanel {
                   JOptionPane.ERROR_MESSAGE);
               return;
             }
-            // PlayerId defaultPlayer = TerritoryAttachment.get(territory).getOriginalOwner();
-            final GamePlayer defaultPlayer = ta.getOriginalOwner();
+            final Optional<GamePlayer> optionalDefaultPlayer =
+                optionalTerritoryAttachment.get().getOriginalOwner();
             final PlayerChooser playerChooser =
                 new PlayerChooser(
-                    getData().getPlayerList(), defaultPlayer, getMap().getUiContext(), true);
+                    getData().getPlayerList(),
+                    optionalDefaultPlayer.orElse(null),
+                    getMap().getUiContext(),
+                    true);
             final JDialog dialog =
                 playerChooser.createDialog(getTopLevelAncestor(), "Select new owner for territory");
             dialog.setVisible(true);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -12,6 +12,7 @@ import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.ui.OverlayIcon;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -138,21 +139,28 @@ public class TerritoryDetailPanel extends JPanel {
       return;
     }
     setElementsVisible(true);
-    final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     final String labelText;
     final String additionalText =
         frame.getAdditionalTerritoryDetails().computeAdditionalText(territory);
-    if (ta == null) {
-      labelText =
-          "<html>"
-              + territory.getName()
-              + "<br>Water Territory"
-              + "<br><br>"
-              + additionalText
-              + "</html>";
-    } else {
-      labelText = "<html>" + ta.toStringForInfo(true, true) + "<br>" + additionalText + "</html>";
-    }
+    final Optional<TerritoryAttachment> optionalTerritoryAttachment =
+        TerritoryAttachment.get(territory);
+    labelText =
+        optionalTerritoryAttachment
+            .map(
+                territoryAttachment ->
+                    "<html>"
+                        + territoryAttachment.toStringForInfo(true, true)
+                        + "<br>"
+                        + additionalText
+                        + "</html>")
+            .orElseGet(
+                () ->
+                    "<html>"
+                        + territory.getName()
+                        + "<br>Water Territory"
+                        + "<br><br>"
+                        + additionalText
+                        + "</html>");
     territoryInfo.setText(labelText);
 
     final List<UnitCategory> unitsList;


### PR DESCRIPTION
noReturnNull (TerritoryAttachment.get OriginalOwnerTracker.getOriginalOwner)

Major files
TerritoryAttachment.java
- methods get: Return Optional instead of null

OriginalOwnerTracker
- methods getOriginalOwner: Return Optional instead of null

## Notes to Reviewer
All other files are adjusted for handling Optional instead of null from above methods.