### PR TITLE
RNG: Switch from MersenneTwister to SplitMix64 (SplittableRandom)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
@@ -19,6 +19,9 @@ public final class PlainRandomSource implements IRandomSource {
   /// Documentation:
   /// - https://docs.oracle.com/javase/8/docs/api/java/util/SplittableRandom.html
   ///
+  /// Note: @GuardedBy("lock") remains for correctness. The cost to acquire
+  /// the lock when not under contention is close to free.
+  ///
   @GuardedBy("lock")
   private final SplittableRandom random = new SplittableRandom();
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
@@ -2,18 +2,25 @@ package games.strategy.engine.random;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.SplittableRandom;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.math3.random.MersenneTwister;
-import org.apache.commons.math3.random.RandomGenerator;
 
 /** A source of random numbers that uses a pseudorandom number generator. */
 @ThreadSafe
 public final class PlainRandomSource implements IRandomSource {
   private final Object lock = new Object();
 
+  /// SplittableRandom (AKA splitmix64) is selected for reasons:
+  /// - small state (8 bytes)
+  /// - good cache performance undur concurrent simulation
+  /// - passes BigCrush,
+  /// - no LSB quality issues
+  /// Documentation:
+  /// - https://docs.oracle.com/javase/8/docs/api/java/util/SplittableRandom.html
+  ///
   @GuardedBy("lock")
-  private final RandomGenerator random = new MersenneTwister();
+  private final SplittableRandom random = new SplittableRandom();
 
   @Override
   public int[] getRandom(final int max, final int count, final String annotation) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
@@ -13,7 +13,7 @@ public final class PlainRandomSource implements IRandomSource {
 
   /// SplittableRandom (AKA splitmix64) is selected for reasons:
   /// - small state (8 bytes)
-  /// - good cache performance undur concurrent simulation
+  /// - good cache performance under concurrent simulation
   /// - passes BigCrush,
   /// - no LSB quality issues
   /// Documentation:


### PR DESCRIPTION
This new RNG is faster and uses a smaller state size compared to Mersenne Twister (8 bytes vs 2,496 bytes)

Biggest reasoning to transitioning is that smaller state size, slightly higher quality RNG.

Xoshiro256++ was consider but SplitMix has an even smaller state size (8 bytes vs 32), and is designed for parallism while Xoshiro256++ is not (it's a pretty close call between the two)

Future updates:
* The splittable RNG might be something we want to expose directly to AI so that it can use the 'split()' method to
spawn new RNGS.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
