### PR TITLE
Extract Main Convention Plugin and Begin Documenting Build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,21 +14,6 @@ wrapper {
     distributionType = Wrapper.DistributionType.ALL
 }
 
-allprojects {
-    apply plugin: "com.diffplug.spotless"
-    apply plugin: "java"
-
-    spotless {
-        format "allFiles", {
-            target "*"
-            targetExclude "gradlew.bat"
-            endWithNewline()
-            leadingTabsToSpaces()
-            trimTrailingWhitespace()
-        }
-    }
-}
-
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
@@ -134,12 +119,5 @@ subprojects {
         ruleSets = []
         incrementalAnalysis = true
         toolVersion = libs.versions.pmd.get()
-    }
-
-    spotless {
-        java {
-            googleJavaFormat()
-            removeUnusedImports()
-        }
     }
 }

--- a/docs/development/build-overview-and-development.md
+++ b/docs/development/build-overview-and-development.md
@@ -1,0 +1,37 @@
+# Build Overview
+
+Currently, the build uses a mix of Gradle tasks and bash scripts.
+Gradle plugins used by the build are located in `/gradle/build-logic`.
+
+## Convention Plugins
+
+The TripleA build defines Gradle [Convention Plugins](https://docs.gradle.org/current/userguide/implementing_gradle_plugins_convention.html#header) to avoid cross-project configuration and duplication of configuration.
+There are currently the following types of projects:
+
+### `triplea-java-library`
+
+This is a standard "vanilla" java library type.
+It applies the `java-library` plugin and applies universal configuration, code conventions, and sets up static analysis. 
+
+# Future Work
+
+To continue to improve build speeds and make the build structure more idiomatic, some near future work should:
+
+- Convert all build scripts to Kotlin.
+This will make the build easier to maintain by increasing the completion and refactoring assistance the IDE is able to provide.
+- Remove the use of `subprojects` and `allprojects` and replace these with Gradle [Convention Plugins](https://docs.gradle.org/current/userguide/implementing_gradle_plugins_convention.html#header).
+This will make the build easier to maintain by avoiding the pitfalls of cross-project configuration, it will prevent difficulties updating to future Gradle versions, and it will prepare the build to take advantage of future Gradle features like [Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html#header) that will further increase build speed.
+- Avoid creating empty projects in folders such as `game-app`.
+This slows and complicates the build unnecessarily.
+- Remove the need for the `version.gradle` script by moving these tasks to a single proper locations and wiring them with task dependencies to only run when needed.
+- Remove the need for bash scripts like those in `/game-app/run/` or `/verify` that exist only to launch Gradle builds with Gradle lifecycle tasks. 
+- Improve Dependency hygiene by enabling Gradle Dependabot alerts on GitHub, pruning unused project dependencies, properly using the `api` and `implementation` configurations to export dependencies only when necessary, etc. 
+- Properly implement [Test Fixtures](https://docs.gradle.org/current/userguide/java_testing.html#producing_and_using_test_fixtures_within_a_single_project) for sharing common testing code between projects, such as in `:game-app:ai` and in `:lib:test-common`.
+- Remove all/most configuration from the root `build.gradle(.kts)` file.
+- Describe projects using the `description` field, especially any unique components of a project's build.
+- Describe all tasks using the `description` and `group` field, use custom task types rather than ad-hoc tasks.
+- Define the necessary Java version using [JVM Toolchains](https://docs.gradle.org/current/userguide/toolchains.html#sec:consuming) and daemon toolchains.
+This will remove the need for any specific version of Java to be installed to run the build.
+- Conform to other Gradle [Best Practices](https://docs.gradle.org/current/userguide/best_practices.html).
+
+The end result of this should be a simpler more comprehensible build structure, faster builds, automatic avoidance of unnecessary work, quicker detection of improper configuration (such as unnecessary dependencies), and easy upgrades to future Gradle versions.

--- a/game-app/ai/build.gradle
+++ b/game-app/ai/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("triplea-java-library")
+}
+
 dependencies {
     implementation project(":game-app:game-core")
     implementation project(":lib:java-extras")

--- a/game-app/domain-data/build.gradle
+++ b/game-app/domain-data/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java-library'
+    id("triplea-java-library")
     id("maven-publish")
 }
 

--- a/game-app/game-core/build.gradle
+++ b/game-app/game-core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("triplea-java-library")
+}
+
 dependencies {
     implementation project(":game-app:domain-data")
     implementation project(":game-app:map-data")

--- a/game-app/game-headed/build.gradle
+++ b/game-app/game-headed/build.gradle
@@ -1,6 +1,8 @@
 import com.install4j.gradle.Install4jTask
+import de.undercouch.gradle.tasks.download.Download
 
 plugins {
+    id("triplea-java-library")
     id "application"
     alias(libs.plugins.shadow)
     alias(libs.plugins.install4j)
@@ -39,7 +41,7 @@ jar {
 }
 
 def assetsZipFileName = "game_headed_assets.zip"
-def downloadAssets = tasks.register("downloadAssets", de.undercouch.gradle.tasks.download.Download) {
+def downloadAssets = tasks.register("downloadAssets", Download) {
     src "https://github.com/triplea-game/assets/releases/download/47/$assetsZipFileName"
     dest project.layout.buildDirectory.dir("downloads/assets-zip")
     overwrite false

--- a/game-app/game-headless/build.gradle
+++ b/game-app/game-headless/build.gradle
@@ -2,6 +2,7 @@ import org.apache.tools.ant.filters.FixCrLfFilter
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
+    id("triplea-java-library")
     id "application"
     alias(libs.plugins.shadow)
 }

--- a/game-app/game-relay-server/build.gradle
+++ b/game-app/game-relay-server/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("triplea-java-library")
+}
+
 dependencies {
     implementation project(":lib:websocket-client")
     implementation project(":lib:websocket-server")

--- a/game-app/map-data/build.gradle
+++ b/game-app/map-data/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("triplea-java-library")
+}
+
 dependencies {
     implementation project(":lib:java-extras")
     implementation project(":lib:xml-reader")

--- a/game-app/smoke-testing/build.gradle
+++ b/game-app/smoke-testing/build.gradle
@@ -1,6 +1,7 @@
 import de.undercouch.gradle.tasks.download.Download
 
 plugins {
+    id("triplea-java-library")
     alias(libs.plugins.download)
 }
 

--- a/gradle/build-logic/failure-summary-plugin/build.gradle
+++ b/gradle/build-logic/failure-summary-plugin/build.gradle
@@ -10,3 +10,6 @@ gradlePlugin {
         }
     }
 }
+
+description = """This project creates a Gradle Settings plugin that lists all test failures in the console at the end of a failed build.  
+The failures are sorted alphabetically by project."""

--- a/gradle/build-logic/failure-summary-plugin/src/main/java/org/triplea/build/plugins/FailureSummaryPlugin.java
+++ b/gradle/build-logic/failure-summary-plugin/src/main/java/org/triplea/build/plugins/FailureSummaryPlugin.java
@@ -24,6 +24,7 @@ import java.util.Map;
  * This plugin sets up listeners to gather test failure information across all projects, and
  * report it at the end of a build.
  */
+@SuppressWarnings("UnstableApiUsage")
 public abstract class FailureSummaryPlugin implements Plugin<Settings> {
   @Inject
   protected abstract FlowScope getFlowScope();
@@ -88,7 +89,7 @@ public abstract class FailureSummaryPlugin implements Plugin<Settings> {
   public static abstract class FailureReporter implements FlowAction<FailureReporter.Params> {
     private static final Logger logger = Logging.getLogger(FailureReporter.class);
 
-    interface Params extends FlowParameters {
+    public interface Params extends FlowParameters {
       @ServiceReference
       Property<FailedTestsService> getFailedTestsService();
     }
@@ -99,10 +100,8 @@ public abstract class FailureSummaryPlugin implements Plugin<Settings> {
 
       if (!failedTestsByProject.isEmpty()) {
         failedTestsByProject.keySet().stream().sorted().forEach(projectName -> {
-          logger.warn("Failed tests for " + projectName + ":");
-          failedTestsByProject.get(projectName).stream().sorted().forEach(failedTest -> {
-            logger.warn(failedTest);
-          });
+          logger.warn("Failed tests for {}:", projectName);
+          failedTestsByProject.get(projectName).stream().sorted().forEach(logger::warn);
           logger.warn("");
         });
       }

--- a/gradle/build-logic/settings.gradle
+++ b/gradle/build-logic/settings.gradle
@@ -1,3 +1,0 @@
-rootProject.name = "build-logic"
-
-include("failure-summary-plugin")

--- a/gradle/build-logic/settings.gradle.kts
+++ b/gradle/build-logic/settings.gradle.kts
@@ -1,0 +1,22 @@
+@file:Suppress("UnstableApiUsage")
+
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+
+include("failure-summary-plugin", "triplea-java-library")

--- a/gradle/build-logic/triplea-java-library/build.gradle.kts
+++ b/gradle/build-logic/triplea-java-library/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation(libs.spotless)
+}
+
+description = """This project creates Gradle pre-compiled script plugins that define conventional project types used in the build.  
+This avoids the need for `subprojects` and `allprojects`, and keeps project configuration local."""

--- a/gradle/build-logic/triplea-java-library/src/main/kotlin/triplea-java-library.gradle.kts
+++ b/gradle/build-logic/triplea-java-library/src/main/kotlin/triplea-java-library.gradle.kts
@@ -1,0 +1,24 @@
+/*
+  This convention defines a standard TripleA java library project.
+  It applies the `java-library` plugin and applies universal configuration, code conventions, and sets up static analysis.
+*/
+
+plugins {
+    `java-library`
+    id("com.diffplug.spotless")
+}
+
+spotless {
+    format("allFiles") {
+        target("*")
+        targetExclude("gradlew.bat")
+        endWithNewline()
+        leadingTabsToSpaces()
+        trimTrailingWhitespace()
+    }
+
+    java {
+        googleJavaFormat()
+        removeUnusedImports()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ mockito-subclass = { module = "org.mockito:mockito-subclass", version.ref = "moc
 radiance-substance = { module = "org.pushing-pixels:radiance-substance", version.ref = "substance" }
 snakeyaml-engine = { module = "org.snakeyaml:snakeyaml-engine", version.ref = "snake-yaml" }
 sonatype-goodies-prefs = { module = "org.sonatype.goodies:goodies-prefs", version.ref = "sonatype-goodies-prefs" }
+spotless = { module = "com.diffplug.gradle.spotless:com.diffplug.gradle.spotless.gradle.plugin", version.ref = "spotless" }
 wiremock = { module = "com.github.tomakehurst:wiremock", version.ref = "wiremock" }
 wiremock-junit5 = { module = "ru.lanwen.wiremock:wiremock-junit5", version.ref = "wiremock-junit5" }
 xchart = { module = "org.knowm.xchart:xchart", version.ref = "xchart" }

--- a/http-clients/lobby-client/build.gradle
+++ b/http-clients/lobby-client/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java-library'
+    id("triplea-java-library")
     id("maven-publish")
 }
 

--- a/lib/feign-common/build.gradle
+++ b/lib/feign-common/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
-    id 'java-library'
+    id("triplea-java-library")
     id("maven-publish")
 }
 

--- a/lib/http-client-lib/build.gradle
+++ b/lib/http-client-lib/build.gradle
@@ -1,3 +1,0 @@
-dependencies {
-    implementation project(":game-app:domain-data")
-}

--- a/lib/java-extras/build.gradle
+++ b/lib/java-extras/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
-    id 'java-library'
+    id("triplea-java-library")
     id("maven-publish")
 }
 

--- a/lib/swing-lib-test-support/build.gradle
+++ b/lib/swing-lib-test-support/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("triplea-java-library")
+}
+
 description = "TripleA library for utilities and components that depend only on core java, javax.swing, and java.awt"
 
 dependencies {

--- a/lib/swing-lib/build.gradle
+++ b/lib/swing-lib/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("triplea-java-library")
+}
+
 description = "TripleA library for utilities and components that depend only on core java, javax.swing, and java.awt"
 
 dependencies {

--- a/lib/test-common/build.gradle
+++ b/lib/test-common/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("triplea-java-library")
+}
+
 description = "Test utility library, generic test utilities useful for TripleA projects"
 
 dependencies {

--- a/lib/websocket-client/build.gradle
+++ b/lib/websocket-client/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
-    id 'java-library'
+    id("triplea-java-library")
     id("maven-publish")
 }
 

--- a/lib/websocket-server/build.gradle
+++ b/lib/websocket-server/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("triplea-java-library")
+}
+
 dependencies {
     implementation project(":lib:feign-common")
     implementation project(":lib:java-extras")

--- a/lib/xml-reader/build.gradle
+++ b/lib/xml-reader/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("triplea-java-library")
+}
+
 dependencies {
     implementation project(":lib:java-extras")
 }


### PR DESCRIPTION
This creates a pre-compiled script plugin to apply common setup across all projects in the build.  Previously, this was done via an allprojects block.

This is a more idiomatic way to share configuration across multiple projects, and will enable future Gradle build acceleration features.  Though it adds additional lines of configuration to simple projects like /game-app/map-data vs. the previous setup, this is a worthwhile change.  

Gradle projects should "pull" configuration from conventions, not have configuration "pushed" into them from all/subprojects blocks.  This will future proof the build and make individual projects easier to change.