### PR TITLE
Split the Player Panel (Cleanup)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/stats/IStat.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/stats/IStat.java
@@ -4,6 +4,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.triplea.ui.mapdata.MapData;
 import java.text.DecimalFormat;
+import org.jetbrains.annotations.Nls;
 
 /**
  * A game statistic, such as total resources, total unit value, etc. Statistics can be obtained per
@@ -12,6 +13,7 @@ import java.text.DecimalFormat;
 public interface IStat {
   DecimalFormat DECIMAL_FORMAT = new DecimalFormat("##0.##");
 
+  @Nls
   String getName();
 
   double getValue(GamePlayer player, GameData data, MapData mapData);


### PR DESCRIPTION
Cleanup to PR https://github.com/triplea-game/triplea/pull/13391

ExtendedStats.java
- attribute statsExtended: Modifier transient
- method fillExtendedStats: Fill one list newStatsExtended and add later once
- method TechCountStat.getValue: Combine boolean methods into list before counting -method GenericUnitNameStat.getValue: for loop to stream for return value
- new interface GenericStat<T> to compress init calls

IStat.java
- method getName: Annotate Nls

StatPanel.java
- new method addListenerToGameDataChanged: Replaces call to deprecated gameData.addDataChangeListener(this)
- method setGameData: Replaced with annotation Setter
- methods getIcon: No return value used, so reworked and  renamed createImageIconIfNeeded
- attribute StatTableModel.collectData: Annotate Nullable, NonNls
- method getAlliancesToShow: Annotate return list entry Nls
