### PR TITLE
noReturnNull getDelegate + enfore GameData.getXxxDelegate calls

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -243,8 +243,13 @@ public class GameData implements Serializable, GameState {
     delegates.put(delegate.getName(), delegate);
   }
 
+  public Optional<IDelegate> getDelegateOptional(final String name) {
+    return Optional.ofNullable(delegates.get(name));
+  }
+
   public IDelegate getDelegate(final String name) {
-    return delegates.get(name);
+    return getDelegateOptional(name)
+        .orElseThrow(() -> new IllegalStateException(name + " delegate not found"));
   }
 
   @Override
@@ -399,10 +404,12 @@ public class GameData implements Serializable, GameState {
 
   @RemoveOnNextMajorRelease
   public void fixUpNullPlayersInDelegates() {
-    BattleDelegate battleDelegate = (BattleDelegate) getDelegate("battle");
-    if (battleDelegate != null) {
-      battleDelegate.getBattleTracker().fixUpNullPlayers(playerList.getNullPlayer());
-    }
+    getDelegateOptional("battle")
+        .ifPresent(
+            delegate ->
+                ((BattleDelegate) delegate)
+                    .getBattleTracker()
+                    .fixUpNullPlayers(playerList.getNullPlayer()));
   }
 
   public interface Unlocker extends Closeable {
@@ -480,30 +487,22 @@ public class GameData implements Serializable, GameState {
 
   @Override
   public PoliticsDelegate getPoliticsDelegate() {
-    return (PoliticsDelegate) findDelegate("politics");
-  }
-
-  private IDelegate findDelegate(final String delegateName) {
-    final IDelegate delegate = this.getDelegate(delegateName);
-    if (delegate == null) {
-      throw new IllegalStateException(delegateName + " delegate not found");
-    }
-    return delegate;
+    return (PoliticsDelegate) getDelegate("politics");
   }
 
   @Override
   public BattleDelegate getBattleDelegate() {
-    return (BattleDelegate) findDelegate("battle");
+    return (BattleDelegate) getDelegate("battle");
   }
 
   @Override
   public AbstractMoveDelegate getMoveDelegate() {
-    return (AbstractMoveDelegate) findDelegate("move");
+    return (AbstractMoveDelegate) getDelegate("move");
   }
 
   @Override
   public TechnologyDelegate getTechDelegate() {
-    return (TechnologyDelegate) findDelegate("tech");
+    return (TechnologyDelegate) getDelegate("tech");
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -250,7 +250,10 @@ public class GameData implements Serializable, GameState {
 
   public IDelegate getDelegate(final String name) {
     return getDelegateOptional(name)
-        .orElseThrow(() -> new IllegalStateException(name + " delegate not found"));
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    name + " delegate not found in list: " + delegates.keySet()));
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -12,6 +12,7 @@ import games.strategy.engine.history.History;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleA;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
+import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.delegate.PoliticsDelegate;
 import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.TechnologyDelegate;
@@ -503,6 +504,11 @@ public class GameData implements Serializable, GameState {
   @Override
   public TechnologyDelegate getTechDelegate() {
     return (TechnologyDelegate) getDelegate("tech");
+  }
+
+  @Override
+  public EndRoundDelegate getEndRoundDelegate() {
+    return (EndRoundDelegate) getDelegate("endRound");
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameState.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameState.java
@@ -2,6 +2,7 @@ package games.strategy.engine.data;
 
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
+import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.delegate.PoliticsDelegate;
 import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.TechnologyDelegate;
@@ -73,4 +74,6 @@ public interface GameState {
   AbstractMoveDelegate getMoveDelegate();
 
   TechnologyDelegate getTechDelegate();
+
+  EndRoundDelegate getEndRoundDelegate();
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -98,6 +98,10 @@ public class GameStep extends GameDataComponent {
     return player;
   }
 
+  public Optional<IDelegate> getDelegateOptional() {
+    return getData().getDelegateOptional(delegateName);
+  }
+
   public IDelegate getDelegate() {
     return getData().getDelegate(delegateName);
   }
@@ -132,8 +136,8 @@ public class GameStep extends GameDataComponent {
 
   public String getDisplayName() {
     if (displayName == null) {
-      IDelegate delegate = getDelegate();
-      return delegate != null ? delegate.getDisplayName() : delegateName;
+      Optional<IDelegate> optionalDelegate = getDelegateOptional();
+      return optionalDelegate.isPresent() ? optionalDelegate.get().getDisplayName() : delegateName;
     }
     return displayName;
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -341,7 +341,7 @@ public final class GameParser {
 
   /** If the Delegate cannot be found an exception will be thrown. */
   private IDelegate getDelegate(final String name) throws GameParseException {
-    return Optional.ofNullable(data.getDelegate(name))
+    return data.getDelegateOptional(name)
         .orElseThrow(
             () ->
                 new GameParseException(MessageFormat.format("Could not find delegate: {0}", name)));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -25,13 +25,13 @@ public class TripleA implements IGameLoader {
 
   protected transient IGame game;
 
+  private static Player toGamePlayer(final Map.Entry<String, PlayerTypes.Type> namePlayerType) {
+    return namePlayerType.getValue().newPlayerWithName(namePlayerType.getKey());
+  }
+
   @Override
   public Set<Player> newPlayers(final Map<String, PlayerTypes.Type> playerNames) {
     return playerNames.entrySet().stream().map(TripleA::toGamePlayer).collect(Collectors.toSet());
-  }
-
-  private static Player toGamePlayer(final Map.Entry<String, PlayerTypes.Type> namePlayerType) {
-    return namePlayerType.getValue().newPlayerWithName(namePlayerType.getKey());
   }
 
   @Override
@@ -49,7 +49,7 @@ public class TripleA implements IGameLoader {
       final LaunchAction launchAction,
       @Nullable final Chat chat) {
     this.game = game;
-    if (game.getData().getDelegate("edit") == null) {
+    if (game.getData().getDelegateOptional("edit").isEmpty()) {
       // An evil hack: instead of modifying the XML, force an EditDelegate by adding one here
       final EditDelegate delegate = new EditDelegate();
       delegate.initialize("edit", "edit");

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -31,7 +31,6 @@ import games.strategy.engine.history.IDelegateHistoryWriter;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
-import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.OriginalOwnerTracker;
 import games.strategy.triplea.delegate.TechAdvance;
@@ -2502,8 +2501,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
                   + MyFormatter.defaultNamedToTextList(t.getPlayers())
                   + " have just won the game, with this victory: "
                   + messageForRecord);
-          final EndRoundDelegate delegateEndRound = (EndRoundDelegate) data.getDelegate("endRound");
-          delegateEndRound.signalGameOver(victoryMessage.trim(), t.getPlayers(), bridge);
+          data.getEndRoundDelegate().signalGameOver(victoryMessage.trim(), t.getPlayers(), bridge);
         } catch (final Exception e) {
           log.error("Failed to signal game over", e);
         }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -15,6 +15,7 @@ import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.message.IRemote;
 import games.strategy.engine.player.Player;
@@ -39,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.CollectionUtils;
@@ -68,14 +70,15 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
 
     // Only add territory resources if endTurn not endTurnNoPU
     for (final GameStep step : data.getSequence()) {
-      if (player.equals(step.getPlayerId())
-          && step.getDelegate() != null
-          && step.getDelegate().getName().equals("endTurn")) {
-        final List<Territory> territories = data.getMap().getTerritoriesOwnedBy(player);
-        final int pusFromTerritories =
-            getProduction(territories, data) * Properties.getPuMultiplier(data.getProperties());
-        resources.add(new Resource(Constants.PUS, data), pusFromTerritories);
-        resources.add(EndTurnDelegate.getResourceProduction(territories, data));
+      if (player.equals(step.getPlayerId())) {
+        Optional<IDelegate> optionalDelegate = step.getDelegateOptional();
+        if (optionalDelegate.isPresent() && optionalDelegate.get().getName().equals("endTurn")) {
+          final List<Territory> territories = data.getMap().getTerritoriesOwnedBy(player);
+          final int pusFromTerritories =
+              getProduction(territories, data) * Properties.getPuMultiplier(data.getProperties());
+          resources.add(new Resource(Constants.PUS, data), pusFromTerritories);
+          resources.add(EndTurnDelegate.getResourceProduction(territories, data));
+        }
       }
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -7,8 +7,10 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.GameStep;
+import games.strategy.engine.delegate.IDelegate;
 import games.strategy.triplea.Properties;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 import lombok.experimental.UtilityClass;
@@ -188,11 +190,11 @@ public final class GameStepPropertiesHelper {
       if (prop != null) {
         return Boolean.parseBoolean(prop);
       }
-      return (data.getSequence().getStep().getDelegate() == null
-              || !NoAirCheckPlaceDelegate.class.equals(
-                  data.getSequence().getStep().getDelegate().getClass()))
+      Optional<IDelegate> optionalDelegate = data.getSequence().getStep().getDelegateOptional();
+      return (optionalDelegate.isEmpty()
+              || !NoAirCheckPlaceDelegate.class.equals(optionalDelegate.get().getClass()))
           && (isNonCombatDelegate(data)
-              || data.getSequence().getStep().getName().endsWith("Place"));
+              || GameStep.isPlaceStepName(data.getSequence().getStep().getName()));
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.printgenerator;
 
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameStep;
+import games.strategy.engine.delegate.IDelegate;
 import games.strategy.triplea.delegate.BidPlaceDelegate;
 import games.strategy.triplea.delegate.BidPurchaseDelegate;
 import games.strategy.triplea.delegate.EndRoundDelegate;
@@ -17,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 class PlayerOrder {
@@ -28,8 +30,9 @@ class PlayerOrder {
 
   void saveToFile(final PrintGenerationData printData) throws IOException {
     for (final GameStep currentStep : printData.getData().getSequence()) {
-      if (currentStep.getDelegate() != null) {
-        final String delegateClassName = currentStep.getDelegate().getClass().getName();
+      Optional<IDelegate> optionalDelegate = currentStep.getDelegateOptional();
+      if (optionalDelegate.isPresent()) {
+        final String delegateClassName = optionalDelegate.get().getClass().getName();
         if (delegateClassName.equals(InitializationDelegate.class.getName())
             || delegateClassName.equals(BidPurchaseDelegate.class.getName())
             || delegateClassName.equals(BidPlaceDelegate.class.getName())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/PlayerOrderComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/PlayerOrderComparator.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.GameStep;
 import games.strategy.engine.delegate.IDelegate;
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.Optional;
 
 /** A comparator for {@link GamePlayer} that sorts instances in game play order. */
 public class PlayerOrderComparator implements Comparator<GamePlayer>, Serializable {
@@ -31,12 +32,12 @@ public class PlayerOrderComparator implements Comparator<GamePlayer>, Serializab
       if (s.getPlayerId() == null) {
         continue;
       }
-      final IDelegate delegate;
+      final Optional<IDelegate> optionalDelegate;
       try (GameData.Unlocker ignored = gameData.acquireReadLock()) {
-        delegate = s.getDelegate();
+        optionalDelegate = s.getDelegateOptional();
       }
-      if (delegate != null) {
-        final String delegateClassName = delegate.getClass().getName();
+      if (optionalDelegate.isPresent()) {
+        final String delegateClassName = optionalDelegate.get().getClass().getName();
         if (delegateClassName.equals("games.strategy.triplea.delegate.InitializationDelegate")
             || delegateClassName.equals("games.strategy.triplea.delegate.BidPurchaseDelegate")
             || delegateClassName.equals("games.strategy.triplea.delegate.BidPlaceDelegate")

--- a/game-app/game-core/src/test/java/games/strategy/triplea/TripleATest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/TripleATest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
@@ -63,7 +62,6 @@ public class TripleATest {
   void testStartGameAndShutDownWhenServerGameStartedWithoutEditDelegate() {
 
     when(serverGame.getData()).thenReturn(gameData);
-    when(gameData.getDelegate(anyString())).thenReturn(null);
     doAnswer(
             invocation -> {
               IGame game = invocation.getArgument(1);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -146,7 +146,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     moveDelegate.move(sz45.getUnits(), new Route(sz45, sz44));
     moveDelegate.end();
     // fight the battle
-    final BattleDelegate battle = (BattleDelegate) gameData.getDelegate("battle");
+    final BattleDelegate battle = gameData.getBattleDelegate();
     battle.setDelegateBridgeAndPlayer(bridge);
     whenGetRandom(bridge)
         .thenAnswer(withValues(0, 0))
@@ -197,7 +197,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     moveDelegate.move(sz45.getUnits(), new Route(sz45, sz44));
     moveDelegate.end();
     // fight the battle
-    final BattleDelegate battle = (BattleDelegate) gameData.getDelegate("battle");
+    final BattleDelegate battle = gameData.getBattleDelegate();
     battle.setDelegateBridgeAndPlayer(bridge);
     whenGetRandom(bridge).thenAnswer(withValues(0, 0)).thenAnswer(withValues(0, 0, 0));
     battle.start();
@@ -245,7 +245,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     moveDelegate.move(sz11.getUnits(), new Route(sz11, sz9));
     moveDelegate.end();
     // fight the battle
-    final BattleDelegate battle = (BattleDelegate) gameData.getDelegate("battle");
+    final BattleDelegate battle = gameData.getBattleDelegate();
     battle.setDelegateBridgeAndPlayer(bridge);
     whenGetRandom(bridge).thenAnswer(withValues(0));
     battle.start();
@@ -296,7 +296,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
         sz9.getUnitCollection().getUnits(infantryType, 1), new Route(sz9, eastCanada));
     moveDelegate.end();
     // fight the battle
-    final BattleDelegate battle = (BattleDelegate) gameData.getDelegate("battle");
+    final BattleDelegate battle = gameData.getBattleDelegate();
     battle.setDelegateBridgeAndPlayer(bridge);
     battle.start();
     whenGetRandom(bridge).thenAnswer(withValues(0)).thenAnswer(withValues(0, 0));

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -139,7 +139,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     final int preCountSz52 = sz52.getUnitCollection().size();
     final int preCountAirSz44 = sz44.getUnitCollection().getMatches(Matches.unitIsAir()).size();
     // now move to attack
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -190,7 +190,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     final int preCountSz52 = sz52.getUnitCollection().size();
     final int preCountSz43 = sz43.getUnitCollection().size();
     // now move to attack
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -238,7 +238,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     final int preCountCanada = eastCanada.getUnitCollection().size();
     final int preCountAirSz9 = sz9.getUnitCollection().getMatches(Matches.unitIsAir()).size();
     // now move to attack
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -287,7 +287,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     final int preCountCanada = eastCanada.getUnitCollection().size();
     final int preCountAirSz9 = sz9.getUnitCollection().getMatches(Matches.unitIsAir()).size();
     // now move to attack
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -139,7 +139,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     final int preCountSz52 = sz52.getUnitCollection().size();
     final int preCountAirSz44 = sz44.getUnitCollection().getMatches(Matches.unitIsAir()).size();
     // now move to attack
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -190,7 +190,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     final int preCountSz52 = sz52.getUnitCollection().size();
     final int preCountSz43 = sz43.getUnitCollection().size();
     // now move to attack
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -238,7 +238,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     final int preCountCanada = eastCanada.getUnitCollection().size();
     final int preCountAirSz9 = sz9.getUnitCollection().getMatches(Matches.unitIsAir()).size();
     // now move to attack
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -287,7 +287,7 @@ class AirThatCantLandUtilTest extends AbstractClientSettingTestCase {
     final int preCountCanada = eastCanada.getUnitCollection().size();
     final int preCountAirSz9 = sz9.getUnitCollection().getMatches(Matches.unitIsAir()).size();
     // now move to attack
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -380,12 +380,12 @@ public final class GameDataTestUtil {
 
   /** Returns a MoveDelegate from the given GameData object. */
   public static MoveDelegate moveDelegate(final GameData data) {
-    return data.getMoveDelegate();
+    return (MoveDelegate) data.getMoveDelegate();
   }
 
   /** Returns a TechnologyDelegate from the given GameData object. */
   static TechnologyDelegate techDelegate(final GameData data) {
-    return (TechnologyDelegate) data.getDelegate("tech");
+    return data.getTechDelegate();
   }
 
   /** Returns a PurchaseDelegate from the given GameData object. */

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -375,7 +375,7 @@ public final class GameDataTestUtil {
 
   /** Returns a BattleDelegate from the given GameData object. */
   public static BattleDelegate battleDelegate(final GameData data) {
-    return (BattleDelegate) data.getDelegate("battle");
+    return data.getBattleDelegate();
   }
 
   /** Returns a MoveDelegate from the given GameData object. */

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -380,7 +380,7 @@ public final class GameDataTestUtil {
 
   /** Returns a MoveDelegate from the given GameData object. */
   public static MoveDelegate moveDelegate(final GameData data) {
-    return (MoveDelegate) data.getDelegate("move");
+    return data.getMoveDelegate();
   }
 
   /** Returns a TechnologyDelegate from the given GameData object. */

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -43,7 +43,7 @@ class LhtrTest extends AbstractClientSettingTestCase {
 
   @Test
   void testFightersCanLandOnNewPlacedCarrier() {
-    final MoveDelegate delegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate delegate = gameData.getMoveDelegate();
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);
@@ -70,7 +70,7 @@ class LhtrTest extends AbstractClientSettingTestCase {
 
   @Test
   void testFightersDestroyedWhenNoPendingCarriers() {
-    final MoveDelegate delegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate delegate = gameData.getMoveDelegate();
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);
@@ -93,7 +93,7 @@ class LhtrTest extends AbstractClientSettingTestCase {
 
   @Test
   void testAaGunsDontFireNonCombat() {
-    final MoveDelegate delegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate delegate = gameData.getMoveDelegate();
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -43,7 +43,7 @@ class LhtrTest extends AbstractClientSettingTestCase {
 
   @Test
   void testFightersCanLandOnNewPlacedCarrier() {
-    final MoveDelegate delegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate delegate = gameData.getMoveDelegate();
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);
@@ -70,7 +70,7 @@ class LhtrTest extends AbstractClientSettingTestCase {
 
   @Test
   void testFightersDestroyedWhenNoPendingCarriers() {
-    final MoveDelegate delegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate delegate = gameData.getMoveDelegate();
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);
@@ -93,7 +93,7 @@ class LhtrTest extends AbstractClientSettingTestCase {
 
   @Test
   void testAaGunsDontFireNonCombat() {
-    final MoveDelegate delegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate delegate = gameData.getMoveDelegate();
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -181,7 +181,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Unit sub = sz8.getUnitCollection().iterator().next();
     sub.setSubmerged(true);
     // now move to attack it
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -214,7 +214,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final UnitType infantryType = infantry(gameData);
     gameData.performChange(ChangeFactory.addUnits(sinkiang, infantryType.create(1, japanese)));
     // now move to attack it
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -248,7 +248,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final GamePlayer russians = russians(gameData);
     final GamePlayer germans = germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -331,7 +331,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testOverFlyBombersDies() {
     final GamePlayer british = british(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -352,7 +352,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testMultipleOverFlyBombersDies() {
     final GamePlayer british = british(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -380,7 +380,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     // a bomber flies over aa to join a battle, gets hit,
     // it should not appear in the battle
     final GamePlayer british = british(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -403,7 +403,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory sz14 = gameData.getMap().getTerritory("14 Sea Zone");
     final Territory sz13 = gameData.getMap().getTerritory("13 Sea Zone");
     final GamePlayer germans = germans(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -420,7 +420,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     final UnitType infantryType = infantry(gameData);
     final GamePlayer germans = germans(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -455,7 +455,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory norway = gameData.getMap().getTerritory("Norway");
     final UnitType infantryType = infantry(gameData);
     final GamePlayer germans = germans(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -501,7 +501,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -545,7 +545,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Change change = ChangeFactory.addUnits(eastEurope, infantryType.create(1, japanese));
     gameData.performChange(change);
     final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(japanese);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -577,7 +577,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -628,7 +628,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -675,7 +675,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final GamePlayer germans = germans(gameData);
     // german sub tries to attack a transport in non combat
     // should be an error
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -691,7 +691,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final GamePlayer germans = germans(gameData);
     // german sub tries to attack a transport in non combat
     // should be an error
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -707,7 +707,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final GamePlayer british = british(gameData);
     // german sub tries to attack a transport in non combat
     // should be an error
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -727,7 +727,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Change c = ChangeFactory.addUnits(sz45, sub.create(1, british));
     gameData.performChange(c);
     // new move delegate
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(japanese);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -181,7 +181,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Unit sub = sz8.getUnitCollection().iterator().next();
     sub.setSubmerged(true);
     // now move to attack it
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -214,7 +214,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final UnitType infantryType = infantry(gameData);
     gameData.performChange(ChangeFactory.addUnits(sinkiang, infantryType.create(1, japanese)));
     // now move to attack it
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -248,7 +248,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final GamePlayer russians = russians(gameData);
     final GamePlayer germans = germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -331,7 +331,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testOverFlyBombersDies() {
     final GamePlayer british = british(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -352,7 +352,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
   @Test
   void testMultipleOverFlyBombersDies() {
     final GamePlayer british = british(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -380,7 +380,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     // a bomber flies over aa to join a battle, gets hit,
     // it should not appear in the battle
     final GamePlayer british = british(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -403,7 +403,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory sz14 = gameData.getMap().getTerritory("14 Sea Zone");
     final Territory sz13 = gameData.getMap().getTerritory("13 Sea Zone");
     final GamePlayer germans = germans(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -420,7 +420,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     final UnitType infantryType = infantry(gameData);
     final GamePlayer germans = germans(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -455,7 +455,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory norway = gameData.getMap().getTerritory("Norway");
     final UnitType infantryType = infantry(gameData);
     final GamePlayer germans = germans(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -501,7 +501,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -545,7 +545,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Change change = ChangeFactory.addUnits(eastEurope, infantryType.create(1, japanese));
     gameData.performChange(change);
     final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(japanese);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -577,7 +577,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -628,7 +628,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -675,7 +675,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final GamePlayer germans = germans(gameData);
     // german sub tries to attack a transport in non combat
     // should be an error
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -691,7 +691,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final GamePlayer germans = germans(gameData);
     // german sub tries to attack a transport in non combat
     // should be an error
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -707,7 +707,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final GamePlayer british = british(gameData);
     // german sub tries to attack a transport in non combat
     // should be an error
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -727,7 +727,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Change c = ChangeFactory.addUnits(sz45, sub.create(1, british));
     gameData.performChange(c);
     // new move delegate
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(japanese);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -221,7 +221,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
     final Territory novo = gameData.getMap().getTerritory("Novosibirsk");
     move(novo.getUnits(), new Route(novo, sinkiang));
     moveDelegate.end();
-    final BattleDelegate battle = (BattleDelegate) gameData.getDelegate("battle");
+    final BattleDelegate battle = gameData.getBattleDelegate();
     battle.setDelegateBridgeAndPlayer(bridge);
     whenGetRandom(bridge).thenAnswer(withValues(0, 0)).thenAnswer(withValues(0));
     battle.start(); // fights battle
@@ -277,7 +277,7 @@ class RevisedTest extends AbstractClientSettingTestCase {
         CollectionUtils.getNMatches(sz5.getUnits(), 1, Matches.unitIsOfType(infantryType)),
         new Route(sz5, karelia));
     moveDelegate.end();
-    final IDelegate battle = gameData.getDelegate("battle");
+    final IDelegate battle = gameData.getBattleDelegate();
     battle.setDelegateBridgeAndPlayer(bridge);
     battle.start();
     final BattleTracker tracker = AbstractMoveDelegate.getBattleTracker(gameData);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -77,7 +77,7 @@ class VictoryTest {
 
     italianResources = italians.getResources().getResourcesCopy();
     purchaseDelegate = (PurchaseDelegate) gameData.getDelegate("purchase");
-    moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    moveDelegate = gameData.getMoveDelegate();
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -77,7 +77,7 @@ class VictoryTest {
 
     italianResources = italians.getResources().getResourcesCopy();
     purchaseDelegate = (PurchaseDelegate) gameData.getDelegate("purchase");
-    moveDelegate = gameData.getMoveDelegate();
+    moveDelegate = (MoveDelegate) gameData.getMoveDelegate();
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -57,7 +57,7 @@ class WW2V3Year42Test {
     final Territory sz5 = territory("5 Sea Zone", gameData);
     final Territory germany = territory("Germany", gameData);
     final GamePlayer germans = germans(gameData);
-    final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
+    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -57,7 +57,7 @@ class WW2V3Year42Test {
     final Territory sz5 = territory("5 Sea Zone", gameData);
     final Territory germany = territory("Germany", gameData);
     final GamePlayer germans = germans(gameData);
-    final MoveDelegate moveDelegate = gameData.getMoveDelegate();
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -205,7 +205,8 @@ final class ExportMenu extends JMenu {
       }
       writer.println();
       writer.append("Winners: ,");
-      final EndRoundDelegate delegateEndRound = (EndRoundDelegate) gameData.getDelegate("endRound");
+      final EndRoundDelegate delegateEndRound =
+          (EndRoundDelegate) gameData.getDelegateOptional("endRound").orElse(null);
       if (delegateEndRound != null && delegateEndRound.getWinners() != null) {
         for (final GamePlayer p : delegateEndRound.getWinners()) {
           writer.append(p.getName()).append(',');

--- a/game-app/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/game-app/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -39,7 +39,7 @@ public class AiGameTest {
     }
     assertThat(game.isGameOver(), is(true));
     assertThat(game.getData().getSequence().getRound(), greaterThan(2));
-    EndRoundDelegate endDelegate = (EndRoundDelegate) game.getData().getDelegate("endRound");
+    EndRoundDelegate endDelegate = (EndRoundDelegate) game.getData().getEndRoundDelegate();
     assertThat(endDelegate.getWinners(), not(empty()));
     log.info("Game completed at round: " + game.getData().getSequence().getRound());
     log.info("Game winners: " + endDelegate.getWinners());


### PR DESCRIPTION
-GameData getDelegate to not return null
If assumed, new method getDelegateOptional can be used now
-Enforce use of GameData.getXxxDelegate methods