### PR TITLE
Quick-fix for the bias in the dice roller due to low-bit linearity issue in MT

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
@@ -29,10 +29,10 @@ public final class PlainRandomSource implements IRandomSource {
 
   @Override
   public int getRandom(final int max, final String annotation) {
-    checkArgument(max > 0, "max must be > 0 (%s)", annotation);
+    checkArgument(max > 0 && max < 4194303, "max must be > 0 and < 4194303 (%s)", annotation);
 
     synchronized (lock) {
-      return random.nextInt(max);
+      return random.nextInt(max * 512) / 512;
     }
   }
 }


### PR DESCRIPTION
See, for example, Vigna, "It Is High Time We Let Go Of The Mersenne Twister" (arXiv:1910.06437). TL;DR the two lowest bits fail TestU01 BigCrush's linear-complexity test. The original paper on MT explicitly says that the least significant six bits are much less well distributed than the full 32-bit output. 

This patch replaces the call to random (modulo max) with random (modulo max*512) then discards the low-order 9 bits.

A full fix could replace MT, but this minimal change is probably good enough. 

"Even paranoiacs have some real enemies." -- Delmore Schwartz

## Notes to Reviewer

- Single commit, single file.
- No UI changes.
- Manual testing: `./verify` passes on a clean branch (stashed unrelated working-tree changes before running).
- Rationale and citation are in the commit message.
- Open to replacing MT entirely as a follow-up, but kept this PR narrowly scoped to the bit-shift mitigation.
- I say "quick-fix" meaning that this hopefully should be quick to review, and not impact performance. Replacing the PRNG with something else will take much more serious review/test/performance considerations. IMHO (as a professional cryptographer) this dice rolling task does not need a cryptographically secure random number generator. But it's better to not use the low-order six bits of MT. I discard 9. 