### PR TITLE
Fix headless build - upgrade docker JDK11 image

### DIFF
--- a/game-app/game-headless/Dockerfile
+++ b/game-app/game-headless/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim-buster
+FROM openjdk:11.0.16-jdk
 
 ENV BOT_PORT_NUMBER=4000
 EXPOSE $BOT_PORT_NUMBER


### PR DESCRIPTION
The previous image is no longer avaialble. This update resolves a build issue when building the docker image for 'bot' (headless) servers.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
