### PR TITLE
Github action packaging: INSTALL4J license variable potential fix

### DIFF
--- a/.github/workflows/upload-game-installers.yml
+++ b/.github/workflows/upload-game-installers.yml
@@ -27,15 +27,16 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - name: Build Installers
-        run: ./game-app/run/package
-        env:
-          INSTALL4J_LICENSE_KEY: ${{ secrets.INSTALL4J_LICENSE_KEY }}
-      - name: set build version variables
+      - name: set env variables
         run: |
           BUILD_VERSION=$(game-app/run/.build/get-build-version)
           echo "build_version=$BUILD_VERSION" | tee -a $GITHUB_ENV
           echo "release_name=$(date +%Y-%B-%d) - $BUILD_VERSION" | tee -a $GITHUB_ENV
+          echo "INSTALL4J_LICENSE_KEY=$INSTALL4J_LICENSE_KEY" | tee -a $GITHUB_ENV
+        env:
+          INSTALL4J_LICENSE_KEY: ${{ secrets.INSTALL4J_LICENSE_KEY }}
+      - name: Build Installers
+        run: ./game-app/run/package
       - name: Create Github Release
         uses: ncipollo/release-action@v1
         with:        


### PR DESCRIPTION
Set env variables a different way. It appears our license variable is not being exported and is therefore not available to the 'gradle' child process that is started via our 'package' script.

This update does a github action config to set env variables that are (hopefully) exported and therefore (hopefully) available to the gradle process that needs the INSTALL4J_LICENSE_KEY variable.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
