### PR TITLE
Build fix: download install4j11 installer file directly from install4j

### DIFF
--- a/game-app/run/package
+++ b/game-app/run/package
@@ -27,25 +27,10 @@ function install_install4j() {
   mkdir -p $INSTALL4J_HOME
 
   echo "Downloading and installing install4j to '$INSTALL4J_HOME'"
-  install4j_url="https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_linux-x64_11_0_3.sh"
-
-  # The install4j file is host on github LFS
-  # The 'install4j_url' gives us manifest data, we first get the SHA & size of the object we are downloading
-  sha=$(curl -s "$install4j_url" | grep "^oid" | sed 's/.*sha256://')
-  size=$(curl -s "$install4j_url" | grep "^size" | sed 's/.* //')
-
-  # Now, we can send a request to github LFS for the download URL of the object, we do so, and we get back a response.
-  # We use 'jq' to parse the JSON response for the download href.
-  downloadUrl=$(
-    curl -s -X POST \
-      -H "Accept: application/vnd.git-lfs+json" \
-      -H "Content-type: application/json" \
-      -d "{\"operation\": \"download\", \"transfer\": [\"basic\"], \"objects\": [{\"oid\": \"$sha\", \"size\": $size}]}" \
-      https://github.com/triplea-game/assets.git/info/lfs/objects/batch \
-    | jq -r '.objects[0].actions.download.href')
+  install4j_url="https://download.ej-technologies.com/install4j/install4j_linux-x64_11_0_4.sh"
 
   # Now, do the download, download the installer
-  wget --no-verbose -O install4j_unix.sh "$downloadUrl"
+  wget --no-verbose -O install4j_unix.sh "$install4j_url"
 
   chmod +x install4j_unix.sh
   ./install4j_unix.sh -q -dir "$INSTALL4J_HOME"


### PR DESCRIPTION
Simple fix to avoid Git LFS rate limiting, download directly install4j installer file directly from ej-technologies

Before we hosted all files needed to create installers. Continuing that tradition, we hosted install4j_11. Though, Github does not allow files over 100MB, so we needed Git LFS. Except, Github Git LFS is quite rate limited, and we hit that rate quickly. Going forward, Git LFS is not a good solution for hosting larger files.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
