### PR TITLE
fix13462_PropertyPuIncomeBonus (PlayerSelectorRow#IllegalArgumentException)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -39,6 +39,7 @@ import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.delegate.GenericTechAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -496,7 +497,8 @@ public final class GameParser {
       // Next, infer the type of property based on its value
       // and set the property  in game data properties.
       if (current.getEditable() == null || !current.getEditable()) {
-        final Object castedValue = PropertyValueTypeInference.castToInferredType(value);
+        final Serializable castedValue =
+            (Serializable) PropertyValueTypeInference.castToInferredType(value);
         properties.set(propertyName, castedValue);
       } else {
         final Class<?> dataType = PropertyValueTypeInference.inferType(value);
@@ -535,13 +537,18 @@ public final class GameParser {
                 data.getProperties()
                     .addPlayerProperty(
                         new NumberProperty(
-                            Constants.getIncomePercentageFor(playerId), null, 999, 0, 100)));
+                            Constants.getPropertyNameIncomePercentageFor(playerId),
+                            null,
+                            999,
+                            0,
+                            100)));
     data.getPlayerList()
         .forEach(
             playerId ->
                 data.getProperties()
                     .addPlayerProperty(
-                        new NumberProperty(Constants.getPuIncomeBonus(playerId), null, 999, 0, 0)));
+                        new NumberProperty(
+                            Constants.getPropertyNamePuIncomeBonusFor(playerId), null, 999, 0, 0)));
   }
 
   private void parseOffset(final GamePlay.Offset offset) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.data.properties;
 
+import java.io.Serializable;
 import javax.swing.JComponent;
 
 /**
@@ -7,7 +8,7 @@ import javax.swing.JComponent;
  *
  * @param <T> The generic Type of the value being stored.
  */
-public interface IEditableProperty<T> {
+public interface IEditableProperty<T> extends Serializable {
   /**
    * get the name of the property.
    *

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -2,13 +2,14 @@ package games.strategy.engine.data.properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.io.Serial;
 import javax.swing.JComponent;
 import lombok.Getter;
 import org.triplea.swing.IntTextField;
 
 /** Implementation of {@link IEditableProperty} for an integer value. */
 public class NumberProperty extends AbstractEditableProperty<Integer> {
-  private static final long serialVersionUID = 6826763550643504789L;
+  @Serial private static final long serialVersionUID = 6826763550643504789L;
 
   @Getter private final int max;
   @Getter private final int min;
@@ -58,5 +59,16 @@ public class NumberProperty extends AbstractEditableProperty<Integer> {
       return i <= max && i >= min;
     }
     return false;
+  }
+
+  /**
+   * Copy method.
+   *
+   * @param newName New name of the cloned instance
+   * @return Cloned instance with a new name
+   */
+  public NumberProperty cloneAs(final String newName) {
+    return new NumberProperty(
+        newName, this.getDescription(), this.getMax(), this.getMin(), this.getValue());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/Constants.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/Constants.java
@@ -258,11 +258,11 @@ public interface Constants {
   @NonNls String SIGN_TECH_NOT_ENABLED = "-";
   @NonNls String SIGN_TECH_ENABLED = "X";
 
-  static String getIncomePercentageFor(final GamePlayer gamePlayer) {
+  static String getPropertyNameIncomePercentageFor(final GamePlayer gamePlayer) {
     return MessageFormat.format("{0} Income Percentage", gamePlayer.getName());
   }
 
-  static String getPuIncomeBonus(final GamePlayer gamePlayer) {
+  static String getPropertyNamePuIncomeBonusFor(final GamePlayer gamePlayer) {
     return MessageFormat.format("{0} PU Income Bonus", gamePlayer.getName());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -467,11 +467,11 @@ public final class Properties implements Constants {
 
   public static int getIncomePercentage(
       final GamePlayer gamePlayer, final GameProperties properties) {
-    return properties.get(Constants.getIncomePercentageFor(gamePlayer), 100);
+    return properties.get(Constants.getPropertyNameIncomePercentageFor(gamePlayer), 100);
   }
 
   public static int getPuIncomeBonus(final GamePlayer gamePlayer, final GameProperties properties) {
-    return properties.get(Constants.getPuIncomeBonus(gamePlayer), 0);
+    return properties.get(Constants.getPropertyNamePuIncomeBonusFor(gamePlayer), 0);
   }
 
   public static int getRelationshipsLastExtraRounds(final GameProperties properties) {

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -9,7 +9,6 @@ import games.strategy.triplea.Constants;
 import java.awt.Container;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
-import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -104,23 +103,11 @@ public class PlayerSelectorRow implements PlayerCountrySelection {
 
     incomePercentage =
         gameProperties
-            .getPlayerProperty(Constants.getIncomePercentageFor(player))
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        MessageFormat.format(
-                            "Property not found: {0}", Constants.getIncomePercentageFor(player))))
+            .getPlayerPropertyOrThrow(Constants.getPropertyNameIncomePercentageFor(player))
             .getEditorComponent();
     incomePercentageLabel = new JLabel("%");
-    puIncomeBonus =
-        gameProperties
-            .getPlayerProperty(Constants.getPuIncomeBonus(player))
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        MessageFormat.format(
-                            "Property not found: {0}", Constants.getPuIncomeBonus(player))))
-            .getEditorComponent();
+
+    puIncomeBonus = gameProperties.ensurePropertyPuIncomeBonusFor(player).getEditorComponent();
     puIncomeBonusLabel = new JLabel("PUs");
 
     setWidgetActivation();


### PR DESCRIPTION
PlayerSelectorRow.java
- constructor PlayerSelectorRow: Extract enforcing existence of player properties IncomePercentage and PuIncomeBonus

GameProperties.java
 - method set/get: Parameter value/return parameter from Object to Serializable (according to comment) and annotate Nullable
 - new method getPlayerPropertyOrThrow: Extracted
 - new method ensurePropertyPuIncomeBonusFor: Fix missing space in "GermansPU Income Bonus" if this old style is used

 Constants.java
 - rename methods getIncomePercentageFor/getPuIncomeBonus to getPropertyNameIncomePercentageFor/getPropertyNamePuIncomeBonusFor

 IEditableProperty.java
 - extends Serializable

 NumberProperty.java
 - new method cloneAs