### PR TITLE
Fix on-launch error message for 'headedServerSetupModel' being null

### DIFF
--- a/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -187,10 +187,9 @@ public final class HeadedGameRunner {
               () -> {
                 showMainFrame();
                 gameSelectorModel.setReadyForSaveLoad();
+                UpdateChecks.launch(headedServerSetupModel.getUi());
               });
         });
-
-    UpdateChecks.launch(headedServerSetupModel.getUi());
   }
 
   /**


### PR DESCRIPTION
On launch of headed game client, observed error with pop-up:

> java.lang.NullPointerException: Cannot invoke "games.strategy.engine.framework.startup.ui.panels.main.HeadedServerSetupModel.getUi()" because "org.triplea.game.client.HeadedGameRunner.headedServerSetupModel" is null
	at org.triplea.game.client.HeadedGameRunner.start(HeadedGameRunner.java:193)
	at org.triplea.game.client.HeadedGameRunner.main(HeadedGameRunner.java:168)

Problem is the initialization of 'headedServerSetupModel' to a non-null value is done on a new thread. We spawn that thread and immediately use a needed value from 'headedServerSetupModel'.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
