### PR TITLE
Dev tools - docker components & scripts to run a lobby server

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,0 +1,21 @@
+## .docker
+
+With docker you can run TripleA databases and servers.
+
+This folder contains scripts & config files for interacting with docker and
+helper scripts for starting servers.
+
+## Starting lobby
+
+Run:
+
+```bash
+./start-servers.sh
+```
+Lobby will be running on localhost port 5000.
+
+## Test Data
+
+As part of database startup, we'll also insert sample data that can
+be handy for testing, for example a lobby user with (user:pass) "test:test"
+is created.

--- a/.docker/database/01-init.sql
+++ b/.docker/database/01-init.sql
@@ -1,0 +1,3 @@
+create user lobby_user with password 'lobby_user';
+create database lobby_db with owner lobby_user;
+

--- a/.docker/db-connect.sh
+++ b/.docker/db-connect.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker compose exec database psql -U postgres

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,62 @@
+# This docker-compose file depends on './gradlew shadowJar'
+#
+# Launches all of the background servers used by TripleA.
+# The main entrypoint to those services is NGINX which
+# is listening on localhost:80
+#
+version: '3'
+services:
+  database:
+    image: postgres:10
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    volumes:
+      - ./database/01-init.sql:/docker-entrypoint-initdb.d/01-init.sql
+    ports:
+      - "${POSTGRES_PORT}:5432"
+    healthcheck:
+      test: echo 'select 1' | psql -h localhost -U postgres  | grep -q '1 row'
+      interval: 3s
+      retries: 10
+      timeout: 3s
+  flyway:
+    image: ghcr.io/triplea-game/lobby/flyway:latest
+    command: >
+      -locations=filesystem:/flyway/sql
+      -connectRetries=60
+      -user=lobby_user
+      -password=lobby_user
+      -url=jdbc:postgresql://database:5432/lobby_db
+      -ignoreMigrationPatterns=repeatable:missing
+      migrate
+    volumes:
+      - ./docker-flyway.config:/flyway/conf/flyway.config
+    depends_on:
+      - database
+  sample_data:
+    image: ghcr.io/triplea-game/lobby/sample_data:latest
+    command: >
+      -locations=filesystem:/flyway/sql
+      -connectRetries=60
+      -user=lobby_user
+      -password=lobby_user
+      -url=jdbc:postgresql://database:5432/lobby_db
+      migrate
+    volumes:
+      - ./docker-flyway.config:/flyway/conf/flyway.config
+    depends_on:
+      flyway:
+        condition: service_completed_successfully
+  lobby:
+    image: ghcr.io/triplea-game/lobby/server:latest
+    environment:
+      - DATABASE_USER=lobby_user
+      - DATABASE_PASSWORD=lobby_user
+      - DB_URL=database:5432/lobby_db
+    ports:
+      - "${LOBBY_PORT}:8080"
+    depends_on:
+      sample_data:
+         condition: service_completed_successfully

--- a/.docker/docker-flyway.config
+++ b/.docker/docker-flyway.config
@@ -1,0 +1,4 @@
+flyway.url=jdbc:postgresql://postgres:5432/lobby_db
+flyway.user=lobby_user
+flyway.password=lobby_user
+flyway.baselineOnMigrate=false

--- a/.docker/start-servers.sh
+++ b/.docker/start-servers.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Use docker to start local TripleA servers
+
+scriptDir="$(dirname "$0")"
+set -eu
+(
+  cd "$scriptDir" || exit 1
+  docker compose pull
+  LOBBY_PORT=5000 docker compose up --detach
+  echo "lobby started on port 5000"
+)

--- a/.docker/stop-servers.sh
+++ b/.docker/stop-servers.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Use docker to start local TripleA servers
+
+scriptDir="$(dirname "$0")"
+set -eu
+
+(
+  cd "$scriptDir" || exit 1
+  docker compose down
+)


### PR DESCRIPTION
Add a number of docker configs & scripts to a new folder '.docker'

We add docker-compose configuration that can launch a lobby on localhost port 5000. We add convenience scripts to start & stop the lobby.

Soon we'll have more servers and more databases to start up and not just the lobby. To handle this we'll want to have a NGINX do routing for us, which means adding a docker container with NGINX and the correct routing config for localhost.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
