### PR TITLE
Optional & null usage fixes

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -573,7 +573,7 @@ final class ProTechAi {
     // note this does not care if subs are submerged or not, should it?
     // does submerging affect movement of enemies?
     if (start == null || destination == null || !start.isWater() || !destination.isWater()) {
-      return null;
+      return Optional.empty();
     }
     final Predicate<Unit> transport =
         Matches.unitIsSeaTransport().negate().and(Matches.unitIsLand().negate());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1101,7 +1101,7 @@ public class ProTerritoryManager {
               final Predicate<Territory> canMove =
                   isCheckingEnemyAttacks ? canMoveSea : canMoveSeaThrough;
               for (final Territory to : map.getNeighbors(from, movesLeft, canMove)) {
-                if (map.getRouteForUnit(from, to, canMoveSeaThrough, transport, player) != null) {
+                if (map.getRouteForUnit(from, to, canMoveSeaThrough, transport, player).isPresent()) {
                   seaMoveTerritories.add(to);
                 }
               }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1101,7 +1101,8 @@ public class ProTerritoryManager {
               final Predicate<Territory> canMove =
                   isCheckingEnemyAttacks ? canMoveSea : canMoveSeaThrough;
               for (final Territory to : map.getNeighbors(from, movesLeft, canMove)) {
-                if (map.getRouteForUnit(from, to, canMoveSeaThrough, transport, player).isPresent()) {
+                if (map.getRouteForUnit(from, to, canMoveSeaThrough, transport, player)
+                    .isPresent()) {
                   seaMoveTerritories.add(to);
                 }
               }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -90,7 +90,7 @@ public final class ProMoveUtils {
         }
 
         // Determine route and add to move list
-        Optional<Route> optionalRoute = null;
+        Optional<Route> optionalRoute = Optional.empty();
         if (unitList.stream().anyMatch(Matches.unitIsSea())) {
 
           // Sea unit (including carriers with planes)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2540,7 +2540,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   public static Predicate<TriggerAttachment> resourceMatch() {
-    return t -> t.getResource() != null && t.getResourceCount() != 0;
+    return t -> t.getResource().isPresent() && t.getResourceCount() != 0;
   }
 
   public static Predicate<TriggerAttachment> supportMatch() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -784,7 +784,7 @@ public class BattleTracker implements Serializable {
       if (territory.isWater()) {
         // should probably see if there is something actually happening for water
         broadcaster.playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_SEA, gamePlayer);
-      } else if (territoryAttachment.getCapital() != null) {
+      } else if (territoryAttachment.getCapital().isPresent()) {
         broadcaster.playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_CAPITAL, gamePlayer);
       } else if (blitzed.contains(territory)
           && arrivedUnits != null
@@ -809,7 +809,7 @@ public class BattleTracker implements Serializable {
     // Also check to make sure playerAttachment even HAS a capital to fix abend
     if (isTerritoryOwnerAnEnemy
         && isTerritoryOrigOwnerAllied
-        && territoryAttachment.getCapital() != null
+        && territoryAttachment.getCapital().isPresent()
         && TerritoryAttachment.getAllCapitals(optionalTerrOrigOwner.get(), data.getMap())
             .contains(territory)) {
       final GamePlayer terrOrigOwner = optionalTerrOrigOwner.get();


### PR DESCRIPTION
Values of type optional should never be assigned to null, nor should they be compared to null. Following a recent refactor, it seems a few updates were missed to change the comparison of newly returned optional types against null. These comparisons should all be against whether the optional is empty or present, checking against null is incorrect.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
