### PR TITLE
No return null (get territory)#1.1

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -20,6 +20,7 @@ import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
 import org.triplea.java.collections.IntegerMap;
 
 /**
@@ -173,9 +174,25 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
         && (Objects.equals(name, other.name) || this.toString().equals(other.toString()));
   }
 
-  protected Territory getTerritoryOrThrow(String name) throws GameParseException {
-    return Optional.ofNullable(getData().getMap().getTerritory(name))
-        .orElseThrow(() -> new GameParseException("No territory named: " + name + thisErrorMsg()));
+  private Optional<Territory> getTerritory(@Nullable String territoryName) {
+    return Optional.ofNullable(getData().getMap().getTerritoryOrNull(territoryName));
+  }
+
+  @NotNull
+  protected Territory getTerritoryOrThrowGameParseException(String territoryName)
+      throws GameParseException {
+    return getTerritory(territoryName)
+        .orElseThrow(
+            () -> new GameParseException("No territory named: " + territoryName + thisErrorMsg()));
+  }
+
+  @NotNull
+  protected Territory getTerritoryOrThrowIllegalStateException(@Nullable String territoryName)
+      throws IllegalStateException {
+    return getTerritory(territoryName)
+        .orElseThrow(
+            () ->
+                new IllegalStateException("No territory named: " + territoryName + thisErrorMsg()));
   }
 
   protected List<GamePlayer> parsePlayerList(final String value, List<GamePlayer> existingList)

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -16,11 +16,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NonNls;
-import org.jetbrains.annotations.NotNull;
 import org.triplea.java.collections.IntegerMap;
 
 /**
@@ -178,7 +178,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
     return Optional.ofNullable(getData().getMap().getTerritoryOrNull(territoryName));
   }
 
-  @NotNull
+  @Nonnull
   protected Territory getTerritoryOrThrowGameParseException(String territoryName)
       throws GameParseException {
     return getTerritory(territoryName)
@@ -186,7 +186,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
             () -> new GameParseException("No territory named: " + territoryName + thisErrorMsg()));
   }
 
-  @NotNull
+  @Nonnull
   protected Territory getTerritoryOrThrowIllegalStateException(@Nullable String territoryName)
       throws IllegalStateException {
     return getTerritory(territoryName)

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -253,7 +253,7 @@ public class GameData implements Serializable, GameState {
       case UnitHolder.PLAYER:
         return playerList.getPlayerId(name);
       case UnitHolder.TERRITORY:
-        return map.getTerritory(name);
+        return map.getTerritoryOrThrow(name);
       default:
         throw new IllegalStateException("Invalid type: " + type);
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
 import org.triplea.java.RemoveOnNextMajorRelease;
 import org.triplea.java.collections.IntegerMap;
 
@@ -390,7 +389,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param t1 start territory of the route
    * @param t2 end territory of the route
    */
-  public int getDistance(@NotNull final Territory t1, @NotNull final Territory t2) {
+  public int getDistance(@Nonnull final Territory t1, @Nonnull final Territory t2) {
     return getDistance(t1, t2, it -> true);
   }
 
@@ -403,7 +402,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param cond condition that covered territories of the route must match
    */
   public int getDistance(
-      @NotNull final Territory t1, @NotNull final Territory t2, final Predicate<Territory> cond) {
+      @Nonnull final Territory t1, @Nonnull final Territory t2, final Predicate<Territory> cond) {
     return getDistance(t1, t2, (it, it2) -> cond.test(it2));
   }
 
@@ -416,8 +415,8 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param routeCond condition that neighboring territories along route must match.
    */
   public int getDistance(
-      @NotNull final Territory t1,
-      @NotNull final Territory t2,
+      @Nonnull final Territory t1,
+      @Nonnull final Territory t2,
       final BiPredicate<Territory, Territory> routeCond) {
     if (t1.equals(t2)) {
       return 0;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.triplea.java.RemoveOnNextMajorRelease;
 import org.triplea.java.collections.IntegerMap;
 
@@ -63,7 +64,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     territoryLookup.put(t1.getName(), t1);
   }
 
-  /** Bi-directional. T1 connects to T2, and T2 connects to T1. */
+  /** Bidirectional. T1 connects to T2, and T2 connects to T1. */
   public void addConnection(final Territory t1, final Territory t2) {
     if (t1.equals(t2)) {
       throw new IllegalArgumentException("Cannot connect a territory to itself: " + t1);
@@ -85,21 +86,28 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
-   * Returns the territory with the given name, or null if no territory can be found (case
-   * sensitive).
+   * Case-sensitive search for {@link Territory} by name. *
    *
-   * @param s name of the searched territory (case sensitive)
+   * @param territoryName name of the searched territory (case-sensitive)
+   * @return Territory with the given name or {@code null} if no territory can be found.
    */
-  public @Nullable Territory getTerritory(final String s) {
-    return territoryLookup.get(s);
+  public @Nullable Territory getTerritoryOrNull(final String territoryName) {
+    return territoryLookup.get(territoryName);
   }
 
-  public Territory getTerritoryOrThrow(final String s) {
-    return Optional.ofNullable(territoryLookup.get(s))
+  /**
+   * Case-sensitive search for {@link Territory} by name.
+   *
+   * @param territoryName name of the searched territory (case-sensitive)
+   * @return Territory with the given name or {@link Territory} if no territory can be found.
+   */
+  public Territory getTerritoryOrThrow(final String territoryName) {
+    return Optional.ofNullable(getTerritoryOrNull(territoryName))
         .orElseThrow(
             () ->
                 new IllegalArgumentException(
-                    MessageFormat.format("Territory with name {0} could not be found", s)));
+                    MessageFormat.format(
+                        "Territory with name {0} could not be found", territoryName)));
   }
 
   /**
@@ -382,7 +390,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param t1 start territory of the route
    * @param t2 end territory of the route
    */
-  public int getDistance(final Territory t1, final Territory t2) {
+  public int getDistance(@NotNull final Territory t1, @NotNull final Territory t2) {
     return getDistance(t1, t2, it -> true);
   }
 
@@ -394,7 +402,8 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param t2 end territory of the route
    * @param cond condition that covered territories of the route must match
    */
-  public int getDistance(final Territory t1, final Territory t2, final Predicate<Territory> cond) {
+  public int getDistance(
+      @NotNull final Territory t1, @NotNull final Territory t2, final Predicate<Territory> cond) {
     return getDistance(t1, t2, (it, it2) -> cond.test(it2));
   }
 
@@ -407,7 +416,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param routeCond condition that neighboring territories along route must match.
    */
   public int getDistance(
-      final Territory t1, final Territory t2, final BiPredicate<Territory, Territory> routeCond) {
+      @NotNull final Territory t1,
+      @NotNull final Territory t2,
+      final BiPredicate<Territory, Territory> routeCond) {
     if (t1.equals(t2)) {
       return 0;
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
@@ -64,7 +64,7 @@ public class GameObjectStreamData implements Externalizable {
         case PLAYERID:
           return data.getPlayerList().getPlayerId(name);
         case TERRITORY:
-          return data.getMap().getTerritory(name);
+          return data.getMap().getTerritoryOrThrow(name);
         case UNITTYPE:
           return data.getUnitTypeList().getUnitTypeOrThrow(name);
         case PRODUCTIONRULE:

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -51,7 +51,10 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
                     MessageFormat.format("UnitTypeList has no unit type for {0}", name)));
   }
 
-  /** Will return null if even a single name is not on the unit list. */
+  /**
+   * @param names Array of String values for UnitType names
+   * @return Set of UnitType
+   */
   public Set<UnitType> getUnitTypes(final String[] names) {
     final Set<UnitType> types = new HashSet<>();
     for (final String name : names) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
@@ -60,7 +60,7 @@ class PlayerOwnerChange extends Change {
       final GamePlayer player = data.getPlayerList().getPlayerId(owner);
       unit.setOwner(player);
     }
-    data.getMap().getTerritory(territoryName).notifyChanged();
+    data.getMap().getTerritoryOrThrow(territoryName).notifyChanged();
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/units/BombingUnitDamageChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/units/BombingUnitDamageChange.java
@@ -51,7 +51,7 @@ public class BombingUnitDamageChange extends Change {
                     .get(UUID.fromString(unitId))
                     .setUnitDamage(newDamage.getInt(unitId)));
     this.territoriesToNotify.forEach(
-        territory -> data.getMap().getTerritory(territory).notifyChanged());
+        territory -> data.getMap().getTerritoryOrThrow(territory).notifyChanged());
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/units/UnitDamageReceivedChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/units/UnitDamageReceivedChange.java
@@ -56,7 +56,7 @@ public class UnitDamageReceivedChange extends Change {
         });
     // invoke territory change listeners
     for (final String territory : territoriesToNotify) {
-      data.getMap().getTerritory(territory).notifyChanged();
+      data.getMap().getTerritoryOrThrow(territory).notifyChanged();
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -309,7 +309,7 @@ public final class GameParser {
   }
 
   private Territory getTerritory(final String name) throws GameParseException {
-    return Optional.ofNullable(data.getMap().getTerritory(name))
+    return Optional.ofNullable(data.getMap().getTerritoryOrNull(name))
         .orElseThrow(
             () ->
                 new GameParseException(

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
+import javax.annotation.Nonnull;
 import lombok.Getter;
-import org.jetbrains.annotations.NotNull;
 import org.triplea.java.ObjectUtils;
 import org.triplea.java.collections.CollectionUtils;
 
@@ -46,10 +46,10 @@ public final class BreadthFirstSearch {
    * caller before running the BreadthFirstSearch.
    */
   public static class TerritoryFinder implements Visitor {
-    @NotNull final Territory destination;
+    @Nonnull final Territory destination;
     @Getter int distanceFound = -1;
 
-    public TerritoryFinder(@NotNull Territory destination) {
+    public TerritoryFinder(@Nonnull Territory destination) {
       this.destination = destination;
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 import org.triplea.java.ObjectUtils;
 import org.triplea.java.collections.CollectionUtils;
 
@@ -45,10 +46,10 @@ public final class BreadthFirstSearch {
    * caller before running the BreadthFirstSearch.
    */
   public static class TerritoryFinder implements Visitor {
-    final Territory destination;
+    @NotNull final Territory destination;
     @Getter int distanceFound = -1;
 
-    public TerritoryFinder(Territory destination) {
+    public TerritoryFinder(@NotNull Territory destination) {
       this.destination = destination;
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -473,7 +473,7 @@ class ProPurchaseAi {
               }
             }
             doPlace(
-                data.getMap().getTerritory(ppt.getTerritory().getName()),
+                data.getMap().getTerritoryOrNull(ppt.getTerritory().getName()),
                 unitsToPlace,
                 placeDelegate);
             ProLogger.debug(ppt.getTerritory() + " placed units: " + unitsToPlace);
@@ -494,7 +494,7 @@ class ProPurchaseAi {
               }
             }
             doPlace(
-                data.getMap().getTerritory(ppt.getTerritory().getName()),
+                data.getMap().getTerritoryOrNull(ppt.getTerritory().getName()),
                 unitsToPlace,
                 placeDelegate);
             ProLogger.debug(ppt.getTerritory() + " placed units: " + unitsToPlace);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -94,7 +94,7 @@ public final class ProSimulateTurnUtils {
         }
         battleDelegate.getBattleTracker().getConquered().add(t);
         battleDelegate.getBattleTracker().removeBattle(battle, data);
-        final Territory updatedTerritory = data.getMap().getTerritory(t.getName());
+        final Territory updatedTerritory = data.getMap().getTerritoryOrNull(t.getName());
         ProLogger.debug(
             "after changes owner="
                 + updatedTerritory.getOwner()
@@ -122,7 +122,7 @@ public final class ProSimulateTurnUtils {
     final Map<Territory, ProTerritory> result = new HashMap<>();
     final List<Unit> usedUnits = new ArrayList<>();
     for (final Territory fromTerritory : moveMap.keySet()) {
-      final Territory toTerritory = toData.getMap().getTerritory(fromTerritory.getName());
+      final Territory toTerritory = toData.getMap().getTerritoryOrNull(fromTerritory.getName());
       final ProTerritory patd = new ProTerritory(toTerritory, proData);
       result.put(toTerritory, patd);
       final Map<Unit, List<Unit>> amphibAttackMap = moveMap.get(fromTerritory).getAmphibAttackMap();
@@ -168,7 +168,9 @@ public final class ProSimulateTurnUtils {
           patd.getTransportTerritoryMap()
               .put(
                   toTransport,
-                  toData.getMap().getTerritory(transportTerritoryMap.get(transport).getName()));
+                  toData
+                      .getMap()
+                      .getTerritoryOrNull(transportTerritoryMap.get(transport).getName()));
         }
         ProLogger.trace(
             "---Transferring transport="
@@ -204,7 +206,7 @@ public final class ProSimulateTurnUtils {
         final Unit toUnit = transferUnit(u, unitTerritoryMap, usedUnits, toData, player);
         if (toUnit != null) {
           patd.getBombardTerritoryMap()
-              .put(toUnit, toData.getMap().getTerritory(bombardMap.get(u).getName()));
+              .put(toUnit, toData.getMap().getTerritoryOrNull(bombardMap.get(u).getName()));
           ProLogger.trace(
               "---Transferring bombard="
                   + u
@@ -269,7 +271,7 @@ public final class ProSimulateTurnUtils {
     final List<Unit> toUnits =
         toData
             .getMap()
-            .getTerritory(unitTerritory.getName())
+            .getTerritoryOrNull(unitTerritory.getName())
             .getMatches(
                 ProMatches.unitIsOwnedAndMatchesTypeAndNotTransporting(player, u.getType()));
     for (final Unit toUnit : toUnits) {
@@ -293,7 +295,7 @@ public final class ProSimulateTurnUtils {
     final List<Unit> toTransports =
         toData
             .getMap()
-            .getTerritory(unitTerritory.getName())
+            .getTerritoryOrNull(unitTerritory.getName())
             .getMatches(
                 ProMatches.unitIsOwnedAndMatchesTypeAndIsTransporting(player, transport.getType()));
     for (final Unit toTransport : toTransports) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -283,10 +283,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
         setTerritoryCount(allTerritories.size());
         return allTerritories;
       default: // The list just contained 1 territory
-        final Territory t = data.getMap().getTerritory(name);
-        if (t == null) {
-          throw new IllegalStateException("No territory called: " + name + thisErrorMsg());
-        }
+        final Territory t = getTerritoryOrThrowIllegalStateException(name);
         final Set<Territory> terr = new HashSet<>();
         terr.add(t);
         setTerritoryCount(1);
@@ -392,10 +389,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
         // territory name is not an integer; fall through
       }
       // Validate all territories exist
-      final Territory territory = getData().getMap().getTerritory(name);
-      if (territory == null) {
-        throw new IllegalStateException("No territory called: " + name + thisErrorMsg());
-      }
+      final Territory territory = getTerritoryOrThrowIllegalStateException(name);
       territories.add(territory);
     }
     if (mustSetTerritoryCount && !haveSetCount) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -86,10 +86,7 @@ public class CanalAttachment extends DefaultAttachment {
   private void setLandTerritories(final String landTerritories) {
     final Set<Territory> terrs = new HashSet<>();
     for (final String name : splitOnColon(landTerritories)) {
-      final Territory territory = getData().getMap().getTerritory(name);
-      if (territory == null) {
-        throw new IllegalStateException("Canals: No territory called: " + name + thisErrorMsg());
-      }
+      final Territory territory = getTerritoryOrThrowIllegalStateException(name);
       terrs.add(territory);
     }
     this.landTerritories = terrs;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -210,10 +210,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     final GameMap map = getData().getMap();
     // this loop starts on 4, so do not replace with an enhanced for loop
     for (int i = 4; i < s.length; i++) {
-      final Territory t = map.getTerritory(s[i]);
-      if (t == null) {
-        throw new GameParseException("no such territory called: " + s[i] + thisErrorMsg());
-      }
+      final Territory t = getTerritoryOrThrowGameParseException(s[i]);
       terrs.add(t);
     }
     if (battle == null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -6,7 +6,6 @@ import static com.google.common.base.Preconditions.checkState;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.BattleRecordsList;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.IAttachment;
@@ -207,7 +206,6 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       }
     }
     final List<Territory> terrs = new ArrayList<>();
-    final GameMap map = getData().getMap();
     // this loop starts on 4, so do not replace with an enhanced for loop
     for (int i = 4; i < s.length; i++) {
       final Territory t = getTerritoryOrThrowGameParseException(s[i]);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -545,7 +545,7 @@ public class TerritoryAttachment extends DefaultAttachment {
       return;
     }
     for (final String subString : splitOnColon(value)) {
-      final Territory territory = getTerritoryOrThrow(subString);
+      final Territory territory = getTerritoryOrThrowGameParseException(subString);
       if (convoyAttached == null) {
         convoyAttached = new HashSet<>();
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -55,10 +55,10 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NonNls;
-import org.jetbrains.annotations.NotNull;
 import org.triplea.java.ObjectUtils;
 import org.triplea.java.PredicateBuilder;
 import org.triplea.java.collections.CollectionUtils;
@@ -1254,7 +1254,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     removeUnits = null;
   }
 
-  public @NotNull Collection<Territory> getTerritoriesFromFieldValue(
+  public @Nonnull Collection<Territory> getTerritoriesFromFieldValue(
       @NonNls final String territoryFieldValue) throws GameParseException {
     final Collection<Territory> territories = new ArrayList<>();
     try {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2652,7 +2652,7 @@ public class UnitAttachment extends DefaultAttachment {
     final Set<Territory> territories = new HashSet<>();
     for (final String name : list) {
       // Validate all territories exist
-      final Territory territory = getData().getMap().getTerritory(name);
+      final Territory territory = getData().getMap().getTerritoryOrNull(name);
       if (territory != null) {
         territories.add(territory);
       } else {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -71,7 +71,7 @@ class BattleCalculator implements IBattleCalculator {
           defender == null
               ? gameData.getPlayerList().getNullPlayer()
               : gameData.getPlayerList().getPlayerId(defender.getName());
-      final Territory location2 = gameData.getMap().getTerritory(location.getName());
+      final Territory location2 = gameData.getMap().getTerritoryOrThrow(location.getName());
       final Collection<Unit> attackingUnits =
           translateCollectionIntoOtherGameData(attacking, gameData);
       final Collection<Unit> defendingUnits =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -534,23 +534,24 @@ public class MapData {
     final Iterator<String> iter = keys.iterator();
     while (iter.hasNext()) {
       final String name = iter.next();
-      final Territory terr = data.getMap().getTerritory(name);
+      final Territory terr = data.getMap().getTerritoryOrNull(name);
       // allow loading saved games with missing territories; just ignore them
       if (terr == null) {
         iter.remove();
       }
     }
-
-    for (final Territory terr : data.getMap().getTerritories()) {
-      if (!keys.contains(terr.getName())) {
-        errors
-            .append("No data of type ")
-            .append(dataTypeForErrorMessage)
-            .append(" for territory: ")
-            .append(terr.getName())
-            .append("\n");
-      }
-    }
+    data.getMap().getTerritories().stream()
+        .map(Territory::getName)
+        .filter(territoryName -> !keys.contains(territoryName))
+        .forEach(
+            territoryName -> {
+              errors
+                  .append("No data of type ")
+                  .append(dataTypeForErrorMessage)
+                  .append(" for territory: ")
+                  .append(territoryName)
+                  .append("\n");
+            });
     if (errors.length() > 0) {
       throw new IllegalStateException(errors.toString());
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -544,7 +544,7 @@ public class MapPanel extends ImageScrollerLargeView {
     if (name == null) {
       return null;
     }
-    return gameData.getMap().getTerritory(name);
+    return gameData.getMap().getTerritoryOrThrow(name);
   }
 
   private double normalizeX(final double x) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TerritoryOverLayDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TerritoryOverLayDrawable.java
@@ -40,7 +40,7 @@ class TerritoryOverLayDrawable extends AbstractDrawable {
       final GameData data,
       final Graphics2D graphics,
       final MapData mapData) {
-    final Territory territory = data.getMap().getTerritory(territoryName);
+    final Territory territory = data.getMap().getTerritoryOrThrow(territoryName);
     final List<Polygon> polygons = mapData.getPolygons(territory);
     graphics.setColor(color);
     for (final Polygon polygon : polygons) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -24,8 +24,8 @@ import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.util.List;
 import java.util.function.Predicate;
+import javax.annotation.Nonnull;
 import lombok.Getter;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Draws units for the associated territory.
@@ -276,7 +276,7 @@ public class UnitsDrawer extends AbstractDrawable {
     return territory.getMatches(selectedUnits);
   }
 
-  public @NotNull Territory getTerritory(GameData data) {
+  public @Nonnull Territory getTerritory(GameData data) {
     return data.getMap().getTerritoryOrThrow(territoryName);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -25,6 +25,7 @@ import java.awt.RenderingHints;
 import java.util.List;
 import java.util.function.Predicate;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Draws units for the associated territory.
@@ -261,7 +262,7 @@ public class UnitsDrawer extends AbstractDrawable {
     // note - it may be the case where the territory is being changed as a result to a mouse click,
     // and the map units haven't updated yet, so the unit count from the territory won't match the
     // units in count
-    final Territory t = data.getMap().getTerritory(territoryName);
+    final Territory territory = data.getMap().getTerritoryOrThrow(territoryName);
     final UnitType type = data.getUnitTypeList().getUnitTypeOrThrow(unitType);
     final Predicate<Unit> selectedUnits =
         Matches.unitIsOfType(type)
@@ -272,11 +273,11 @@ public class UnitsDrawer extends AbstractDrawable {
                 bombingUnitDamage > 0
                     ? Matches.unitHasTakenSomeBombingUnitDamage()
                     : Matches.unitHasNotTakenAnyBombingUnitDamage());
-    return t.getMatches(selectedUnits);
+    return territory.getMatches(selectedUnits);
   }
 
-  public Territory getTerritory(GameData data) {
-    return data.getMap().getTerritory(territoryName);
+  public @NotNull Territory getTerritory(GameData data) {
+    return data.getMap().getTerritoryOrThrow(territoryName);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
@@ -30,7 +30,7 @@ public class BattleDrawable extends TerritoryDrawable {
       final GameData data,
       final Graphics2D graphics,
       final MapData mapData) {
-    final Territory territory = data.getMap().getTerritory(territoryName);
+    final Territory territory = data.getMap().getTerritoryOrThrow(territoryName);
     final Set<GamePlayer> players = new HashSet<>();
     for (final Unit u : territory.getUnitCollection()) {
       if (!u.getSubmerged()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BlockadeZoneDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BlockadeZoneDrawable.java
@@ -22,7 +22,8 @@ public class BlockadeZoneDrawable extends AbstractDrawable {
       final Graphics2D graphics,
       final MapData mapData) {
     // Find blockade.png from misc folder
-    final Point point = mapData.getBlockadePlacementPoint(data.getMap().getTerritory(location));
+    final Point point =
+        mapData.getBlockadePlacementPoint(data.getMap().getTerritoryOrThrow(location));
     drawImage(graphics, mapData.getBlockadeImage(), point, bounds);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
@@ -36,7 +36,8 @@ public class CapitolMarkerDrawable extends AbstractDrawable {
     // Changed back to use Large flags
     final Image img =
         uiContext.getFlagImageFactory().getLargeFlag(data.getPlayerList().getPlayerId(player));
-    final Point point = mapData.getCapitolMarkerLocation(data.getMap().getTerritory(location));
+    final Point point =
+        mapData.getCapitolMarkerLocation(data.getMap().getTerritoryOrThrow(location));
     graphics.drawImage(img, point.x - bounds.x, point.y - bounds.y, null);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
@@ -35,7 +35,8 @@ public class ConvoyZoneDrawable extends AbstractDrawable {
     } else {
       img = uiContext.getFlagImageFactory().getFlag(data.getPlayerList().getPlayerId(player));
     }
-    final Point point = mapData.getConvoyMarkerLocation(data.getMap().getTerritory(location));
+    final Point point =
+        mapData.getConvoyMarkerLocation(data.getMap().getTerritoryOrThrow(location));
     graphics.drawImage(img, point.x - bounds.x, point.y - bounds.y, null);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
@@ -33,7 +33,7 @@ public class KamikazeZoneDrawable extends AbstractDrawable {
       final Graphics2D graphics,
       final MapData mapData) {
     // Change so only original owner gets the kamikaze zone marker
-    final Territory terr = data.getMap().getTerritory(location);
+    final Territory terr = data.getMap().getTerritoryOrThrow(location);
     GamePlayer owner;
     if (Properties.getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(data.getProperties())) {
       owner = terr.getOwner();
@@ -54,7 +54,8 @@ public class KamikazeZoneDrawable extends AbstractDrawable {
       }
     }
     final Image img = uiContext.getFlagImageFactory().getFadedFlag(owner);
-    final Point point = mapData.getKamikazeMarkerLocation(data.getMap().getTerritory(location));
+    final Point point =
+        mapData.getKamikazeMarkerLocation(data.getMap().getTerritoryOrThrow(location));
     graphics.drawImage(img, point.x - bounds.x, point.y - bounds.y, null);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.ui.screen.drawable;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.Util;
 import java.awt.Color;
@@ -27,8 +26,8 @@ public class SeaZoneOutlineDrawable extends AbstractDrawable {
       final GameData data,
       final Graphics2D graphics,
       final MapData mapData) {
-    final Territory territory = data.getMap().getTerritory(territoryName);
-    final List<Polygon> polys = mapData.getPolygons(territory);
+    final List<Polygon> polys =
+        mapData.getPolygons(data.getMap().getTerritoryOrThrow(territoryName));
     graphics.setColor(Color.BLACK);
     for (final Polygon polygon : polys) {
       if (!polygon.intersects(bounds) && !polygon.contains(bounds)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -35,7 +35,7 @@ public class TerritoryNameDrawable extends AbstractDrawable {
       final GameData data,
       final Graphics2D graphics,
       final MapData mapData) {
-    final Territory territory = data.getMap().getTerritory(territoryName);
+    final Territory territory = data.getMap().getTerritoryOrThrow(territoryName);
     final Optional<TerritoryAttachment> optionalTerritoryAttachment =
         TerritoryAttachment.get(territory);
     final boolean drawFromTopLeft = mapData.drawNamesFromTopLeft();

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/ChangeTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/ChangeTest.java
@@ -43,7 +43,7 @@ class ChangeTest {
   @Test
   void testUnitsAddTerritory() {
     // make sure we know where we are starting
-    final Territory can = gameData.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritoryOrThrow("canada");
     assertEquals(5, can.getUnitCollection().getUnitCount());
     // add some units
     final Change change =
@@ -63,7 +63,7 @@ class ChangeTest {
   @Test
   void testUnitsRemoveTerritory() {
     // make sure we now where we are starting
-    final Territory can = gameData.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritoryOrThrow("canada");
     assertEquals(5, can.getUnitCollection().getUnitCount());
     // remove some units
     final Collection<Unit> units =
@@ -83,7 +83,7 @@ class ChangeTest {
   @Test
   void testSerializeUnitsRemoteTerritory() throws Exception {
     // make sure we now where we are starting
-    final Territory can = gameData.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritoryOrThrow("canada");
     assertEquals(5, can.getUnitCollection().getUnitCount());
     // remove some units
     final Collection<Unit> units =
@@ -138,8 +138,8 @@ class ChangeTest {
 
   @Test
   void testUnitsMove() {
-    final Territory canada = gameData.getMap().getTerritory("canada");
-    final Territory greenland = gameData.getMap().getTerritory("greenland");
+    final Territory canada = gameData.getMap().getTerritoryOrThrow("canada");
+    final Territory greenland = gameData.getMap().getTerritoryOrThrow("greenland");
     assertEquals(5, canada.getUnitCollection().getUnitCount());
     assertEquals(0, greenland.getUnitCollection().getUnitCount());
     final Collection<Unit> units =
@@ -157,8 +157,8 @@ class ChangeTest {
 
   @Test
   void testUnitsMoveSerialization() throws Exception {
-    final Territory canada = gameData.getMap().getTerritory("canada");
-    final Territory greenland = gameData.getMap().getTerritory("greenland");
+    final Territory canada = gameData.getMap().getTerritoryOrThrow("canada");
+    final Territory greenland = gameData.getMap().getTerritoryOrThrow("greenland");
     assertEquals(5, canada.getUnitCollection().getUnitCount());
     assertEquals(0, greenland.getUnitCollection().getUnitCount());
     final Collection<Unit> units =
@@ -217,7 +217,7 @@ class ChangeTest {
   void testChangeOwner() {
     final GamePlayer can = gameData.getPlayerList().getPlayerId("chretian");
     final GamePlayer us = gameData.getPlayerList().getPlayerId("bush");
-    final Territory greenland = gameData.getMap().getTerritory("greenland");
+    final Territory greenland = gameData.getMap().getTerritoryOrThrow("greenland");
     final Change change = ChangeFactory.changeOwner(greenland, us);
     assertEquals(greenland.getOwner(), can);
     gameData.performChange(change);
@@ -230,7 +230,7 @@ class ChangeTest {
   void testChangeOwnerSerialize() throws Exception {
     final GamePlayer can = gameData.getPlayerList().getPlayerId("chretian");
     final GamePlayer us = gameData.getPlayerList().getPlayerId("bush");
-    final Territory greenland = gameData.getMap().getTerritory("greenland");
+    final Territory greenland = gameData.getMap().getTerritoryOrThrow("greenland");
     Change change = ChangeFactory.changeOwner(greenland, us);
     change = serialize(change);
     assertEquals(greenland.getOwner(), can);
@@ -256,7 +256,7 @@ class ChangeTest {
     assertEquals(can, inf1.getOwner());
     assertEquals(us, inf2.getOwner());
     Change change =
-        ChangeFactory.changeOwner(units, can, gameData.getMap().getTerritory("greenland"));
+        ChangeFactory.changeOwner(units, can, gameData.getMap().getTerritoryOrThrow("greenland"));
     gameData.performChange(change);
     assertEquals(can, inf1.getOwner());
     assertEquals(can, inf2.getOwner());
@@ -280,7 +280,7 @@ class ChangeTest {
     assertEquals(can, inf1.getOwner());
     assertEquals(us, inf2.getOwner());
     Change change =
-        ChangeFactory.changeOwner(units, can, gameData.getMap().getTerritory("greenland"));
+        ChangeFactory.changeOwner(units, can, gameData.getMap().getTerritoryOrThrow("greenland"));
     change = serialize(change);
     gameData.performChange(change);
     assertEquals(can, inf1.getOwner());
@@ -321,7 +321,7 @@ class ChangeTest {
     assertTrue(compositeChange.isEmpty());
     compositeChange.add(new CompositeChange());
     assertTrue(compositeChange.isEmpty());
-    final Territory can = gameData.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritoryOrThrow("canada");
     final Collection<Unit> units = List.of();
     compositeChange.add(ChangeFactory.removeUnits(can, units));
     assertFalse(compositeChange.isEmpty());

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/GameMapTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/GameMapTest.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 
 public class GameMapTest {
   private final GameData gameData = TestMapGameData.REVISED.getGameData();
-  private final Territory caucasus = gameData.getMap().getTerritory("Caucasus");
-  private final Territory germany = gameData.getMap().getTerritory("Germany");
-  private final Territory russia = gameData.getMap().getTerritory("Russia");
-  private final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+  private final Territory caucasus = gameData.getMap().getTerritoryOrThrow("Caucasus");
+  private final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+  private final Territory russia = gameData.getMap().getTerritoryOrThrow("Russia");
+  private final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
 
   private int getLandDistance(Territory from, Territory to) {
     return gameData.getMap().getLandDistance(from, to);

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/MapTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/MapTest.java
@@ -110,12 +110,12 @@ class MapTest {
 
   @Test
   void testCantFindByName() {
-    assertNull(map.getTerritory("nowhere"));
+    assertNull(map.getTerritoryOrNull("nowhere"));
   }
 
   @Test
   void testCanFindByName() {
-    assertNotNull(map.getTerritory("aa"));
+    assertNotNull(map.getTerritoryOrNull("aa"));
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/SerializationTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/SerializationTest.java
@@ -57,9 +57,9 @@ class SerializationTest {
 
   @Test
   void testWriteTerritory() throws Exception {
-    final Object orig = gameDataSource.getMap().getTerritory("canada");
+    final Object orig = gameDataSource.getMap().getTerritoryOrThrow("canada");
     final Object read = serialize(orig);
-    final Object local = gameDataSink.getMap().getTerritory("canada");
+    final Object local = gameDataSink.getMap().getTerritoryOrThrow("canada");
     assertThat(local, is(not(sameInstance(read))));
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
@@ -78,7 +78,7 @@ final class GameParserTest {
         (TerritoryAttachment)
             gameData
                 .getMap()
-                .getTerritory("Sparta")
+                .getTerritoryOrThrow("Sparta")
                 .getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
 
     assertThat(spartaTerritoryAttachment.getVictoryCity(), is(1));
@@ -91,7 +91,7 @@ final class GameParserTest {
         (TerritoryAttachment)
             gameData
                 .getMap()
-                .getTerritory("Roma")
+                .getTerritoryOrThrow("Roma")
                 .getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
 
     assertThat(romaTerritoryAttachment.getVictoryCity(), is(0));

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/util/BreadthFirstSearchTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/util/BreadthFirstSearchTest.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 
 public class BreadthFirstSearchTest {
   private final GameData gameData = TestMapGameData.REVISED.getGameData();
-  private final Territory caucasus = gameData.getMap().getTerritory("Caucasus");
-  private final Territory germany = gameData.getMap().getTerritory("Germany");
-  private final Territory russia = gameData.getMap().getTerritory("Russia");
-  private final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+  private final Territory caucasus = gameData.getMap().getTerritoryOrThrow("Caucasus");
+  private final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+  private final Territory russia = gameData.getMap().getTerritoryOrThrow("Russia");
+  private final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
 
   private int getLandDistance(Territory from, Territory to) {
     var territoryFinder = new BreadthFirstSearch.TerritoryFinder(to);

--- a/game-app/game-core/src/test/java/games/strategy/engine/xml/ParserTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/xml/ParserTest.java
@@ -40,16 +40,17 @@ class ParserTest {
 
   @Test
   void testWater() {
-    final Territory atl = gameData.getMap().getTerritory("atlantic");
+    final Territory atl = gameData.getMap().getTerritoryOrThrow("atlantic");
     assertTrue(atl.isWater());
-    final Territory can = gameData.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritoryOrThrow("canada");
     assertFalse(can.isWater());
   }
 
   @Test
   void testTerritoriesConnected() {
     final GameMap map = gameData.getMap();
-    assertEquals(1, map.getDistance(map.getTerritory("canada"), map.getTerritory("us")));
+    assertEquals(
+        1, map.getDistance(map.getTerritoryOrThrow("canada"), map.getTerritoryOrThrow("us")));
   }
 
   @Test
@@ -126,7 +127,10 @@ class ParserTest {
     assertEquals(1, ua.getTransportCost());
     att =
         (TestAttachment)
-            gameData.getMap().getTerritory("us").getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
+            gameData
+                .getMap()
+                .getTerritoryOrThrow("us")
+                .getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
     assertEquals("us of a", att.getValue());
     att =
         (TestAttachment)
@@ -139,11 +143,11 @@ class ParserTest {
 
   @Test
   void testOwnerInitialze() {
-    final Territory can = gameData.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritoryOrThrow("canada");
     assertNotNull(can, "couldnt find country");
     assertNotNull(can.getOwner(), "owner null");
     assertEquals("chretian", can.getOwner().getName());
-    final Territory us = gameData.getMap().getTerritory("us");
+    final Territory us = gameData.getMap().getTerritoryOrThrow("us");
     assertEquals("bush", us.getOwner().getName());
   }
 
@@ -155,7 +159,7 @@ class ParserTest {
 
   @Test
   void testUnitsPlacedInitialized() {
-    final Territory terr = gameData.getMap().getTerritory("canada");
+    final Territory terr = gameData.getMap().getTerritoryOrThrow("canada");
     assertEquals(5, terr.getUnitCollection().getUnitCount());
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
@@ -26,7 +26,7 @@ class AiUtilsTest {
 
   @Test
   void testSortByCost() {
-    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
     final List<Unit> sorted = new ArrayList<>(germany.getUnits());
     sorted.sort(AiUtils.getCostComparator());
     assertEquals(Constants.UNIT_TYPE_INFANTRY, sorted.get(0).getType().getName());

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
@@ -31,54 +31,63 @@ public abstract class AbstractDelegateTestCase extends AbstractClientSettingTest
   protected GamePlayer japanese = GameDataTestUtil.japanese(gameData);
   protected GamePlayer russians = GameDataTestUtil.russians(gameData);
   protected GamePlayer germans = GameDataTestUtil.germans(gameData);
-  protected Territory northSea = gameData.getMap().getTerritory("North Sea Zone");
-  protected Territory blackSea = gameData.getMap().getTerritory("Black Sea Zone");
-  protected Territory uk = gameData.getMap().getTerritory("United Kingdom");
-  protected Territory japan = gameData.getMap().getTerritory("Japan");
-  protected Territory japanSeaZone = gameData.getMap().getTerritory("Japan Sea Zone");
-  protected Territory sfeSeaZone = gameData.getMap().getTerritory("Soviet Far East Sea Zone");
-  protected Territory brazil = gameData.getMap().getTerritory("Brazil");
-  protected Territory westCanada = gameData.getMap().getTerritory("West Canada");
-  protected Territory eastCanada = gameData.getMap().getTerritory("East Canada");
-  protected Territory westCanadaSeaZone = gameData.getMap().getTerritory("West Canada Sea Zone");
-  protected Territory germany = gameData.getMap().getTerritory("Germany");
-  protected Territory syria = gameData.getMap().getTerritory("Syria Jordan");
-  protected Territory manchuria = gameData.getMap().getTerritory("Manchuria");
-  protected Territory egypt = gameData.getMap().getTerritory("Anglo Sudan Egypt");
-  protected Territory congo = gameData.getMap().getTerritory("Congo");
-  protected Territory congoSeaZone = gameData.getMap().getTerritory("Congo Sea Zone");
-  protected Territory northAtlantic = gameData.getMap().getTerritory("North Atlantic Sea Zone");
-  protected Territory westAfricaSea = gameData.getMap().getTerritory("West Africa Sea Zone");
-  protected Territory kenya = gameData.getMap().getTerritory("Kenya-Rhodesia");
-  protected Territory eastAfrica = gameData.getMap().getTerritory("Italian East Africa");
-  protected Territory libya = gameData.getMap().getTerritory("Libya");
-  protected Territory algeria = gameData.getMap().getTerritory("Algeria");
-  protected Territory equatorialAfrica = gameData.getMap().getTerritory("French Equatorial Africa");
-  protected Territory redSea = gameData.getMap().getTerritory("Red Sea Zone");
-  protected Territory westAfrica = gameData.getMap().getTerritory("French West Africa");
-  protected Territory angola = gameData.getMap().getTerritory("Angola");
-  protected Territory angolaSeaZone = gameData.getMap().getTerritory("Angola Sea Zone");
-  protected Territory eastCompass = gameData.getMap().getTerritory("East Compass Sea Zone");
-  protected Territory westCompass = gameData.getMap().getTerritory("West Compass Sea Zone");
-  protected Territory mozambiqueSeaZone = gameData.getMap().getTerritory("Mozambique Sea Zone");
+  protected Territory northSea = gameData.getMap().getTerritoryOrThrow("North Sea Zone");
+  protected Territory blackSea = gameData.getMap().getTerritoryOrThrow("Black Sea Zone");
+  protected Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
+  protected Territory japan = gameData.getMap().getTerritoryOrThrow("Japan");
+  protected Territory japanSeaZone = gameData.getMap().getTerritoryOrThrow("Japan Sea Zone");
+  protected Territory sfeSeaZone =
+      gameData.getMap().getTerritoryOrThrow("Soviet Far East Sea Zone");
+  protected Territory brazil = gameData.getMap().getTerritoryOrThrow("Brazil");
+  protected Territory westCanada = gameData.getMap().getTerritoryOrThrow("West Canada");
+  protected Territory eastCanada = gameData.getMap().getTerritoryOrThrow("East Canada");
+  protected Territory westCanadaSeaZone =
+      gameData.getMap().getTerritoryOrThrow("West Canada Sea Zone");
+  protected Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+  protected Territory syria = gameData.getMap().getTerritoryOrThrow("Syria Jordan");
+  protected Territory manchuria = gameData.getMap().getTerritoryOrThrow("Manchuria");
+  protected Territory egypt = gameData.getMap().getTerritoryOrThrow("Anglo Sudan Egypt");
+  protected Territory congo = gameData.getMap().getTerritoryOrThrow("Congo");
+  protected Territory congoSeaZone = gameData.getMap().getTerritoryOrThrow("Congo Sea Zone");
+  protected Territory northAtlantic =
+      gameData.getMap().getTerritoryOrThrow("North Atlantic Sea Zone");
+  protected Territory westAfricaSea = gameData.getMap().getTerritoryOrThrow("West Africa Sea Zone");
+  protected Territory kenya = gameData.getMap().getTerritoryOrThrow("Kenya-Rhodesia");
+  protected Territory eastAfrica = gameData.getMap().getTerritoryOrThrow("Italian East Africa");
+  protected Territory libya = gameData.getMap().getTerritoryOrThrow("Libya");
+  protected Territory algeria = gameData.getMap().getTerritoryOrThrow("Algeria");
+  protected Territory equatorialAfrica =
+      gameData.getMap().getTerritoryOrThrow("French Equatorial Africa");
+  protected Territory redSea = gameData.getMap().getTerritoryOrThrow("Red Sea Zone");
+  protected Territory westAfrica = gameData.getMap().getTerritoryOrThrow("French West Africa");
+  protected Territory angola = gameData.getMap().getTerritoryOrThrow("Angola");
+  protected Territory angolaSeaZone = gameData.getMap().getTerritoryOrThrow("Angola Sea Zone");
+  protected Territory eastCompass = gameData.getMap().getTerritoryOrThrow("East Compass Sea Zone");
+  protected Territory westCompass = gameData.getMap().getTerritoryOrThrow("West Compass Sea Zone");
+  protected Territory mozambiqueSeaZone =
+      gameData.getMap().getTerritoryOrThrow("Mozambique Sea Zone");
   protected Territory eastMediteranean =
-      gameData.getMap().getTerritory("East Mediteranean Sea Zone");
-  protected Territory indianOcean = gameData.getMap().getTerritory("Indian Ocean Sea Zone");
-  protected Territory westAfricaSeaZone = gameData.getMap().getTerritory("West Africa Sea Zone");
-  protected Territory southAfrica = gameData.getMap().getTerritory("South Africa");
-  protected Territory saudiArabia = gameData.getMap().getTerritory("Saudi Arabia");
-  protected Territory india = gameData.getMap().getTerritory("India");
-  protected Territory southAtlantic = gameData.getMap().getTerritory("South Atlantic Sea Zone");
-  protected Territory antarticSea = gameData.getMap().getTerritory("Antartic Sea Zone");
-  protected Territory southAfricaSeaZone = gameData.getMap().getTerritory("South Africa Sea Zone");
-  protected Territory southBrazilSeaZone = gameData.getMap().getTerritory("South Brazil Sea Zone");
-  protected Territory russia = gameData.getMap().getTerritory("Russia");
-  protected Territory spain = gameData.getMap().getTerritory("Spain");
-  protected Territory gibraltar = gameData.getMap().getTerritory("Gibraltar");
-  protected Territory balticSeaZone = gameData.getMap().getTerritory("Baltic Sea Zone");
-  protected Territory karelia = gameData.getMap().getTerritory("Karelia S.S.R.");
-  protected Territory westEurope = gameData.getMap().getTerritory("West Europe");
-  protected Territory finlandNorway = gameData.getMap().getTerritory("Finland Norway");
+      gameData.getMap().getTerritoryOrThrow("East Mediteranean Sea Zone");
+  protected Territory indianOcean = gameData.getMap().getTerritoryOrThrow("Indian Ocean Sea Zone");
+  protected Territory westAfricaSeaZone =
+      gameData.getMap().getTerritoryOrThrow("West Africa Sea Zone");
+  protected Territory southAfrica = gameData.getMap().getTerritoryOrThrow("South Africa");
+  protected Territory saudiArabia = gameData.getMap().getTerritoryOrThrow("Saudi Arabia");
+  protected Territory india = gameData.getMap().getTerritoryOrThrow("India");
+  protected Territory southAtlantic =
+      gameData.getMap().getTerritoryOrThrow("South Atlantic Sea Zone");
+  protected Territory antarticSea = gameData.getMap().getTerritoryOrThrow("Antartic Sea Zone");
+  protected Territory southAfricaSeaZone =
+      gameData.getMap().getTerritoryOrThrow("South Africa Sea Zone");
+  protected Territory southBrazilSeaZone =
+      gameData.getMap().getTerritoryOrThrow("South Brazil Sea Zone");
+  protected Territory russia = gameData.getMap().getTerritoryOrThrow("Russia");
+  protected Territory spain = gameData.getMap().getTerritoryOrThrow("Spain");
+  protected Territory gibraltar = gameData.getMap().getTerritoryOrThrow("Gibraltar");
+  protected Territory balticSeaZone = gameData.getMap().getTerritoryOrThrow("Baltic Sea Zone");
+  protected Territory karelia = gameData.getMap().getTerritoryOrThrow("Karelia S.S.R.");
+  protected Territory westEurope = gameData.getMap().getTerritoryOrThrow("West Europe");
+  protected Territory finlandNorway = gameData.getMap().getTerritoryOrThrow("Finland Norway");
   protected UnitType armour = GameDataTestUtil.armour(gameData);
   protected UnitType infantry = GameDataTestUtil.infantry(gameData);
   protected UnitType transport = GameDataTestUtil.transport(gameData);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -54,7 +54,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
   void testCantLandEnemyTerritory() {
     final GamePlayer player = americansPlayer;
     final IDelegateBridge bridge = newDelegateBridge(player);
-    final Territory balkans = gameData.getMap().getTerritory("Balkans");
+    final Territory balkans = gameData.getMap().getTerritoryOrThrow("Balkans");
     final Change addAir = ChangeFactory.addUnits(balkans, fighterType.create(2, player));
     gameData.performChange(addAir);
     final AirThatCantLandUtil airThatCantLandUtil = new AirThatCantLandUtil(bridge);
@@ -71,7 +71,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
   void testCantLandWater() {
     final GamePlayer player = americansPlayer;
     final IDelegateBridge bridge = newDelegateBridge(player);
-    final Territory sz55 = gameData.getMap().getTerritory("55 Sea Zone");
+    final Territory sz55 = gameData.getMap().getTerritoryOrThrow("55 Sea Zone");
     final Change addAir = ChangeFactory.addUnits(sz55, fighterType.create(2, player));
     gameData.performChange(addAir);
     final AirThatCantLandUtil airThatCantLandUtil = new AirThatCantLandUtil(bridge);
@@ -87,7 +87,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
   void testSpareNextToFactory() {
     final GamePlayer player = americansPlayer;
     final IDelegateBridge bridge = newDelegateBridge(player);
-    final Territory sz55 = gameData.getMap().getTerritory("55 Sea Zone");
+    final Territory sz55 = gameData.getMap().getTerritoryOrThrow("55 Sea Zone");
     final Change addAir = ChangeFactory.addUnits(sz55, fighterType.create(2, player));
     gameData.performChange(addAir);
     final AirThatCantLandUtil airThatCantLandUtil = new AirThatCantLandUtil(bridge);
@@ -100,7 +100,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     // 1 carrier in the region, but three fighters, make sure we cant land
     final GamePlayer player = americansPlayer;
     final IDelegateBridge bridge = newDelegateBridge(player);
-    final Territory sz52 = gameData.getMap().getTerritory("52 Sea Zone");
+    final Territory sz52 = gameData.getMap().getTerritoryOrThrow("52 Sea Zone");
     final Change addAir = ChangeFactory.addUnits(sz52, fighterType.create(2, player));
     gameData.performChange(addAir);
     final AirThatCantLandUtil airThatCantLandUtil = new AirThatCantLandUtil(bridge);
@@ -125,9 +125,9 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     initDel.start();
     initDel.end();
     // Get necessary sea zones and unit types for this test
-    final Territory sz44 = gameData.getMap().getTerritory("44 Sea Zone");
-    final Territory sz45 = gameData.getMap().getTerritory("45 Sea Zone");
-    final Territory sz52 = gameData.getMap().getTerritory("52 Sea Zone");
+    final Territory sz44 = gameData.getMap().getTerritoryOrThrow("44 Sea Zone");
+    final Territory sz45 = gameData.getMap().getTerritoryOrThrow("45 Sea Zone");
+    final Territory sz52 = gameData.getMap().getTerritoryOrThrow("52 Sea Zone");
     final UnitType subType = GameDataTestUtil.submarine(gameData);
     final UnitType carrierType = GameDataTestUtil.carrier(gameData);
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
@@ -174,10 +174,10 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     initDel.start();
     initDel.end();
     // Get necessary sea zones and unit types for this test
-    final Territory sz43 = gameData.getMap().getTerritory("43 Sea Zone");
-    final Territory sz44 = gameData.getMap().getTerritory("44 Sea Zone");
-    final Territory sz45 = gameData.getMap().getTerritory("45 Sea Zone");
-    final Territory sz52 = gameData.getMap().getTerritory("52 Sea Zone");
+    final Territory sz43 = gameData.getMap().getTerritoryOrThrow("43 Sea Zone");
+    final Territory sz44 = gameData.getMap().getTerritoryOrThrow("44 Sea Zone");
+    final Territory sz45 = gameData.getMap().getTerritoryOrThrow("45 Sea Zone");
+    final Territory sz52 = gameData.getMap().getTerritoryOrThrow("52 Sea Zone");
     final UnitType subType = GameDataTestUtil.submarine(gameData);
     final UnitType carrierType = GameDataTestUtil.carrier(gameData);
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
@@ -224,9 +224,9 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     initDel.start();
     initDel.end();
     // Get necessary sea zones and unit types for this test
-    final Territory sz9 = gameData.getMap().getTerritory("9 Sea Zone");
-    final Territory eastCanada = gameData.getMap().getTerritory("Eastern Canada");
-    final Territory sz11 = gameData.getMap().getTerritory("11 Sea Zone");
+    final Territory sz9 = gameData.getMap().getTerritoryOrThrow("9 Sea Zone");
+    final Territory eastCanada = gameData.getMap().getTerritoryOrThrow("Eastern Canada");
+    final Territory sz11 = gameData.getMap().getTerritoryOrThrow("11 Sea Zone");
     final UnitType subType = GameDataTestUtil.submarine(gameData);
     final UnitType carrierType = GameDataTestUtil.carrier(gameData);
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
@@ -263,9 +263,9 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     final GamePlayer americans = GameDataTestUtil.americans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(japanese);
     // Get necessary sea zones and unit types for this test
-    final Territory sz9 = gameData.getMap().getTerritory("9 Sea Zone");
-    final Territory eastCanada = gameData.getMap().getTerritory("Eastern Canada");
-    final Territory sz11 = gameData.getMap().getTerritory("11 Sea Zone");
+    final Territory sz9 = gameData.getMap().getTerritoryOrThrow("9 Sea Zone");
+    final Territory eastCanada = gameData.getMap().getTerritoryOrThrow("Eastern Canada");
+    final Territory sz11 = gameData.getMap().getTerritoryOrThrow("11 Sea Zone");
     final UnitType subType = GameDataTestUtil.submarine(gameData);
     final UnitType carrierType = GameDataTestUtil.carrier(gameData);
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -39,7 +39,7 @@ class DiceRollTest {
 
   @Test
   void testSimple() {
-    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritoryOrThrow("West Russia");
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
@@ -128,7 +128,7 @@ class DiceRollTest {
   @Test
   void testSimpleLowLuck() {
     GameDataTestUtil.makeGameLowLuck(gameData);
-    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritoryOrThrow("West Russia");
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
@@ -216,7 +216,7 @@ class DiceRollTest {
 
   @Test
   void testArtillerySupport() {
-    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritoryOrThrow("West Russia");
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
@@ -247,7 +247,7 @@ class DiceRollTest {
 
   @Test
   void testVariableArtillerySupport() {
-    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritoryOrThrow("West Russia");
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     // Add 1 artillery
@@ -286,7 +286,7 @@ class DiceRollTest {
   @Test
   void testLowLuck() {
     GameDataTestUtil.makeGameLowLuck(gameData);
-    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritoryOrThrow("West Russia");
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
@@ -315,7 +315,7 @@ class DiceRollTest {
   @Test
   void testMarineAttackPlus1() {
     gameData = TestMapGameData.IRON_BLITZ.getGameData();
-    final Territory algeria = gameData.getMap().getTerritory("Algeria");
+    final Territory algeria = gameData.getMap().getTerritoryOrThrow("Algeria");
     final GamePlayer americans = GameDataTestUtil.americans(gameData);
     final UnitType marine =
         gameData.getUnitTypeList().getUnitTypeOrThrow(Constants.UNIT_TYPE_MARINE);
@@ -356,7 +356,7 @@ class DiceRollTest {
   void testMarineAttackPlus1LowLuck() {
     gameData = TestMapGameData.IRON_BLITZ.getGameData();
     GameDataTestUtil.makeGameLowLuck(gameData);
-    final Territory algeria = gameData.getMap().getTerritory("Algeria");
+    final Territory algeria = gameData.getMap().getTerritoryOrThrow("Algeria");
     final GamePlayer americans = GameDataTestUtil.americans(gameData);
     final UnitType marine =
         gameData.getUnitTypeList().getUnitTypeOrThrow(Constants.UNIT_TYPE_MARINE);
@@ -396,7 +396,7 @@ class DiceRollTest {
   @Test
   void testMarineAttackNormalIfNotAmphibious() {
     gameData = TestMapGameData.IRON_BLITZ.getGameData();
-    final Territory algeria = gameData.getMap().getTerritory("Algeria");
+    final Territory algeria = gameData.getMap().getTerritoryOrThrow("Algeria");
     final GamePlayer americans = GameDataTestUtil.americans(gameData);
     final UnitType marine =
         gameData.getUnitTypeList().getUnitTypeOrThrow(Constants.UNIT_TYPE_MARINE);
@@ -435,7 +435,7 @@ class DiceRollTest {
 
   @Test
   void testAa() {
-    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritoryOrThrow("West Russia");
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final UnitType aaGunType = GameDataTestUtil.aaGun(gameData);
@@ -479,7 +479,7 @@ class DiceRollTest {
   @Test
   void testAaLowLuck() {
     GameDataTestUtil.makeGameLowLuck(gameData);
-    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritoryOrThrow("West Russia");
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final UnitType aaGunType = GameDataTestUtil.aaGun(gameData);
@@ -555,7 +555,7 @@ class DiceRollTest {
   @Test
   void testAaLowLuckDifferentMovement() {
     GameDataTestUtil.makeGameLowLuck(gameData);
-    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritoryOrThrow("West Russia");
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final UnitType aaGunType = GameDataTestUtil.aaGun(gameData);
@@ -591,7 +591,7 @@ class DiceRollTest {
   void testAaLowLuckWithRadar() {
     gameData = TestMapGameData.WW2V3_1941.getGameData();
     GameDataTestUtil.makeGameLowLuck(gameData);
-    final Territory finnland = gameData.getMap().getTerritory("Finland");
+    final Territory finnland = gameData.getMap().getTerritoryOrThrow("Finland");
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final UnitType aaGunType = GameDataTestUtil.aaGun(gameData);
@@ -840,11 +840,11 @@ class DiceRollTest {
     final List<Unit> bombers =
         gameData
             .getMap()
-            .getTerritory("United Kingdom")
+            .getTerritoryOrThrow("United Kingdom")
             .getUnitCollection()
             .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(2, 3, 2));
-    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
     final DiceRoll dice =
         RollDiceFactory.rollBattleDice(
             bombers,
@@ -880,11 +880,11 @@ class DiceRollTest {
     final List<Unit> bombers =
         gameData
             .getMap()
-            .getTerritory("United Kingdom")
+            .getTerritoryOrThrow("United Kingdom")
             .getUnitCollection()
             .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(0));
-    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
     final DiceRoll dice =
         RollDiceFactory.rollBattleDice(
             bombers,
@@ -915,11 +915,11 @@ class DiceRollTest {
     final List<Unit> bombers =
         gameData
             .getMap()
-            .getTerritory("United Kingdom")
+            .getTerritoryOrThrow("United Kingdom")
             .getUnitCollection()
             .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(0));
-    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
     final DiceRoll dice =
         RollDiceFactory.rollBattleDice(
             bombers,
@@ -956,11 +956,11 @@ class DiceRollTest {
     final List<Unit> bombers =
         gameData
             .getMap()
-            .getTerritory("United Kingdom")
+            .getTerritoryOrThrow("United Kingdom")
             .getUnitCollection()
             .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(2, 3));
-    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
     final DiceRoll dice =
         RollDiceFactory.rollBattleDice(
             bombers,
@@ -998,11 +998,11 @@ class DiceRollTest {
     final List<Unit> bombers =
         gameData
             .getMap()
-            .getTerritory("United Kingdom")
+            .getTerritoryOrThrow("United Kingdom")
             .getUnitCollection()
             .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(3, 2));
-    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
     final DiceRoll dice =
         RollDiceFactory.rollBattleDice(
             bombers,
@@ -1039,11 +1039,11 @@ class DiceRollTest {
     final List<Unit> bombers =
         gameData
             .getMap()
-            .getTerritory("United Kingdom")
+            .getTerritoryOrThrow("United Kingdom")
             .getUnitCollection()
             .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(0, 1));
-    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
     final DiceRoll dice =
         RollDiceFactory.rollBattleDice(
             bombers,
@@ -1074,7 +1074,7 @@ class DiceRollTest {
     final Unit bomber =
         gameData
             .getMap()
-            .getTerritory("United Kingdom")
+            .getTerritoryOrThrow("United Kingdom")
             .getMatches(Matches.unitIsStrategicBomber())
             .get(0);
     // default 1 roll

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -146,7 +146,7 @@ public final class GameDataTestUtil {
    * @return A Territory matching the given name if present, otherwise throwing an Exception.
    */
   public static Territory territory(final String name, final GameState data) {
-    return checkNotNull(data.getMap().getTerritory(name), "No territory: " + name);
+    return checkNotNull(data.getMap().getTerritoryOrThrow(name), "No territory: " + name);
   }
 
   /** Returns an armor UnitType object for the specified GameData object. */

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -50,8 +50,8 @@ class LhtrTest extends AbstractClientSettingTestCase {
     advanceToStep(bridge, "germanNonCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
-    final Territory baltic = gameData.getMap().getTerritory("5 Sea Zone");
-    final Territory easternEurope = gameData.getMap().getTerritory("Eastern Europe");
+    final Territory baltic = gameData.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final Territory easternEurope = gameData.getMap().getTerritoryOrThrow("Eastern Europe");
     final UnitType carrirType = GameDataTestUtil.carrier(gameData);
     // move a fighter to the baltic
     final Route route = new Route(easternEurope, baltic);
@@ -77,8 +77,8 @@ class LhtrTest extends AbstractClientSettingTestCase {
     advanceToStep(bridge, "germanNonCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
-    final Territory baltic = gameData.getMap().getTerritory("5 Sea Zone");
-    final Territory easternEurope = gameData.getMap().getTerritory("Eastern Europe");
+    final Territory baltic = gameData.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final Territory easternEurope = gameData.getMap().getTerritoryOrThrow("Eastern Europe");
     // move a fighter to the baltic
     final Route route = new Route(easternEurope, baltic);
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
@@ -103,9 +103,9 @@ class LhtrTest extends AbstractClientSettingTestCase {
     // move 1 fighter over the aa gun in caucus
     final Route route =
         new Route(
-            gameData.getMap().getTerritory("Ukraine S.S.R."),
-            gameData.getMap().getTerritory("Caucasus"),
-            gameData.getMap().getTerritory("West Russia"));
+            gameData.getMap().getTerritoryOrThrow("Ukraine S.S.R."),
+            gameData.getMap().getTerritoryOrThrow("Caucasus"),
+            gameData.getMap().getTerritoryOrThrow("West Russia"));
     final List<Unit> fighter = route.getStart().getUnitCollection().getMatches(Matches.unitIsAir());
     delegate.move(fighter, route);
     // if we try to move aa, then the game will ask us if we want to move
@@ -137,8 +137,8 @@ class LhtrTest extends AbstractClientSettingTestCase {
 
   @Test
   void testLhtrBombingRaid() {
-    final Territory germany = gameData.getMap().getTerritory("Germany");
-    final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final GamePlayer british = GameDataTestUtil.british(gameData);
     final BattleTracker tracker = new BattleTracker();
@@ -175,8 +175,8 @@ class LhtrTest extends AbstractClientSettingTestCase {
 
   @Test
   void testLhtrBombingRaid2Bombers() {
-    final Territory germany = gameData.getMap().getTerritory("Germany");
-    final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final GamePlayer british = GameDataTestUtil.british(gameData);
     // add a unit

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -109,7 +109,7 @@ final class MatchesTest {
       enemyPlayer = GameDataTestUtil.russians(gameData);
       assertThat(player.isAtWar(enemyPlayer), is(true));
 
-      territory = gameData.getMap().getTerritory("Germany");
+      territory = gameData.getMap().getTerritoryOrThrow("Germany");
       territory.setOwner(player);
       territory.getUnitCollection().clear();
     }
@@ -181,11 +181,11 @@ final class MatchesTest {
 
       player = GameDataTestUtil.germans(gameData);
 
-      landTerritory = gameData.getMap().getTerritory("Germany");
+      landTerritory = gameData.getMap().getTerritoryOrThrow("Germany");
       landTerritory.setOwner(player);
       assertTrue(TerritoryAttachment.get(landTerritory).isPresent());
 
-      seaTerritory = gameData.getMap().getTerritory("Baltic Sea Zone");
+      seaTerritory = gameData.getMap().getTerritoryOrThrow("Baltic Sea Zone");
       seaTerritory.setOwner(player);
       assertTrue(TerritoryAttachment.get(seaTerritory).isEmpty());
       TerritoryAttachment.add(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -787,7 +787,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     route = new Route(congoSeaZone, westAfricaSea, northAtlantic);
     Collection<Unit> units =
         CollectionUtils.getMatches(
-            gameData.getMap().getTerritory(congoSeaZone.toString()).getUnits(),
+            gameData.getMap().getTerritoryOrThrow(congoSeaZone.toString()).getUnits(),
             Matches.unitIsCarrier());
     results = delegate.move(units, route);
     assertValid(results);
@@ -795,7 +795,8 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     route = new Route(redSea, eastMediteranean, blackSea);
     units =
         CollectionUtils.getMatches(
-            gameData.getMap().getTerritory(redSea.toString()).getUnits(), Matches.unitIsCarrier());
+            gameData.getMap().getTerritoryOrThrow(redSea.toString()).getUnits(),
+            Matches.unitIsCarrier());
     results = delegate.move(units, route);
     assertValid(results);
     // make sure the place cant use it to land

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
@@ -21,11 +21,11 @@ class PactOfSteel2Test {
 
   @Test
   void testDirectOwnershipTerritories() {
-    final Territory norway = gameData.getMap().getTerritory("Norway");
-    final Territory easternEurope = gameData.getMap().getTerritory("Eastern Europe");
-    final Territory eastBalkans = gameData.getMap().getTerritory("East Balkans");
-    final Territory ukraineSsr = gameData.getMap().getTerritory("Ukraine S.S.R.");
-    final Territory belorussia = gameData.getMap().getTerritory("Belorussia");
+    final Territory norway = gameData.getMap().getTerritoryOrThrow("Norway");
+    final Territory easternEurope = gameData.getMap().getTerritoryOrThrow("Eastern Europe");
+    final Territory eastBalkans = gameData.getMap().getTerritoryOrThrow("East Balkans");
+    final Territory ukraineSsr = gameData.getMap().getTerritoryOrThrow("Ukraine S.S.R.");
+    final Territory belorussia = gameData.getMap().getTerritoryOrThrow("Belorussia");
     final GamePlayer british = GameDataTestUtil.british(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final GamePlayer russians = GameDataTestUtil.russians(gameData);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -132,9 +132,9 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testMoveBadRoute() {
     final GamePlayer british = british(gameData);
-    final Territory sz1 = gameData.getMap().getTerritory("1 Sea Zone");
-    final Territory sz11 = gameData.getMap().getTerritory("11 Sea Zone");
-    final Territory sz9 = gameData.getMap().getTerritory("9 Sea Zone");
+    final Territory sz1 = gameData.getMap().getTerritoryOrThrow("1 Sea Zone");
+    final Territory sz11 = gameData.getMap().getTerritoryOrThrow("11 Sea Zone");
+    final Territory sz9 = gameData.getMap().getTerritoryOrThrow("9 Sea Zone");
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -175,9 +175,9 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testMoveThroughSubmergedSubs() {
     final GamePlayer british = british(gameData);
-    final Territory sz1 = gameData.getMap().getTerritory("1 Sea Zone");
-    final Territory sz7 = gameData.getMap().getTerritory("7 Sea Zone");
-    final Territory sz8 = gameData.getMap().getTerritory("8 Sea Zone");
+    final Territory sz1 = gameData.getMap().getTerritoryOrThrow("1 Sea Zone");
+    final Territory sz7 = gameData.getMap().getTerritoryOrThrow("7 Sea Zone");
+    final Territory sz8 = gameData.getMap().getTerritoryOrThrow("8 Sea Zone");
     final Unit sub = sz8.getUnitCollection().iterator().next();
     sub.setSubmerged(true);
     // now move to attack it
@@ -207,7 +207,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     initDel.start();
     initDel.end();
     // make sinkian japanese owned, put one infantry in it
-    final Territory sinkiang = gameData.getMap().getTerritory("Sinkiang");
+    final Territory sinkiang = gameData.getMap().getTerritoryOrThrow("Sinkiang");
     gameData.performChange(ChangeFactory.removeUnits(sinkiang, sinkiang.getUnits()));
     final GamePlayer japanese = japanese(gameData);
     sinkiang.setOwner(japanese);
@@ -218,7 +218,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final Territory novo = gameData.getMap().getTerritory("Novosibirsk");
+    final Territory novo = gameData.getMap().getTerritoryOrThrow("Novosibirsk");
     move(novo.getUnits(), new Route(novo, sinkiang));
     moveDelegate.end();
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegate("battle");
@@ -231,7 +231,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final Territory russia = gameData.getMap().getTerritory("Russia");
+    final Territory russia = gameData.getMap().getTerritoryOrThrow("Russia");
     // move two tanks from russia, then undo
     final Route r = new Route(russia, novo, sinkiang);
     move(russia.getUnitCollection().getMatches(Matches.unitCanBlitz()), r);
@@ -253,9 +253,9 @@ class RevisedTest extends AbstractClientSettingTestCase {
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
     // set up battle
-    final Territory germany = gameData.getMap().getTerritory("Germany");
-    final Territory karelia = gameData.getMap().getTerritory("Karelia S.S.R.");
-    final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    final Territory karelia = gameData.getMap().getTerritoryOrThrow("Karelia S.S.R.");
+    final Territory sz5 = gameData.getMap().getTerritoryOrThrow("5 Sea Zone");
     gameData.performChange(ChangeFactory.removeUnits(sz5, sz5.getUnits()));
     final UnitType infantryType = infantry(gameData);
     final UnitType subType = submarine(gameData);
@@ -400,8 +400,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
 
   @Test
   void testTransportAttack() {
-    final Territory sz14 = gameData.getMap().getTerritory("14 Sea Zone");
-    final Territory sz13 = gameData.getMap().getTerritory("13 Sea Zone");
+    final Territory sz14 = gameData.getMap().getTerritoryOrThrow("14 Sea Zone");
+    final Territory sz13 = gameData.getMap().getTerritoryOrThrow("13 Sea Zone");
     final GamePlayer germans = germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
     final IDelegateBridge bridge = newDelegateBridge(germans);
@@ -416,8 +416,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
 
   @Test
   void testLoadUndo() {
-    final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
+    final Territory sz5 = gameData.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final Territory eastEurope = gameData.getMap().getTerritoryOrThrow("Eastern Europe");
     final UnitType infantryType = infantry(gameData);
     final GamePlayer germans = germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
@@ -450,9 +450,9 @@ class RevisedTest extends AbstractClientSettingTestCase {
 
   @Test
   void testLoadDependencies() {
-    final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
-    final Territory norway = gameData.getMap().getTerritory("Norway");
+    final Territory sz5 = gameData.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final Territory eastEurope = gameData.getMap().getTerritoryOrThrow("Eastern Europe");
+    final Territory norway = gameData.getMap().getTerritoryOrThrow("Norway");
     final UnitType infantryType = infantry(gameData);
     final GamePlayer germans = germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
@@ -497,8 +497,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
 
   @Test
   void testLoadUndoInWrongOrder() {
-    final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
+    final Territory sz5 = gameData.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final Territory eastEurope = gameData.getMap().getTerritoryOrThrow("Eastern Europe");
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
@@ -539,12 +539,12 @@ class RevisedTest extends AbstractClientSettingTestCase {
   void testLoadUnloadAlliedTransport() {
     // you cant load and unload an allied transport the same turn
     final UnitType infantryType = infantry(gameData);
-    final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
+    final Territory eastEurope = gameData.getMap().getTerritoryOrThrow("Eastern Europe");
     // add japanese infantry to eastern europe
     final GamePlayer japanese = japanese(gameData);
     final Change change = ChangeFactory.addUnits(eastEurope, infantryType.create(1, japanese));
     gameData.performChange(change);
-    final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
+    final Territory sz5 = gameData.getMap().getTerritoryOrThrow("5 Sea Zone");
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
     final IDelegateBridge bridge = newDelegateBridge(japanese);
     advanceToStep(bridge, "CombatMove");
@@ -573,8 +573,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testUnloadMultipleTerritories() {
     // in revised a transport may only unload to 1 territory.
-    final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
+    final Territory sz5 = gameData.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final Territory eastEurope = gameData.getMap().getTerritoryOrThrow("Eastern Europe");
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
@@ -594,7 +594,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
                 infantry, eeToSz5, Map.of(infantry.get(0), transport, infantry.get(1), transport)));
     assertValid(error);
     // unload one infantry to Norway
-    final Territory norway = gameData.getMap().getTerritory("Norway");
+    final Territory norway = gameData.getMap().getTerritoryOrThrow("Norway");
     final Route sz5ToNorway = new Route(sz5, norway);
     error = moveDelegate.move(infantry.subList(0, 1), sz5ToNorway);
     assertValid(error);
@@ -624,8 +624,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testUnloadInPreviousPhase() {
     // a transport may not unload in both combat and non combat
-    final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
+    final Territory sz5 = gameData.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final Territory eastEurope = gameData.getMap().getTerritoryOrThrow("Eastern Europe");
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
@@ -645,7 +645,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
                 infantry, eeToSz5, Map.of(infantry.get(0), transport, infantry.get(1), transport)));
     assertValid(error);
     // unload one infantry to Norway
-    final Territory norway = gameData.getMap().getTerritory("Norway");
+    final Territory norway = gameData.getMap().getTerritoryOrThrow("Norway");
     final Route sz5ToNorway = new Route(sz5, norway);
     error = moveDelegate.move(infantry.subList(0, 1), sz5ToNorway);
     assertValid(error);
@@ -718,8 +718,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
 
   @Test
   void testMoveSubAwayFromSubmergedSubsInBattleZone() {
-    final Territory sz45 = gameData.getMap().getTerritory("45 Sea Zone");
-    final Territory sz50 = gameData.getMap().getTerritory("50 Sea Zone");
+    final Territory sz45 = gameData.getMap().getTerritoryOrThrow("45 Sea Zone");
+    final Territory sz50 = gameData.getMap().getTerritoryOrThrow("50 Sea Zone");
     final GamePlayer british = british(gameData);
     final GamePlayer japanese = japanese(gameData);
     // put 1 british sub in sz 45, this simulates a submerged enemy sub
@@ -857,8 +857,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
 
   @Test
   void testStratBombCasualties() {
-    final Territory germany = gameData.getMap().getTerritory("Germany");
-    final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
     final GamePlayer germans = germans(gameData);
     final GamePlayer british = british(gameData);
     final BattleTracker tracker = new BattleTracker();
@@ -890,8 +890,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testStratBombCasualtiesLowLuck() {
     makeGameLowLuck(gameData);
-    final Territory germany = gameData.getMap().getTerritory("Germany");
-    final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final GamePlayer british = GameDataTestUtil.british(gameData);
     final BattleTracker tracker = new BattleTracker();
@@ -931,8 +931,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testStratBombCasualtiesLowLuckManyBombers() {
     makeGameLowLuck(gameData);
-    final Territory germany = gameData.getMap().getTerritory("Germany");
-    final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final GamePlayer british = GameDataTestUtil.british(gameData);
     final BattleTracker tracker = new BattleTracker();
@@ -964,8 +964,8 @@ class RevisedTest extends AbstractClientSettingTestCase {
 
   @Test
   void testStratBombRaidWithHeavyBombers() {
-    final Territory germany = gameData.getMap().getTerritory("Germany");
-    final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final GamePlayer british = GameDataTestUtil.british(gameData);
     final BattleTracker tracker = new BattleTracker();

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -37,8 +37,8 @@ class WW2V3Year42Test {
 
   @Test
   void testTransportAttack() {
-    final Territory sz13 = gameData.getMap().getTerritory("13 Sea Zone");
-    final Territory sz12 = gameData.getMap().getTerritory("12 Sea Zone");
+    final Territory sz13 = gameData.getMap().getTerritoryOrThrow("13 Sea Zone");
+    final Territory sz12 = gameData.getMap().getTerritoryOrThrow("12 Sea Zone");
     final GamePlayer germans = germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");

--- a/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelectorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelectorTest.java
@@ -50,12 +50,12 @@ public class AttackerAndDefenderSelectorTest {
     private final GamePlayer british = british(gameData);
     private final GamePlayer japanese = japanese(gameData);
     private final GamePlayer americans = americans(gameData);
-    private final Territory germany = gameData.getMap().getTerritory("Germany");
-    private final Territory japan = gameData.getMap().getTerritory("Japan");
-    private final Territory unitedKingdom = gameData.getMap().getTerritory("United Kingdom");
-    private final Territory seaZone32 = gameData.getMap().getTerritory("32 Sea Zone");
-    private final Territory kenya = gameData.getMap().getTerritory("Kenya");
-    private final Territory russia = gameData.getMap().getTerritory("Russia");
+    private final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    private final Territory japan = gameData.getMap().getTerritoryOrThrow("Japan");
+    private final Territory unitedKingdom = gameData.getMap().getTerritoryOrThrow("United Kingdom");
+    private final Territory seaZone32 = gameData.getMap().getTerritoryOrThrow("32 Sea Zone");
+    private final Territory kenya = gameData.getMap().getTerritoryOrThrow("Kenya");
+    private final Territory russia = gameData.getMap().getTerritoryOrThrow("Russia");
 
     private final List<GamePlayer> players =
         List.of(
@@ -401,10 +401,10 @@ public class AttackerAndDefenderSelectorTest {
     private final GamePlayer russians = russians(gameData);
     private final GamePlayer british = british(gameData);
     private final GamePlayer french = french(gameData);
-    private final Territory northernItaly = gameData.getMap().getTerritory("Northern Italy");
-    private final Territory balticStates = gameData.getMap().getTerritory("Baltic States");
-    private final Territory sz97 = gameData.getMap().getTerritory("97 Sea Zone");
-    private final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    private final Territory northernItaly = gameData.getMap().getTerritoryOrThrow("Northern Italy");
+    private final Territory balticStates = gameData.getMap().getTerritoryOrThrow("Baltic States");
+    private final Territory sz97 = gameData.getMap().getTerritoryOrThrow("97 Sea Zone");
+    private final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
 
     @Test
     void alliedTerritory() {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
@@ -29,7 +29,7 @@ class BattleCalculatorTest extends AbstractClientSettingTestCase {
   @Test
   void testUnbalancedFight() {
     final GameData gameData = TestMapGameData.REVISED.getGameData();
-    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
     final Collection<Unit> defendingUnits = new ArrayList<>(germany.getUnits());
     final GamePlayer russians = russians(gameData);
     final GamePlayer germans = germans(gameData);
@@ -60,7 +60,7 @@ class BattleCalculatorTest extends AbstractClientSettingTestCase {
     // if one attacking inf must live, the odds much worse
     final GamePlayer germans = germans(gameData);
     final GamePlayer british = british(gameData);
-    final Territory eastCanada = gameData.getMap().getTerritory("Eastern Canada");
+    final Territory eastCanada = gameData.getMap().getTerritoryOrThrow("Eastern Canada");
     final List<Unit> defendingUnits = fighter(gameData).create(1, british);
     final List<Unit> attackingUnits = infantry(gameData).create(1, germans);
     attackingUnits.addAll(bomber(gameData).create(1, germans));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/xml/TestDataBigWorld1942V3.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/xml/TestDataBigWorld1942V3.java
@@ -32,7 +32,7 @@ public class TestDataBigWorld1942V3 {
   public TestDataBigWorld1942V3() {
     gameData = TestMapGameData.BIG_WORLD_1942_V3.getGameData();
     british = checkNotNull(gameData.getPlayerList().getPlayerId("British"));
-    france = checkNotNull(gameData.getMap().getTerritory("France"));
+    france = checkNotNull(gameData.getMap().getTerritoryOrThrow("France"));
     tank = checkNotNull(gameData.getUnitTypeList().getUnitTypeOrThrow("armour"));
     infantry = checkNotNull(gameData.getUnitTypeList().getUnitTypeOrThrow("infantry"));
     marine = checkNotNull(gameData.getUnitTypeList().getUnitTypeOrThrow("marine"));

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1234,7 +1234,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
           }
           mapPanel.centerOn(
               data.getMap()
-                  .getTerritory(CollectionUtils.getAny(possibleUnitsToAttackStringForm.keySet())));
+                  .getTerritoryOrNull(
+                      CollectionUtils.getAny(possibleUnitsToAttackStringForm.keySet())));
           final IndividualUnitPanelGrouped unitPanel =
               new IndividualUnitPanelGrouped(
                   possibleUnitsToAttackStringForm,
@@ -1287,7 +1288,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                   for (final IndividualUnitPanelGrouped terrChooser : unitPanels) {
                     for (final Map.Entry<String, IntegerMap<Unit>> entry :
                         terrChooser.getSelected().entrySet()) {
-                      selection.put(data.getMap().getTerritory(entry.getKey()), entry.getValue());
+                      selection.put(
+                          data.getMap().getTerritoryOrThrow(entry.getKey()), entry.getValue());
                     }
                   }
                   dialog.setVisible(false);

--- a/game-app/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/game-app/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -96,16 +96,16 @@ public class AiGameTest {
     GameTestUtils.runStepsUntil(game, "BlueWealthPlace");
 
     // Now, set up some units on another continent to verify how the AI will handle them.
-    Territory oaxaca = GameTestUtils.getTerritory(gameData, "Oaxaca");
+    Territory oaxaca = GameTestUtils.getTerritoryOrThrow(gameData, "Oaxaca");
     oaxaca.setOwner(blue);
     GameTestUtils.addUnits(oaxaca, blue, "army", "port");
-    Territory stLucia = GameTestUtils.getTerritory(gameData, "St Lucia");
+    Territory stLucia = GameTestUtils.getTerritoryOrThrow(gameData, "St Lucia");
     stLucia.setOwner(blue);
     GameTestUtils.addUnits(stLucia, blue, "army", "wealth");
-    Territory andres = GameTestUtils.getTerritory(gameData, "Andres");
+    Territory andres = GameTestUtils.getTerritoryOrThrow(gameData, "Andres");
     andres.setOwner(blue);
     GameTestUtils.addUnits(andres, blue, "army");
-    Territory culiacan = GameTestUtils.getTerritory(gameData, "Culiacan");
+    Territory culiacan = GameTestUtils.getTerritoryOrThrow(gameData, "Culiacan");
     culiacan.setOwner(blue);
     GameTestUtils.addUnits(culiacan, blue, "army", "wealth");
 

--- a/game-app/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
+++ b/game-app/smoke-testing/src/test/java/games/strategy/engine/data/GameTestUtils.java
@@ -18,7 +18,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import lombok.experimental.UtilityClass;
@@ -112,7 +111,7 @@ public class GameTestUtils {
     return data.getUnitTypeList().getUnitTypeOrThrow(name);
   }
 
-  public static Territory getTerritory(GameData data, String name) {
-    return Optional.ofNullable(data.getMap().getTerritory(name)).orElseThrow();
+  public static Territory getTerritoryOrThrow(GameData data, String name) {
+    return data.getMap().getTerritoryOrThrow(name);
   }
 }


### PR DESCRIPTION
Test.java

usage of method getTerritoryOrThrow instead of getTerritory
DefaultAttachment.java

method getTerritoryOrThrow: replaces with getTerritoryOrThrowGameParseException
new methods getTerritoryOrThrowGameParseException/getTerritoryOrThrowIllegalStateException: Throwing specific exception when no territory was found
new method getTerritory: private method returning Optional to avoid returning null
GameMap.java

method getTerritory: Renamed to getTerritoryOrNull
method getTerritoryOrThrow: Documentation added
methods getDistance: Parameter annotation NotNull added
GameSelectorModel.java

method parseAndValidate: Return Optional instead of null
method setGameData: Parameter annotation Nullable added
GameTestUtils.java

method getTerritory: Replaced with getTerritoryOrThrow
UnitTypeList.java

method getUnitTypes: Documentation updated
Notes to Reviewer
Follow-up PRs shall get to a state that getTerritory is no longer returning null.
Replacement of PR #13584.
