### PR TITLE
Remove crash when triggers subtract PUs below zero

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
@@ -48,16 +48,7 @@ public class ResourceCollection extends GameDataComponent {
       throw new IllegalArgumentException("quantity must be positive");
     }
     final int current = getQuantity(resource);
-    if ((current - quantity) < 0) {
-      throw new IllegalArgumentException(
-          "Can't remove more than player has of resource: "
-              + resource.getName()
-              + ". current:"
-              + current
-              + " toRemove: "
-              + quantity);
-    }
-    change(resource, -quantity);
+    change(resource, -Math.min(current, quantity));
   }
 
   private void change(final Resource resource, final int quantity) {


### PR DESCRIPTION
An arbitrary trigger can subtract a fixed PU amount. This might be 
more than the current number of PUs. When adding such an event 
to the history, there was a check that crashed the game if PUs would go below zero.

This update changes that logic to allow this update, 
so you can subtract an arbitrary amount of PUs.
Except, PUs cannot go negative, we stay at zero
instead. A future update could make this behavior
configurable. For now, this is a fix to the game
crash situation.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
