### PR TITLE
Simplify build: install4j gradle plugin installs install4j

### DIFF
--- a/.github/workflows/upload-game-installers.yml
+++ b/.github/workflows/upload-game-installers.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build Installers
         run: ./game-app/run/package
         env:
-          INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
+          INSTALL4J_LICENSE_KEY: ${{ secrets.INSTALL4J_LICENSE }}
       - name: set build version variables
         run: |
           BUILD_VERSION=$(game-app/run/.build/get-build-version)

--- a/game-app/game-headed/build.gradle
+++ b/game-app/game-headed/build.gradle
@@ -26,12 +26,6 @@ dependencies {
     testImplementation project(":lib:test-common")
 }
 
-install4j {
-    // If you wish to build the installers, you must install install4j and define the "install4jHomeDir" property on the
-    // command line (e.g. -Pinstall4jHomeDir=...) or in your personal Gradle properties (e.g. ~/.gradle/gradle.properties).
-    installDir = file(project.findProperty("install4jHomeDir") ?: ".")
-}
-
 jar {
     manifest {
         attributes "Main-Class": mainClassName
@@ -66,25 +60,10 @@ runShadow {
     dependsOn downloadAssets
 }
 
-// Downloads JDK bundles that are used to create installers
-task downloadPlatformInstallerAssets(group: "release", dependsOn: downloadAssets) {
-    doLast {
-        [
-            "install4j/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.4_11.tar.gz",
-        ].each { path ->
-            download.run {
-                src "https://raw.githubusercontent.com/triplea-game/assets/master/$path"
-                dest "$buildDir/assets/$path"
-                overwrite false
-            }
-        }
-    }
-}
-
 task platformInstallers(
     type: com.install4j.gradle.Install4jTask,
     group: "release",
-    dependsOn: [shadowJar, downloadPlatformInstallerAssets]) {
+    dependsOn: [shadowJar]) {
     projectFile = file("build.install4j")
     release = releaseVersion
 
@@ -107,7 +86,7 @@ task portableInstaller(type: Zip, group: "release", dependsOn: shadowJar) {
 }
 
 // creates installer files using install4j (eg: install.exe)
-task release(group: "release", dependsOn: [portableInstaller, platformInstallers]) {
+task release(group: "release", dependsOn: [portableInstaller, platformInstallers, downloadAssets]) {
     doLast {
         publishArtifacts(portableInstaller.outputs.files + [
             file("$releasesDir/TripleA_${releaseVersion}_macos.dmg"),

--- a/game-app/run/package
+++ b/game-app/run/package
@@ -8,35 +8,17 @@
 ## install install4j
 scriptDir=$(dirname "$0")
 
-if [ -z "$INSTALL4J_LICENSE" ]; then
-  echo "Environment variable 'INSTALL4J_LICENSE' must be set"
+if [ -z "$INSTALL4J_LICENSE_KEY" ]; then
+  echo "Environment variable 'INSTALL4J_LICENSE_KEY' must be set"
   exit 1
 fi
 
 set -ex
 
 function main() {
-  install_install4j
   build_installers
   collect_artifacts
 }
-
-# Installs install4j, the license key is injected into install4j during this step.
-function install_install4j() {
-  INSTALL4J_HOME=/tmp/install4j
-  mkdir -p $INSTALL4J_HOME
-
-  echo "Downloading and installing install4j to '$INSTALL4J_HOME'"
-  install4j_url="https://download.ej-technologies.com/install4j/install4j_linux-x64_11_0_4.sh"
-
-  # Now, do the download, download the installer
-  wget --no-verbose -O install4j_unix.sh "$install4j_url"
-
-  chmod +x install4j_unix.sh
-  ./install4j_unix.sh -q -dir "$INSTALL4J_HOME"
-  "$INSTALL4J_HOME/bin/install4jc" -L "$INSTALL4J_LICENSE"
-}
-
 
 ## Runs gradle command that creates the installer executables, uses intall4j
 function build_installers() {


### PR DESCRIPTION
The gradle plugin for install4j, by default now will install install4j. This means we do not have to worry about downloading and installing the install4j.sh file ourselves, we can leave this up to the gradle build plugin.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
