### PR TITLE
Update build.gradle

### DIFF
--- a/game-app/game-headed/build.gradle
+++ b/game-app/game-headed/build.gradle
@@ -5,11 +5,10 @@ plugins {
     id "de.undercouch.download" version "5.6.0"
 }
 
-//Activate the locked apple API with flag '--add-opens=java.desktop/com.apple.eawt.event=ALL-UNNAMED'
 application {
-    mainClass = 'org.triplea.game.client.HeadedGameRunner'
     applicationDefaultJvmArgs = [
-            '--add-opens=java.desktop/com.apple.eawt.event=ALL-UNNAMED'
+            //This flag fixes touch gestures in Java-21；Technical Reference: https://stackoverflow.com/questions/48535595/what-replaces-gestureutilities-in-java-9
+            "--add-opens=java.desktop/com.apple.eawt.event=ALL-UNNAMED"
     ]
 }
 


### PR DESCRIPTION
It fix the issue #13456 by adding a flag to unlock the API on Mac. The flag should be invalid and should not affect the program working in other operating system.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
For Mac users, try to open the game and pinch on map, it should zoom now.