### PR TITLE
Update server paths, prefix with /lobby or /support

### DIFF
--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/error/report/ErrorReportClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/error/report/ErrorReportClient.java
@@ -8,8 +8,8 @@ import org.triplea.http.client.lobby.AuthenticationHeaders;
 
 /** Http client to upload error reports to the http lobby server. */
 public interface ErrorReportClient {
-  String ERROR_REPORT_PATH = "/error-report";
-  String CAN_UPLOAD_ERROR_REPORT_PATH = "/error-report-check";
+  String ERROR_REPORT_PATH = "/support/error-report";
+  String CAN_UPLOAD_ERROR_REPORT_PATH = "/support/error-report-check";
   int MAX_REPORTS_PER_DAY = 5;
 
   /** Creates an error report uploader clients, sends error reports and gets a response back. */

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/forgot/password/ForgotPasswordClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/forgot/password/ForgotPasswordClient.java
@@ -13,7 +13,7 @@ import org.triplea.http.client.lobby.AuthenticationHeaders;
 @SuppressWarnings("InterfaceNeverImplemented")
 public interface ForgotPasswordClient {
 
-  String FORGOT_PASSWORD_PATH = "/forgot-password";
+  String FORGOT_PASSWORD_PATH = "/lobby/forgot-password";
 
   /**
    * Sends request for a temporary password to be emailed to user.

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/latest/version/LatestVersionClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/latest/version/LatestVersionClient.java
@@ -6,7 +6,7 @@ import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.lobby.AuthenticationHeaders;
 
 public interface LatestVersionClient {
-  String LATEST_VERSION_PATH = "/latest-version";
+  String LATEST_VERSION_PATH = "/support/latest-version";
 
   static LatestVersionClient newClient(final URI uri) {
     return HttpClient.newClient(

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginClient.java
@@ -7,8 +7,8 @@ import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.lobby.AuthenticationHeaders;
 
 public interface LobbyLoginClient {
-  String LOGIN_PATH = "/user-login/authenticate";
-  String CREATE_ACCOUNT = "/user-login/create-account";
+  String LOGIN_PATH = "/lobby/user-login/authenticate";
+  String CREATE_ACCOUNT = "/lobby/user-login/create-account";
 
   static LobbyLoginClient newClient(final URI uri) {
     return newClient(uri, AuthenticationHeaders.systemIdHeaders());

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/banned/name/ToolboxUsernameBanClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/banned/name/ToolboxUsernameBanClient.java
@@ -9,9 +9,9 @@ import org.triplea.http.client.lobby.AuthenticationHeaders;
 
 /** Http client object for adding, removing and querying server for user name bans. */
 public interface ToolboxUsernameBanClient {
-  String REMOVE_BANNED_USER_NAME_PATH = "/moderator-toolbox/remove-username-ban";
-  String ADD_BANNED_USER_NAME_PATH = "/moderator-toolbox/add-username-ban";
-  String GET_BANNED_USER_NAMES_PATH = "/moderator-toolbox/get-username-bans";
+  String REMOVE_BANNED_USER_NAME_PATH = "/lobby/moderator-toolbox/remove-username-ban";
+  String ADD_BANNED_USER_NAME_PATH = "/lobby/moderator-toolbox/add-username-ban";
+  String GET_BANNED_USER_NAMES_PATH = "/lobby/moderator-toolbox/get-username-bans";
 
   static ToolboxUsernameBanClient newClient(final URI serverUri, final ApiKey apiKey) {
     return HttpClient.newClient(

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/banned/user/ToolboxUserBanClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/banned/user/ToolboxUserBanClient.java
@@ -12,9 +12,9 @@ import org.triplea.http.client.lobby.AuthenticationHeaders;
  * the network identifiers of a user, the user name is for informational purposes only.
  */
 public interface ToolboxUserBanClient {
-  String GET_USER_BANS_PATH = "/moderator-toolbox/get-user-bans";
-  String REMOVE_USER_BAN_PATH = "/moderator-toolbox/remove-user-ban";
-  String BAN_USER_PATH = "/moderator-toolbox/ban-user";
+  String GET_USER_BANS_PATH = "/lobby/moderator-toolbox/get-user-bans";
+  String REMOVE_USER_BAN_PATH = "/lobby/moderator-toolbox/remove-user-ban";
+  String BAN_USER_PATH = "/lobby/moderator-toolbox/ban-user";
 
   static ToolboxUserBanClient newClient(final URI serverUri, final ApiKey apiKey) {
     return HttpClient.newClient(

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxAccessLogClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxAccessLogClient.java
@@ -16,7 +16,7 @@ import org.triplea.http.client.lobby.moderator.toolbox.PagingParams;
  * parameters for adding user name or user bans.
  */
 public interface ToolboxAccessLogClient {
-  String FETCH_ACCESS_LOG_PATH = "/moderator-toolbox/access-log";
+  String FETCH_ACCESS_LOG_PATH = "/lobby/moderator-toolbox/access-log";
 
   static ToolboxAccessLogClient newClient(final URI serverUri, final ApiKey apiKey) {
     return HttpClient.newClient(

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxEventLogClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxEventLogClient.java
@@ -13,7 +13,7 @@ import org.triplea.http.client.lobby.moderator.toolbox.PagingParams;
  * moderator actions.
  */
 public interface ToolboxEventLogClient {
-  String AUDIT_HISTORY_PATH = "/moderator-toolbox/audit-history/lookup";
+  String AUDIT_HISTORY_PATH = "/lobby/moderator-toolbox/audit-history/lookup";
 
   static ToolboxEventLogClient newClient(final URI serverUri, final ApiKey apiKey) {
     return HttpClient.newClient(

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClient.java
@@ -12,12 +12,12 @@ import org.triplea.http.client.lobby.AuthenticationHeaders;
  * most actions will be available to a "super-mod" only (super-mod = admin of mods).
  */
 public interface ToolboxModeratorManagementClient {
-  String FETCH_MODERATORS_PATH = "/moderator-toolbox/fetch-moderators";
-  String IS_ADMIN_PATH = "/moderator-toolbox/is-admin";
-  String CHECK_USER_EXISTS_PATH = "/moderator-toolbox/does-user-exist";
-  String REMOVE_MOD_PATH = "/moderator-toolbox/admin/remove-mod";
-  String ADD_ADMIN_PATH = "/moderator-toolbox/admin/add-super-mod";
-  String ADD_MODERATOR_PATH = "/moderator-toolbox/admin/add-moderator";
+  String FETCH_MODERATORS_PATH = "/lobby/moderator-toolbox/fetch-moderators";
+  String IS_ADMIN_PATH = "/lobby/moderator-toolbox/is-admin";
+  String CHECK_USER_EXISTS_PATH = "/lobby/moderator-toolbox/does-user-exist";
+  String REMOVE_MOD_PATH = "/lobby/moderator-toolbox/admin/remove-mod";
+  String ADD_ADMIN_PATH = "/lobby/moderator-toolbox/admin/add-super-mod";
+  String ADD_MODERATOR_PATH = "/lobby/moderator-toolbox/admin/add-moderator";
 
   static ToolboxModeratorManagementClient newClient(final URI serverUri, final ApiKey apiKey) {
     return HttpClient.newClient(

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClient.java
@@ -9,9 +9,9 @@ import org.triplea.http.client.lobby.AuthenticationHeaders;
 
 /** Http client class for fetching the list of bad words and adding and removing them. */
 public interface ToolboxBadWordsClient {
-  String BAD_WORD_ADD_PATH = "/moderator-toolbox/bad-words/add";
-  String BAD_WORD_REMOVE_PATH = "/moderator-toolbox/bad-words/remove";
-  String BAD_WORD_GET_PATH = "/moderator-toolbox/bad-words/get";
+  String BAD_WORD_ADD_PATH = "/lobby/moderator-toolbox/bad-words/add";
+  String BAD_WORD_REMOVE_PATH = "/lobby/moderator-toolbox/bad-words/remove";
+  String BAD_WORD_GET_PATH = "/lobby/moderator-toolbox/bad-words/get";
 
   static ToolboxBadWordsClient newClient(final URI serverUri, final ApiKey apiKey) {
     return HttpClient.newClient(

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/admin/MapTagAdminClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/admin/MapTagAdminClient.java
@@ -9,8 +9,8 @@ import org.triplea.http.client.HttpClient;
 
 /** Http client for 'map tag' administrative functionality. EG: updating a maps tag value. */
 public interface MapTagAdminClient {
-  String GET_MAP_TAGS_META_DATA_PATH = "/maps/list-tags";
-  String UPDATE_MAP_TAG_PATH = "/maps/update-tag";
+  String GET_MAP_TAGS_META_DATA_PATH = "/support/maps/list-tags";
+  String UPDATE_MAP_TAG_PATH = "/support/maps/update-tag";
 
   static MapTagAdminClient newClient(
       final URI mapsServerUri, final ClientIdentifiers clientIdentifiers) {

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
@@ -11,7 +11,7 @@ import org.triplea.http.client.HttpClient;
  * Http client to communicate with the maps server and get a listing of maps available for download.
  */
 public interface MapsClient {
-  String MAPS_LISTING_PATH = "/maps/listing";
+  String MAPS_LISTING_PATH = "/support/maps/listing";
 
   static MapsClient newClient(URI mapsServerUri, ClientIdentifiers clientIdentifiers) {
     return HttpClient.newClient(MapsClient.class, mapsServerUri, clientIdentifiers.createHeaders());

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/remote/actions/RemoteActionsClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/remote/actions/RemoteActionsClient.java
@@ -11,8 +11,8 @@ import org.triplea.http.client.lobby.AuthenticationHeaders;
  * Client to poll for moderator actions and to check with server for players that have been banned.
  */
 public interface RemoteActionsClient {
-  String IS_PLAYER_BANNED_PATH = "/remote/actions/is-player-banned";
-  String SEND_SHUTDOWN_PATH = "/remote/actions/send-shutdown";
+  String IS_PLAYER_BANNED_PATH = "/lobby/remote/actions/is-player-banned";
+  String SEND_SHUTDOWN_PATH = "/lobby/remote/actions/send-shutdown";
 
   static RemoteActionsClient newClient(final URI serverUri, final ApiKey apiKey) {
     return HttpClient.newClient(

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebsocketPaths.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebsocketPaths.java
@@ -5,6 +5,6 @@ import org.jetbrains.annotations.NonNls;
 
 @UtilityClass
 public class WebsocketPaths {
-  @NonNls public static final String GAME_CONNECTIONS = "/game-connection/ws";
-  @NonNls public static final String PLAYER_CONNECTIONS = "/player-connection/ws";
+  @NonNls public static final String GAME_CONNECTIONS = "/lobby/game-connection/ws";
+  @NonNls public static final String PLAYER_CONNECTIONS = "/lobby/player-connection/ws";
 }


### PR DESCRIPTION
- The split will be useful server-side for request routing. Specifically, we'll configure NGINX to route requests based on the path prefix, whether to the 'lobby' or the 'support' server (for context, the support server will be maps & error-reporting)

- Update is done in a backward incompatible way. In the future with live deployments on update, we'll need to do this kind of update in a backward compatible way.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
