### PR TITLE
Remove IllegalState checks

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
@@ -49,15 +49,6 @@ public class RemoveUnits extends Change {
   @Override
   protected void perform(final GameState data) {
     final UnitHolder holder = data.getUnitHolder(name, type);
-    if (!holder.getUnitCollection().containsAll(units)) {
-      throw new IllegalStateException(
-          "Not all units present in:"
-              + name
-              + ".  Trying to remove:"
-              + units
-              + " present:"
-              + holder.getUnits());
-    }
     holder.getUnitCollection().removeAll(units);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/history/HistoryWriter.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/HistoryWriter.java
@@ -115,13 +115,6 @@ public class HistoryWriter implements Serializable {
     if (isCurrentEvent()) {
       closeCurrent();
     }
-    if (!isCurrentStep()) {
-      throw new IllegalStateException(
-          "Not in a step, but trying to add event: "
-              + eventName
-              + ". Current history node is: "
-              + current);
-    }
     final Event event = new Event(eventName, history.getChanges().size());
     addToAndSetCurrent(event);
   }


### PR DESCRIPTION
The checks look correct, but also when they fire, the game looks correct as well. It seems like we have eventual consistency, and having small errors in history is not a big deal.

Removing the illegal state checks allows the game to play as AI players for many rounds, without - the game barely makes it out of round 1

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
