### PR TITLE
Fix custom check script to return correct status code

### DIFF
--- a/.build/code-convention-checks/check-custom-style
+++ b/.build/code-convention-checks/check-custom-style
@@ -138,7 +138,6 @@ function useStaticImportsInTest() {
       "$file" \
      && status=1 && found=1
   done <<< "$(cat "$testFiles")"
-
   displayResult "$found"
 }
 export -f useStaticImportsInTest
@@ -158,10 +157,9 @@ function useJavaxNonnullInsteadOfLombokNonNull() {
 export -f useJavaxNonnullInsteadOfLombokNonNull
 
 
-parallel ::: \
-  removeUnusedLogAnnotations \
-  useStaticImportsInTest \
-  useJavaxNonnullInsteadOfLombokNonNull
+removeUnusedLogAnnotations
+useStaticImportsInTest
+useJavaxNonnullInsteadOfLombokNonNull
 
 ## The below flag errors that need to be fixed before they can be enabled
 #  favorJava9CollectionsApi

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
@@ -76,10 +76,10 @@ class RouteFinderTest {
             territory8);
 
     final TerritoryAttachment ta = mock(TerritoryAttachment.class);
-    Mockito.when(ta.getTerritoryEffect()).thenReturn(new ArrayList<>());
+    when(ta.getTerritoryEffect()).thenReturn(new ArrayList<>());
     territories.forEach(
         territory -> {
-          Mockito.when(territory.getAttachment(Constants.TERRITORY_ATTACHMENT_NAME)).thenReturn(ta);
+          when(territory.getAttachment(Constants.TERRITORY_ATTACHMENT_NAME)).thenReturn(ta);
         });
   }
 


### PR DESCRIPTION
The 'parallel' call is having a side effect where if we set "status=1", the variable assignment is lost after 'parallel' returns. So, if a check fails, we return "OK" incorrectly because the statuc code is reverted.

This update removes the 'parallel' (which has the drawback of a slower script), but corrects the output to correctly flag errors

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
