### PR TITLE
Restore button to polygon grabber

### DIFF
--- a/game-app/game-core/src/main/java/tools/map/making/ui/MapCreator.java
+++ b/game-app/game-core/src/main/java/tools/map/making/ui/MapCreator.java
@@ -21,6 +21,7 @@ import tools.map.making.ui.runnable.DecorationPlacerTask;
 import tools.map.making.ui.runnable.ImageShrinkerTask;
 import tools.map.making.ui.runnable.MapPropertiesMakerTask;
 import tools.map.making.ui.runnable.PlacementPickerTask;
+import tools.map.making.ui.runnable.PolygonGrabberTask;
 import tools.map.making.ui.runnable.TileImageBreakerTask;
 import tools.map.making.ui.runnable.TileImageReconstructorTask;
 
@@ -77,6 +78,7 @@ public class MapCreator {
         new MapMakingPanelFactory.ButtonSpec(
             "Run the Map Properties Maker", MapPropertiesMakerTask::run),
         new MapMakingPanelFactory.ButtonSpec("Run the Center Picker", CenterPickerTask::run),
+        new MapMakingPanelFactory.ButtonSpec("Run the Polygon Grabber", PolygonGrabberTask::run),
         new MapMakingPanelFactory.ButtonSpec(
             "Run the Automatic Placement Finder", AutoPlacementFinderTask::run),
         new MapMakingPanelFactory.ButtonSpec("Run the Placement Picker", PlacementPickerTask::run),


### PR DESCRIPTION
While reworking the UI, the button for the polygon-grabber was 'dropped': f563ed4b6d2a3d6d1d2bfd117b01ca082d69d269

This update restores the button by adding in the 'dropped' line of code that added the polygon grabber button.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
