### PR TITLE
Refreshing board after tech advancement

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -906,6 +906,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                 .result
                 .ifPresent(
                     display -> {
+                      SwingUtilities.invokeLater(this.mapPanel::resetMap);
                       EventThreadJOptionPane.showOptionDialog(
                           TripleAFrame.this,
                           display,
@@ -916,7 +917,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                           new String[] {"OK"},
                           "OK",
                           getUiContext().getCountDownLatchHandler());
-                      this.mapPanel.resetMap();
                     }));
   }
 


### PR DESCRIPTION
Right now, if you go do your technology turn and discover things, the board doesn't actually update. So if changes in technology affect game pieces, they won't be updated unless the game is saved/reopened or if the icons are changed in size.

This push is a small fix that reloads the board after each tech turn, so that changes in tech are instantly reflected.