### PR TITLE
Upgrade Bot Docker JDK to 21

### DIFF
--- a/game-app/game-headless/Dockerfile
+++ b/game-app/game-headless/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16-jdk
+FROM eclipse-temurin:21
 
 ENV BOT_PORT_NUMBER=4000
 EXPOSE $BOT_PORT_NUMBER


### PR DESCRIPTION
Current version does not run! Following error message:

```
Status: Image is up to date for ghcr.io/triplea-game/bot:latest
Error: LinkageError occurred while loading main class org.triplea.game.server.HeadlessGameRunner
	java.lang.UnsupportedClassVersionError: org/triplea/game/server/HeadlessGameRunner has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```
