### PR TITLE
RNG: Use "ThreadLocal random" to seed MersenneTwister instead of "System.millis + object identity"

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
@@ -2,6 +2,7 @@ package games.strategy.engine.random;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.math3.random.MersenneTwister;
@@ -12,8 +13,12 @@ import org.apache.commons.math3.random.RandomGenerator;
 public final class PlainRandomSource implements IRandomSource {
   private final Object lock = new Object();
 
+  // ThreadLocalRandom provides well-distributed seeds even when many instances are created
+  // concurrently (e.g. AI battle simulators). MersenneTwister's no-arg constructor seeds from
+  // currentTimeMillis + identityHashCode, which can collide within the same millisecond and cause
+  // multiple simulators to produce identical dice sequences.
   @GuardedBy("lock")
-  private final RandomGenerator random = new MersenneTwister();
+  private final RandomGenerator random = new MersenneTwister(ThreadLocalRandom.current().nextLong());
 
   @Override
   public int[] getRandom(final int max, final int count, final String annotation) {


### PR DESCRIPTION
This issue was flagged by another person that ran Claude and found that the constructor of MersenneTwister is using millisecond precision combined with object identity. Since we run simulations concurrently,  the millisecond is often the same. So, we *can* have seed collisions as the object identity is not guaranteed to be unique. By switching to ThreadLocal random, we are using Java's built in mechanism to create well spaced seed values, designed for concurrency.

We don't really expect to see a big impact, but we do eliminate the potential for a random-number-generator to be spawned with the same seed.