### PR TITLE
Update test output: show test output only on failure

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,8 +69,29 @@ subprojects {
         useJUnitPlatform() {}
         testLogging {
             setExceptionFormat("full")
-            events("standardOut", "standardError", "skipped", "failed")
+            events("skipped", "failed")
         }
+
+        val outputByTest = mutableMapOf<String, StringBuilder>()
+
+        addTestOutputListener { descriptor, event ->
+            val key = "${descriptor.className}.${descriptor.name}"
+            outputByTest.getOrPut(key) { StringBuilder() }.append(event.message)
+        }
+
+        addTestListener(object : TestListener {
+            override fun beforeSuite(suite: TestDescriptor) {}
+            override fun afterSuite(suite: TestDescriptor, result: TestResult) {}
+            override fun beforeTest(testDescriptor: TestDescriptor) {}
+
+            override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {
+                val key = "${testDescriptor.className}.${testDescriptor.name}"
+                val output = outputByTest.remove(key)
+                if (result.resultType == TestResult.ResultType.FAILURE && !output.isNullOrEmpty()) {
+                    println("\n-- Output for ${testDescriptor.displayName} --\n$output")
+                }
+            }
+        })
     }
 
     extensions.getByType<CheckstyleExtension>().apply {


### PR DESCRIPTION
Adds gradle config to show stdout of tests only when they fail. This is equivalent to maven surefire behavior, which has a flag for the same style of test output. This dramatically reduces output when running tests.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
