### PR TITLE
GameParseException for invalid attachment name

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -160,6 +160,12 @@ public class CanalAttachment extends DefaultAttachment {
       throw new GameParseException(
           MessageFormat.format("Canals must have a canalName set!{0}", thisErrorMsg()));
     }
+    if (getName() == null || !getName().startsWith(Constants.CANAL_ATTACHMENT_PREFIX)) {
+      throw new GameParseException(
+          MessageFormat.format(
+              "Canal attachment name invalid. Must start with ''{0}''!{1}",
+              Constants.CANAL_ATTACHMENT_PREFIX, thisErrorMsg()));
+    }
     if (getLandTerritories().isEmpty()) {
       throw new GameParseException(
           MessageFormat.format(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -11,6 +11,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.Matches;
+import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -156,11 +157,13 @@ public class CanalAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameState data) throws GameParseException {
     if (canalName.isEmpty()) {
-      throw new GameParseException("Canals must have a canalName set!" + thisErrorMsg());
+      throw new GameParseException(
+          MessageFormat.format("Canals must have a canalName set!{0}", thisErrorMsg()));
     }
     if (getLandTerritories().isEmpty()) {
       throw new GameParseException(
-          "Canal named " + canalName + " must have landTerritories set!" + thisErrorMsg());
+          MessageFormat.format(
+              "Canal named ''{0}'' must have landTerritories set!{1}", canalName, thisErrorMsg()));
     }
     final Set<Territory> territories = new HashSet<>();
     for (final Territory t : data.getMap()) {
@@ -170,8 +173,9 @@ public class CanalAttachment extends DefaultAttachment {
     }
     if (territories.size() != 2) {
       throw new GameParseException(
-          "Wrong number of sea zones for canal (exactly 2 sea zones may have the same canalName):"
-              + territories);
+          MessageFormat.format(
+              "Wrong number of sea zones {0} for canal named ''{1}'' (exactly 2 sea zones may have the same canalName): {2}",
+              territories.size(), canalName, territories));
     }
   }
 


### PR DESCRIPTION
Add GameParseException for invalid attachment name (= not starting with name 'canalAttachment').
Assistance to issue #13630