### PR TITLE
feature(Lobby): Auto reconnect to lobby

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
@@ -50,6 +50,9 @@ public class LobbyChatTransmitter implements ChatTransmitter {
     playerToLobbyConnection.addMessageListener(
         PlayerSlapReceivedMessage.TYPE, message -> handleSlapMessage(chatClient, message));
 
+    playerToLobbyConnection.addConnectionResetListener(
+        playerToLobbyConnection::sendConnectToChatMessage);
+
     playerToLobbyConnection.sendConnectToChatMessage();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -11,7 +11,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
@@ -114,7 +113,6 @@ public final class BackgroundTaskRunner {
       final Consumer<T> runOnEdtBeforeDialogClose,
       final Class<E> exceptionType)
       throws E, InterruptedException {
-    checkState(SwingUtilities.isEventDispatchThread());
     checkNotNull(message);
     checkNotNull(backgroundAction);
     checkNotNull(exceptionType);

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
@@ -29,9 +29,9 @@ import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.triplea.swing.SwingComponents;
 import lombok.Setter;
 import org.triplea.game.client.HeadedGameRunner;
+import org.triplea.swing.SwingComponents;
 
 /** This class provides a way to switch between different ISetupPanel displays. */
 @RequiredArgsConstructor

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
@@ -21,6 +21,7 @@ import games.strategy.engine.lobby.client.login.LobbyLogin;
 import games.strategy.engine.lobby.client.login.LoginMode;
 import games.strategy.engine.lobby.client.login.LoginResult;
 import games.strategy.engine.lobby.client.ui.LobbyFrame;
+import games.strategy.engine.lobby.client.ui.LobbyModel;
 import java.awt.Dimension;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -28,6 +29,7 @@ import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.triplea.swing.SwingComponents;
 import lombok.Setter;
 import org.triplea.game.client.HeadedGameRunner;
 
@@ -132,7 +134,11 @@ public class HeadedServerSetupModel {
   }
 
   private void showLobbyWindow(final LoginResult loginResult) {
-    final LobbyFrame lobbyFrame = new LobbyFrame(loginResult);
+    final var lobbyModel =
+        new LobbyModel(
+            loginResult,
+            error -> SwingComponents.showError(null, "Error communicating with lobby", error));
+    final LobbyFrame lobbyFrame = new LobbyFrame(lobbyModel);
     MainFrame.hide();
     lobbyFrame.setVisible(true);
   }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -17,7 +17,6 @@ import lombok.Getter;
 import org.triplea.game.client.HeadedGameRunner;
 import org.triplea.http.client.web.socket.WebSocket;
 import org.triplea.sound.ClipPlayer;
-import org.triplea.swing.DialogBuilder;
 import org.triplea.swing.SwingComponents;
 
 /** The top-level frame window for the lobby client UI. */
@@ -42,23 +41,15 @@ public class LobbyFrame extends JFrame implements QuitHandler {
         new WebSocket.ReconnectionHandler() {
           @Override
           public void onReconnecting(final int attempt) {
-            // TODO: show retrying window here
+            // TODO: Show a non-blocking reconnect overlay displaying attempt number.
+            // The overlay's "Disconnect & Exit" button should call LobbyFrame.this::shutdown,
+            // which chains to connection.close() → reconnect thread interrupt.
+            // No separate handle is needed; shutdown() IS the abort.
           }
 
           @Override
           public void onReconnected() {
-            // TODO: handle reconnection success here
-          }
-
-          @Override
-          public void onReconnectFailed() {
-            // TODO: handle retrying failed here
-            DialogBuilder.builder()
-                .parent(LobbyFrame.this)
-                .title("Connection to Lobby Lost")
-                .errorMessage("Could not reconnect to the lobby after several attempts.")
-                .showDialog();
-            shutdown();
+            // TODO: handle reconnection success here — dismiss the reconnect overlay
           }
         });
 

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -15,6 +15,7 @@ import javax.swing.JFrame;
 import javax.swing.JSplitPane;
 import lombok.Getter;
 import org.triplea.game.client.HeadedGameRunner;
+import org.triplea.http.client.web.socket.WebSocket;
 import org.triplea.sound.ClipPlayer;
 import org.triplea.swing.DialogBuilder;
 import org.triplea.swing.SwingComponents;
@@ -36,16 +37,30 @@ public class LobbyFrame extends JFrame implements QuitHandler {
     final var connection = lobbyModel.getConnection();
 
     setJMenuBar(new LobbyMenu(this, loginResult, connection));
-    connection.addConnectionTerminatedListener(
-        reason -> {
-          DialogBuilder.builder()
-              .parent(this)
-              .title("Connection to Lobby Closed")
-              .errorMessage("Connection closed: " + reason)
-              .showDialog();
-          shutdown();
-        });
     connection.addConnectionClosedListener(this::shutdown);
+    connection.addReconnectionListener(
+        new WebSocket.ReconnectionHandler() {
+          @Override
+          public void onReconnecting(final int attempt) {
+            // TODO: show retrying window here
+          }
+
+          @Override
+          public void onReconnected() {
+            // TODO: handle reconnection success here
+          }
+
+          @Override
+          public void onReconnectFailed() {
+            // TODO: handle retrying failed here
+            DialogBuilder.builder()
+                .parent(LobbyFrame.this)
+                .title("Connection to Lobby Lost")
+                .errorMessage("Could not reconnect to the lobby after several attempts.")
+                .showDialog();
+            shutdown();
+          }
+        });
 
     final ChatMessagePanel chatMessagePanel =
         new ChatMessagePanel(lobbyModel.getChat(), ChatSoundProfile.LOBBY, new ClipPlayer());

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -37,19 +37,17 @@ public class LobbyFrame extends JFrame implements QuitHandler {
 
     setJMenuBar(new LobbyMenu(this, loginResult, connection));
     connection.addConnectionClosedListener(this::shutdown);
+    final var reconnectOverlay = new ReconnectOverlay(this, this::shutdown);
     connection.addReconnectionListener(
         new WebSocket.ReconnectionHandler() {
           @Override
           public void onReconnecting(final int attempt) {
-            // TODO: Show a non-blocking reconnect overlay displaying attempt number.
-            // The overlay's "Disconnect & Exit" button should call LobbyFrame.this::shutdown,
-            // which chains to connection.close() → reconnect thread interrupt.
-            // No separate handle is needed; shutdown() IS the abort.
+            reconnectOverlay.show(attempt);
           }
 
           @Override
           public void onReconnected() {
-            // TODO: handle reconnection success here — dismiss the reconnect overlay
+            reconnectOverlay.dismiss();
           }
         });
 

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -64,8 +64,7 @@ public class LobbyFrame extends JFrame implements QuitHandler {
         clickedChatter ->
             LobbyPlayerActions.buildFor(this, loginResult, clickedChatter, connection));
 
-    final var tableModel =
-        new LobbyGameTableModel(loginResult.isModerator(), gameListingModel);
+    final var tableModel = new LobbyGameTableModel(loginResult.isModerator(), gameListingModel);
     final LobbyGamePanel gamePanel =
         new LobbyGamePanel(this, loginResult, tableModel, gameListingModel);
 

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -1,33 +1,20 @@
 package games.strategy.engine.lobby.client.ui;
 
-import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.ChatMessagePanel;
 import games.strategy.engine.chat.ChatMessagePanel.ChatSoundProfile;
 import games.strategy.engine.chat.ChatPlayerPanel;
-import games.strategy.engine.chat.ChatTransmitter;
-import games.strategy.engine.chat.LobbyChatTransmitter;
-import games.strategy.engine.lobby.client.login.LoginResult;
-import games.strategy.engine.lobby.client.ui.action.BanPlayerModeratorAction;
-import games.strategy.engine.lobby.client.ui.action.DisconnectPlayerModeratorAction;
-import games.strategy.engine.lobby.client.ui.action.MutePlayerAction;
-import games.strategy.engine.lobby.client.ui.action.player.info.ShowPlayerInformationAction;
 import games.strategy.triplea.EngineImageLoader;
-import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.QuitHandler;
 import games.strategy.triplea.ui.menubar.LobbyMenu;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.util.List;
 import java.util.Optional;
-import javax.swing.Action;
 import javax.swing.JFrame;
 import javax.swing.JSplitPane;
 import lombok.Getter;
-import org.triplea.domain.data.ChatParticipant;
 import org.triplea.game.client.HeadedGameRunner;
-import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
 import org.triplea.sound.ClipPlayer;
 import org.triplea.swing.DialogBuilder;
 import org.triplea.swing.SwingComponents;
@@ -36,25 +23,20 @@ import org.triplea.swing.SwingComponents;
 public class LobbyFrame extends JFrame implements QuitHandler {
   private static final long serialVersionUID = -388371674076362572L;
 
-  @Getter private final LoginResult loginResult;
-  private final ChatTransmitter chatTransmitter;
-  private final LobbyGameTableModel tableModel;
+  @Getter private final LobbyModel lobbyModel;
 
-  public LobbyFrame(final LoginResult loginResult) {
+  public LobbyFrame(final LobbyModel lobbyModel) {
     super("TripleA Lobby");
+    this.lobbyModel = lobbyModel;
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     SwingComponents.addWindowClosedListener(this, HeadedGameRunner::exitGameIfNoWindowsVisible);
     setIconImage(EngineImageLoader.loadFrameIcon());
-    this.loginResult = loginResult;
 
-    PlayerToLobbyConnection playerToLobbyConnection =
-        new PlayerToLobbyConnection(
-            ClientSetting.lobbyUri.getValueOrThrow(),
-            loginResult.getApiKey(),
-            error -> SwingComponents.showError(null, "Error communicating with lobby", error));
+    final var loginResult = lobbyModel.getLoginResult();
+    final var connection = lobbyModel.getConnection();
 
-    setJMenuBar(new LobbyMenu(this, loginResult, playerToLobbyConnection));
-    playerToLobbyConnection.addConnectionTerminatedListener(
+    setJMenuBar(new LobbyMenu(this, loginResult, connection));
+    connection.addConnectionTerminatedListener(
         reason -> {
           DialogBuilder.builder()
               .parent(this)
@@ -63,24 +45,24 @@ public class LobbyFrame extends JFrame implements QuitHandler {
               .showDialog();
           shutdown();
         });
-    playerToLobbyConnection.addConnectionClosedListener(this::shutdown);
+    connection.addConnectionClosedListener(this::shutdown);
 
-    chatTransmitter = new LobbyChatTransmitter(playerToLobbyConnection, loginResult.getUsername());
-    final Chat chat = new Chat(chatTransmitter);
     final ChatMessagePanel chatMessagePanel =
-        new ChatMessagePanel(chat, ChatSoundProfile.LOBBY, new ClipPlayer());
+        new ChatMessagePanel(lobbyModel.getChat(), ChatSoundProfile.LOBBY, new ClipPlayer());
     Optional.ofNullable(loginResult.getLoginMessage())
         .ifPresent(chatMessagePanel::addServerMessage);
-    final ChatPlayerPanel chatPlayers = new ChatPlayerPanel(chat);
+
+    final ChatPlayerPanel chatPlayers = new ChatPlayerPanel(lobbyModel.getChat());
     chatPlayers.setPreferredSize(new Dimension(200, 600));
     chatPlayers.addActionFactory(
         clickedChatter ->
-            lobbyPlayerRightClickMenuActions(
-                this, loginResult, clickedChatter, playerToLobbyConnection));
+            LobbyPlayerActions.buildFor(this, loginResult, clickedChatter, connection));
 
-    tableModel = new LobbyGameTableModel(loginResult.isModerator(), playerToLobbyConnection);
+    final var gameListingModel = lobbyModel.getGameListingModel();
+    final var tableModel =
+        new LobbyGameTableModel(loginResult.isModerator(), gameListingModel);
     final LobbyGamePanel gamePanel =
-        new LobbyGamePanel(this, loginResult, tableModel, playerToLobbyConnection);
+        new LobbyGamePanel(this, loginResult, tableModel, gameListingModel);
 
     final JSplitPane leftSplit = new JSplitPane();
     leftSplit.setOrientation(JSplitPane.VERTICAL_SPLIT);
@@ -107,58 +89,11 @@ public class LobbyFrame extends JFrame implements QuitHandler {
         });
   }
 
-  private static List<Action> lobbyPlayerRightClickMenuActions(
-      JFrame parentWindow,
-      LoginResult loginResult,
-      ChatParticipant clickedOn,
-      PlayerToLobbyConnection playerToLobbyConnection) {
-    if (clickedOn.getUserName().equals(loginResult.getUsername())) {
-      return List.of();
-    }
-
-    final var showPlayerInformationAction =
-        ShowPlayerInformationAction.builder()
-            .parent(parentWindow)
-            .playerChatId(clickedOn.getPlayerChatId())
-            .playerName(clickedOn.getUserName())
-            .playerToLobbyConnection(playerToLobbyConnection)
-            .build()
-            .toSwingAction();
-
-    if (!loginResult.isModerator()) {
-      return List.of(showPlayerInformationAction);
-    }
-    return List.of(
-        showPlayerInformationAction,
-        MutePlayerAction.builder()
-            .parent(parentWindow)
-            .playerChatId(clickedOn.getPlayerChatId())
-            .playerToLobbyConnection(playerToLobbyConnection)
-            .playerName(clickedOn.getUserName().getValue())
-            .build()
-            .toSwingAction(),
-        DisconnectPlayerModeratorAction.builder()
-            .parent(parentWindow)
-            .playerToLobbyConnection(playerToLobbyConnection)
-            .playerChatId(clickedOn.getPlayerChatId())
-            .userName(clickedOn.getUserName())
-            .build()
-            .toSwingAction(),
-        BanPlayerModeratorAction.builder()
-            .parent(parentWindow)
-            .playerToLobbyConnection(playerToLobbyConnection)
-            .playerChatIdToBan(clickedOn.getPlayerChatId())
-            .playerName(clickedOn.getUserName().getValue())
-            .build()
-            .toSwingAction());
-  }
-
   @Override
   public boolean shutdown() {
     setVisible(false);
     dispose();
-    chatTransmitter.disconnect();
-    tableModel.shutdown();
+    lobbyModel.shutdown();
     return true;
   }
 }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -37,6 +37,7 @@ public class LobbyFrame extends JFrame implements QuitHandler {
 
     setJMenuBar(new LobbyMenu(this, loginResult, connection));
     connection.addConnectionClosedListener(this::shutdown);
+    final var gameListingModel = lobbyModel.getGameListingModel();
     final var reconnectOverlay = new ReconnectOverlay(this, this::shutdown);
     connection.addReconnectionListener(
         new WebSocket.ReconnectionHandler() {
@@ -47,6 +48,7 @@ public class LobbyFrame extends JFrame implements QuitHandler {
 
           @Override
           public void onReconnected() {
+            gameListingModel.refresh();
             reconnectOverlay.dismiss();
           }
         });
@@ -62,7 +64,6 @@ public class LobbyFrame extends JFrame implements QuitHandler {
         clickedChatter ->
             LobbyPlayerActions.buildFor(this, loginResult, clickedChatter, connection));
 
-    final var gameListingModel = lobbyModel.getGameListingModel();
     final var tableModel =
         new LobbyGameTableModel(loginResult.isModerator(), gameListingModel);
     final LobbyGamePanel gamePanel =

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import javax.swing.SwingUtilities;
 import org.triplea.http.client.lobby.game.lobby.watcher.LobbyGameListing;
 import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
 import org.triplea.http.client.web.socket.messages.envelopes.game.listing.LobbyGameRemovedMessage;
@@ -82,6 +83,24 @@ class LobbyGameListingModel {
 
   void addChangeListener(final Runnable listener) {
     changeListeners.add(listener);
+  }
+
+  /**
+   * Clears the current game list and re-fetches it from the server. Called after a successful
+   * reconnect to remove stale entries.
+   *
+   * <p>The network fetch runs on the calling thread; the list mutation and table notification are
+   * then posted to the EDT so that Swing never observes a cleared list with a stale row count.
+   */
+  void refresh() {
+    final List<LobbyGameListing> freshListing = connection.fetchGameListing();
+    SwingUtilities.invokeLater(
+        () -> {
+          games.clear();
+          freshListing.forEach(this::updateGame);
+          // Notify in case freshListing was empty (updateGame won't fire in that case).
+          notifyListeners();
+        });
   }
 
   private void notifyListeners() {

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.lobby.client.ui;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.SwingUtilities;
@@ -19,7 +18,7 @@ import org.triplea.lobby.common.LobbyGameUpdateListener;
 class LobbyGameListingModel {
   private final PlayerToLobbyConnection connection;
   private final List<LobbyGameListing> games = new CopyOnWriteArrayList<>();
-  private final List<Runnable> changeListeners = new ArrayList<>();
+  private final List<Runnable> changeListeners = new CopyOnWriteArrayList<>();
 
   private final LobbyGameUpdateListener lobbyGameBroadcaster =
       new LobbyGameUpdateListener() {

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
@@ -1,0 +1,120 @@
+package games.strategy.engine.lobby.client.ui;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.triplea.http.client.lobby.game.lobby.watcher.LobbyGameListing;
+import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
+import org.triplea.http.client.web.socket.messages.envelopes.game.listing.LobbyGameRemovedMessage;
+import org.triplea.http.client.web.socket.messages.envelopes.game.listing.LobbyGameUpdatedMessage;
+import org.triplea.lobby.common.GameDescription;
+import org.triplea.lobby.common.LobbyGameUpdateListener;
+
+/**
+ * Pure-Java model for the lobby game list. Owns the connection message listeners, the live game
+ * list, and all network operations (boot / shutdown-signal). Has no Swing dependency.
+ */
+class LobbyGameListingModel {
+  private final PlayerToLobbyConnection connection;
+  private final List<LobbyGameListing> games = new CopyOnWriteArrayList<>();
+  private final List<Runnable> changeListeners = new ArrayList<>();
+
+  private final LobbyGameUpdateListener lobbyGameBroadcaster =
+      new LobbyGameUpdateListener() {
+        @Override
+        public void gameUpdated(final LobbyGameListing lobbyGameListing) {
+          updateGame(lobbyGameListing);
+        }
+
+        @Override
+        public void gameRemoved(final String gameId) {
+          removeGame(gameId);
+        }
+      };
+
+  LobbyGameListingModel(final PlayerToLobbyConnection connection) {
+    this.connection = connection;
+
+    connection.addMessageListener(
+        LobbyGameUpdatedMessage.TYPE,
+        msg -> lobbyGameBroadcaster.gameUpdated(msg.getLobbyGameListing()));
+
+    connection.addMessageListener(
+        LobbyGameRemovedMessage.TYPE,
+        msg -> lobbyGameBroadcaster.gameRemoved(msg.getGameId()));
+
+    connection.fetchGameListing().forEach(lobbyGameBroadcaster::gameUpdated);
+  }
+
+  @VisibleForTesting
+  LobbyGameUpdateListener getLobbyGameBroadcaster() {
+    return lobbyGameBroadcaster;
+  }
+
+  int getRowCount() {
+    return games.size();
+  }
+
+  GameDescription getGameDescriptionForRow(final int i) {
+    return GameDescription.fromLobbyGame(games.get(i).getLobbyGame());
+  }
+
+  LobbyGameListing getGameListingForRow(final int i) {
+    return games.get(i);
+  }
+
+  String getGameIdForRow(final int i) {
+    return games.get(i).getGameId();
+  }
+
+  void bootGame(final String gameId) {
+    connection.bootGame(gameId);
+  }
+
+  void sendShutdownRequest(final String gameId) {
+    connection.sendShutdownRequest(gameId);
+  }
+
+  PlayerToLobbyConnection getConnection() {
+    return connection;
+  }
+
+  void addChangeListener(final Runnable listener) {
+    changeListeners.add(listener);
+  }
+
+  private void notifyListeners() {
+    changeListeners.forEach(Runnable::run);
+  }
+
+  private void updateGame(final LobbyGameListing lobbyGameListing) {
+    final LobbyGameListing toReplace = findGame(lobbyGameListing.getGameId());
+    if (toReplace == null) {
+      games.add(lobbyGameListing);
+    } else {
+      final int replaceIndex = games.indexOf(toReplace);
+      games.set(replaceIndex, lobbyGameListing);
+    }
+    notifyListeners();
+  }
+
+  private void removeGame(final String gameId) {
+    if (gameId == null) {
+      return;
+    }
+    final LobbyGameListing gameToRemove = findGame(gameId);
+    if (gameToRemove != null) {
+      games.remove(gameToRemove);
+      notifyListeners();
+    }
+  }
+
+  private LobbyGameListing findGame(final String gameId) {
+    return games.stream()
+        .filter(game -> game.getGameId().equals(gameId))
+        .findFirst()
+        .orElse(null);
+  }
+}
+

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
@@ -42,8 +42,7 @@ class LobbyGameListingModel {
         msg -> lobbyGameBroadcaster.gameUpdated(msg.getLobbyGameListing()));
 
     connection.addMessageListener(
-        LobbyGameRemovedMessage.TYPE,
-        msg -> lobbyGameBroadcaster.gameRemoved(msg.getGameId()));
+        LobbyGameRemovedMessage.TYPE, msg -> lobbyGameBroadcaster.gameRemoved(msg.getGameId()));
 
     connection.fetchGameListing().forEach(lobbyGameBroadcaster::gameUpdated);
   }
@@ -130,10 +129,6 @@ class LobbyGameListingModel {
   }
 
   private LobbyGameListing findGame(final String gameId) {
-    return games.stream()
-        .filter(game -> game.getGameId().equals(gameId))
-        .findFirst()
-        .orElse(null);
+    return games.stream().filter(game -> game.getGameId().equals(gameId)).findFirst().orElse(null);
   }
 }
-

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -25,8 +25,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableRowSorter;
-import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
-import org.triplea.lobby.common.GameDescription;
 import org.triplea.swing.MouseListenerBuilder;
 import org.triplea.swing.SwingAction;
 
@@ -35,19 +33,19 @@ class LobbyGamePanel extends JPanel {
   private final JFrame parent;
   private final JButton joinGameButton;
   private final LobbyGameTableModel gameTableModel;
+  private final LobbyGameListingModel gameListingModel;
   private final LoginResult loginResult;
   private final JTable gameTable;
-  private final PlayerToLobbyConnection playerToLobbyConnection;
 
   LobbyGamePanel(
       final JFrame parent,
       final LoginResult loginResult,
       final LobbyGameTableModel lobbyGameTableModel,
-      final PlayerToLobbyConnection playerToLobbyConnection) {
+      final LobbyGameListingModel gameListingModel) {
     this.parent = parent;
     this.loginResult = loginResult;
     this.gameTableModel = lobbyGameTableModel;
-    this.playerToLobbyConnection = playerToLobbyConnection;
+    this.gameListingModel = gameListingModel;
 
     final JButton hostGameButton = new JButton("Host Game");
     joinGameButton = new JButton("Join Game");
@@ -60,7 +58,7 @@ class LobbyGamePanel extends JPanel {
               final TableCellRenderer renderer, final int rowIndex, final int colIndex) {
 
             final Component component = super.prepareRenderer(renderer, rowIndex, colIndex);
-            final GameDescription gameDescription =
+            final var gameDescription =
                 lobbyGameTableModel.get(convertRowIndexToModel(rowIndex));
             component.setFont(
                 gameDescription.isBot()
@@ -185,7 +183,7 @@ class LobbyGamePanel extends JPanel {
                     () ->
                         gameTableModel.getGameListingForRow(
                             gameTable.convertRowIndexToModel(gameTable.getSelectedRow())))
-                .playerToLobbyConnection(playerToLobbyConnection)
+                .playerToLobbyConnection(gameListingModel.getConnection())
                 .build()
                 .buildSwingAction())
         .forEach(menu::add);
@@ -194,7 +192,7 @@ class LobbyGamePanel extends JPanel {
       menu.addSeparator();
       List.of(
               SwingAction.of("Boot Game", e -> bootGame()),
-              SwingAction.of("Shutdown", e -> shutdown()))
+              SwingAction.of("Shutdown", e -> shutdownGame()))
           .forEach(menu::add);
     }
 
@@ -209,8 +207,7 @@ class LobbyGamePanel extends JPanel {
       return;
     }
     // we sort the table, so get the correct index
-    final GameDescription description =
-        gameTableModel.get(gameTable.convertRowIndexToModel(selectedIndex));
+    final var description = gameTableModel.get(gameTable.convertRowIndexToModel(selectedIndex));
     GameProcess.joinGame(description, loginResult.getUsername());
   }
 
@@ -247,12 +244,13 @@ class LobbyGamePanel extends JPanel {
       return;
     }
 
-    gameTableModel.bootGame(gameTable.convertRowIndexToModel(selectedIndex));
+    final String gameId = gameTableModel.getGameIdForRow(gameTable.convertRowIndexToModel(selectedIndex));
+    gameListingModel.bootGame(gameId);
     JOptionPane.showMessageDialog(
         null, "The game you selected has been disconnected from the lobby.");
   }
 
-  private void shutdown() {
+  private void shutdownGame() {
     final int selectedIndex = gameTable.getSelectedRow();
     if (selectedIndex == -1) {
       return;
@@ -269,7 +267,7 @@ class LobbyGamePanel extends JPanel {
 
     final String gameId =
         gameTableModel.getGameIdForRow(gameTable.convertRowIndexToModel(selectedIndex));
-    playerToLobbyConnection.sendShutdownRequest(gameId);
+    gameListingModel.sendShutdownRequest(gameId);
     JOptionPane.showMessageDialog(parent, "The game you selected was sent a shutdown signal");
   }
 }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -58,8 +58,7 @@ class LobbyGamePanel extends JPanel {
               final TableCellRenderer renderer, final int rowIndex, final int colIndex) {
 
             final Component component = super.prepareRenderer(renderer, rowIndex, colIndex);
-            final var gameDescription =
-                lobbyGameTableModel.get(convertRowIndexToModel(rowIndex));
+            final var gameDescription = lobbyGameTableModel.get(convertRowIndexToModel(rowIndex));
             component.setFont(
                 gameDescription.isBot()
                     ? UIManager.getDefaults().getFont("Table.font").deriveFont(Font.ITALIC)
@@ -244,7 +243,8 @@ class LobbyGamePanel extends JPanel {
       return;
     }
 
-    final String gameId = gameTableModel.getGameIdForRow(gameTable.convertRowIndexToModel(selectedIndex));
+    final String gameId =
+        gameTableModel.getGameIdForRow(gameTable.convertRowIndexToModel(selectedIndex));
     gameListingModel.bootGame(gameId);
     JOptionPane.showMessageDialog(
         null, "The game you selected has been disconnected from the lobby.");

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -6,15 +6,9 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
-import org.triplea.domain.data.LobbyGame;
 import org.triplea.http.client.lobby.game.lobby.watcher.LobbyGameListing;
-import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
-import org.triplea.http.client.web.socket.messages.envelopes.game.listing.LobbyGameRemovedMessage;
-import org.triplea.http.client.web.socket.messages.envelopes.game.listing.LobbyGameUpdatedMessage;
 import org.triplea.lobby.common.GameDescription;
 import org.triplea.lobby.common.LobbyGameUpdateListener;
 
@@ -34,102 +28,39 @@ class LobbyGameTableModel extends AbstractTableModel {
   }
 
   private final boolean admin;
+  private final LobbyGameListingModel listingModel;
 
-  // these must only be accessed in the swing event thread
-  private final List<LobbyGameListing> gameList = new CopyOnWriteArrayList<>();
-  private final PlayerToLobbyConnection playerToLobbyConnection;
-  private final LobbyGameUpdateListener lobbyGameBroadcaster =
-      new LobbyGameUpdateListener() {
-        @Override
-        public void gameUpdated(final LobbyGameListing lobbyGameListing) {
-          updateGame(lobbyGameListing);
-        }
-
-        @Override
-        public void gameRemoved(final String gameId) {
-          removeGame(gameId);
-        }
-      };
-
-  LobbyGameTableModel(final boolean admin, final PlayerToLobbyConnection playerToLobbyConnection) {
+  LobbyGameTableModel(final boolean admin, final LobbyGameListingModel listingModel) {
     this.admin = admin;
-    this.playerToLobbyConnection = playerToLobbyConnection;
-
-    playerToLobbyConnection.addMessageListener(
-        LobbyGameUpdatedMessage.TYPE,
-        lobbyGameUpdatedMessage ->
-            lobbyGameBroadcaster.gameUpdated(lobbyGameUpdatedMessage.getLobbyGameListing()));
-
-    playerToLobbyConnection.addMessageListener(
-        LobbyGameRemovedMessage.TYPE,
-        lobbyGameRemovedMessage ->
-            lobbyGameBroadcaster.gameRemoved(lobbyGameRemovedMessage.getGameId()));
-
-    playerToLobbyConnection.fetchGameListing().forEach(lobbyGameBroadcaster::gameUpdated);
-  }
-
-  private void removeGame(final String gameId) {
-    SwingUtilities.invokeLater(
-        () -> {
-          if (gameId == null) {
-            return;
-          }
-
-          final LobbyGameListing gameToRemove = findGame(gameId);
-          if (gameToRemove != null) {
-            final int index = gameList.indexOf(gameToRemove);
-            gameList.remove(gameToRemove);
-            fireTableRowsDeleted(index, index);
-          }
-        });
-  }
-
-  private LobbyGameListing findGame(final String gameId) {
-    return gameList.stream()
-        .filter(game -> game.getGameId().equals(gameId))
-        .findFirst()
-        .orElse(null);
+    this.listingModel = listingModel;
+    listingModel.addChangeListener(
+        () -> SwingUtilities.invokeLater(this::fireTableDataChanged));
   }
 
   @VisibleForTesting
   LobbyGameUpdateListener getLobbyGameBroadcaster() {
-    return lobbyGameBroadcaster;
+    return listingModel.getLobbyGameBroadcaster();
   }
 
   GameDescription get(final int i) {
-    return GameDescription.fromLobbyGame(gameList.get(i).getLobbyGame());
+    return listingModel.getGameDescriptionForRow(i);
   }
 
   LobbyGameListing getGameListingForRow(final int i) {
-    return gameList.get(i);
+    return listingModel.getGameListingForRow(i);
   }
 
   String getGameIdForRow(final int i) {
-    return gameList.get(i).getGameId();
+    return listingModel.getGameIdForRow(i);
   }
 
-  private void updateGame(final LobbyGameListing lobbyGameListing) {
-    SwingUtilities.invokeLater(
-        () -> {
-          final LobbyGameListing toReplace = findGame(lobbyGameListing.getGameId());
-          if (toReplace == null) {
-            gameList.add(lobbyGameListing);
-            fireTableRowsInserted(getRowCount() - 1, getRowCount() - 1);
-          } else {
-            final int replaceIndex = gameList.indexOf(toReplace);
-            gameList.set(replaceIndex, lobbyGameListing);
-            fireTableRowsUpdated(replaceIndex, replaceIndex);
-          }
-        });
+  int getColumnIndex(final Column column) {
+    return column.ordinal();
   }
 
   @Override
   public String getColumnName(final int column) {
     return Column.values()[column].toString();
-  }
-
-  int getColumnIndex(final Column column) {
-    return column.ordinal();
   }
 
   @Override
@@ -142,39 +73,32 @@ class LobbyGameTableModel extends AbstractTableModel {
 
   @Override
   public int getRowCount() {
-    return gameList.size();
+    return listingModel.getRowCount();
   }
 
   @Override
   public Object getValueAt(final int rowIndex, final int columnIndex) {
     final Column column = Column.values()[columnIndex];
-    final LobbyGame description = gameList.get(rowIndex).getLobbyGame();
-    switch (column) {
-      case Host:
-        return description.getHostName();
-      case Round:
-        final int round = description.getGameRound();
-        return round == 0 ? "-" : String.valueOf(round);
-      case Name:
-        return description.getMapName();
-      case Players:
-        return description.getPlayerCount();
-      case P:
-        return (description.getPassworded() ? "*" : "");
-      case Status:
-        // Note, we update status client side to avoid a headless game from reporting
-        // a new status when players leave or join. We expect a player count of 0 in
-        // headless games if there are no players connected.
-        return description.getPlayerCount() == 0 ? "Available" : description.getStatus();
-      case Comments:
-        return description.getComments();
-      case Started:
-        return formatBotStartTime(description.getEpochMilliTimeStarted());
-      case UUID:
-        return gameList.get(rowIndex).getGameId();
-      default:
-        throw new IllegalStateException("Unknown column: " + column);
-    }
+    final var lobbyGame = listingModel.getGameListingForRow(rowIndex).getLobbyGame();
+    return switch (column) {
+      case Host -> lobbyGame.getHostName();
+      case Round -> {
+        final int round = lobbyGame.getGameRound();
+        yield round == 0 ? "-" : String.valueOf(round);
+      }
+      case Name -> lobbyGame.getMapName();
+      case Players -> lobbyGame.getPlayerCount();
+      case P -> (lobbyGame.getPassworded() ? "*" : "");
+      case Status ->
+          // Note, we update status client side to avoid a headless game from reporting
+          // a new status when players leave or join. We expect a player count of 0 in
+          // headless games if there are no players connected.
+          lobbyGame.getPlayerCount() == 0 ? "Available" : lobbyGame.getStatus();
+      case Comments -> lobbyGame.getComments();
+      case Started -> formatBotStartTime(lobbyGame.getEpochMilliTimeStarted());
+      case UUID -> listingModel.getGameIdForRow(rowIndex);
+      default -> throw new IllegalStateException("Unknown column: " + column);
+    };
   }
 
   @VisibleForTesting
@@ -184,14 +108,5 @@ class LobbyGameTableModel extends AbstractTableModel {
         .appendLocalized(null, FormatStyle.SHORT)
         .toFormatter()
         .format(LocalDateTime.ofInstant(instant, ZoneOffset.systemDefault()));
-  }
-
-  public void shutdown() {
-    playerToLobbyConnection.close();
-  }
-
-  public void bootGame(final int selectedIndex) {
-    final String gameId = getGameIdForRow(selectedIndex);
-    playerToLobbyConnection.bootGame(gameId);
   }
 }

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -33,8 +33,7 @@ class LobbyGameTableModel extends AbstractTableModel {
   LobbyGameTableModel(final boolean admin, final LobbyGameListingModel listingModel) {
     this.admin = admin;
     this.listingModel = listingModel;
-    listingModel.addChangeListener(
-        () -> SwingUtilities.invokeLater(this::fireTableDataChanged));
+    listingModel.addChangeListener(() -> SwingUtilities.invokeLater(this::fireTableDataChanged));
   }
 
   @VisibleForTesting

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyModel.java
@@ -1,0 +1,43 @@
+package games.strategy.engine.lobby.client.ui;
+
+import games.strategy.engine.chat.Chat;
+import games.strategy.engine.chat.ChatTransmitter;
+import games.strategy.engine.chat.LobbyChatTransmitter;
+import games.strategy.engine.lobby.client.login.LoginResult;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.function.Consumer;
+import lombok.Getter;
+import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
+
+/**
+ * Central domain/network model for a lobby session. Has no Swing dependency. Owns the network
+ * connection and all domain objects derived from it; {@link LobbyFrame} receives this and owns only
+ * layout.
+ */
+public class LobbyModel {
+  @Getter private final LoginResult loginResult;
+  @Getter private final PlayerToLobbyConnection connection;
+  @Getter private final LobbyGameListingModel gameListingModel;
+  @Getter private final ChatTransmitter chatTransmitter;
+  @Getter private final Chat chat;
+
+  public LobbyModel(final LoginResult loginResult, final Consumer<String> onConnectionError) {
+    this.loginResult = loginResult;
+
+    connection =
+        new PlayerToLobbyConnection(
+            ClientSetting.lobbyUri.getValueOrThrow(),
+            loginResult.getApiKey(),
+            onConnectionError);
+
+    gameListingModel = new LobbyGameListingModel(connection);
+    chatTransmitter = new LobbyChatTransmitter(connection, loginResult.getUsername());
+    chat = new Chat(chatTransmitter);
+  }
+
+  void shutdown() {
+    chatTransmitter.disconnect();
+    connection.close();
+  }
+}
+

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyModel.java
@@ -26,9 +26,7 @@ public class LobbyModel {
 
     connection =
         new PlayerToLobbyConnection(
-            ClientSetting.lobbyUri.getValueOrThrow(),
-            loginResult.getApiKey(),
-            onConnectionError);
+            ClientSetting.lobbyUri.getValueOrThrow(), loginResult.getApiKey(), onConnectionError);
 
     gameListingModel = new LobbyGameListingModel(connection);
     chatTransmitter = new LobbyChatTransmitter(connection, loginResult.getUsername());
@@ -40,4 +38,3 @@ public class LobbyModel {
     connection.close();
   }
 }
-

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyPlayerActions.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyPlayerActions.java
@@ -62,4 +62,3 @@ class LobbyPlayerActions {
             .toSwingAction());
   }
 }
-

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyPlayerActions.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyPlayerActions.java
@@ -1,0 +1,65 @@
+package games.strategy.engine.lobby.client.ui;
+
+import games.strategy.engine.lobby.client.login.LoginResult;
+import games.strategy.engine.lobby.client.ui.action.BanPlayerModeratorAction;
+import games.strategy.engine.lobby.client.ui.action.DisconnectPlayerModeratorAction;
+import games.strategy.engine.lobby.client.ui.action.MutePlayerAction;
+import games.strategy.engine.lobby.client.ui.action.player.info.ShowPlayerInformationAction;
+import java.util.List;
+import javax.swing.Action;
+import javax.swing.JFrame;
+import org.triplea.domain.data.ChatParticipant;
+import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
+
+/** Builds the right-click action list for a player entry in the lobby chat panel. */
+class LobbyPlayerActions {
+
+  private LobbyPlayerActions() {}
+
+  static List<Action> buildFor(
+      final JFrame parentWindow,
+      final LoginResult loginResult,
+      final ChatParticipant clickedOn,
+      final PlayerToLobbyConnection playerToLobbyConnection) {
+    if (clickedOn.getUserName().equals(loginResult.getUsername())) {
+      return List.of();
+    }
+
+    final var showPlayerInformationAction =
+        ShowPlayerInformationAction.builder()
+            .parent(parentWindow)
+            .playerChatId(clickedOn.getPlayerChatId())
+            .playerName(clickedOn.getUserName())
+            .playerToLobbyConnection(playerToLobbyConnection)
+            .build()
+            .toSwingAction();
+
+    if (!loginResult.isModerator()) {
+      return List.of(showPlayerInformationAction);
+    }
+    return List.of(
+        showPlayerInformationAction,
+        MutePlayerAction.builder()
+            .parent(parentWindow)
+            .playerChatId(clickedOn.getPlayerChatId())
+            .playerToLobbyConnection(playerToLobbyConnection)
+            .playerName(clickedOn.getUserName().getValue())
+            .build()
+            .toSwingAction(),
+        DisconnectPlayerModeratorAction.builder()
+            .parent(parentWindow)
+            .playerToLobbyConnection(playerToLobbyConnection)
+            .playerChatId(clickedOn.getPlayerChatId())
+            .userName(clickedOn.getUserName())
+            .build()
+            .toSwingAction(),
+        BanPlayerModeratorAction.builder()
+            .parent(parentWindow)
+            .playerToLobbyConnection(playerToLobbyConnection)
+            .playerChatIdToBan(clickedOn.getPlayerChatId())
+            .playerName(clickedOn.getUserName().getValue())
+            .build()
+            .toSwingAction());
+  }
+}
+

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/ReconnectOverlay.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/ReconnectOverlay.java
@@ -1,0 +1,66 @@
+package games.strategy.engine.lobby.client.ui;
+
+import java.awt.Window;
+import javax.swing.BorderFactory;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import org.triplea.swing.JButtonBuilder;
+import org.triplea.swing.JDialogBuilder;
+import org.triplea.swing.JLabelBuilder;
+import org.triplea.swing.jpanel.JPanelBuilder;
+
+/**
+ * A non-blocking dialog shown while the lobby connection is being re-established. It displays the
+ * current reconnect attempt number and offers a "Disconnect &amp; Exit" button that aborts the
+ * reconnect and shuts down the lobby frame.
+ */
+class ReconnectOverlay {
+
+  private final JDialog dialog;
+  private final JLabel messageLabel;
+
+  ReconnectOverlay(final Window owner, final Runnable onDisconnect) {
+    messageLabel = new JLabelBuilder().border(BorderFactory.createEmptyBorder(16, 24, 8, 24)).build();
+
+    final var buttonPanel =
+        new JPanelBuilder()
+            .flowLayout()
+            .add(new JButtonBuilder("Disconnect & Exit").actionListener(onDisconnect).build())
+            .build();
+
+    final var content =
+        new JPanelBuilder()
+            .borderLayout()
+            .addCenter(messageLabel)
+            .addSouth(buttonPanel)
+            .build();
+
+    dialog =
+        new JDialogBuilder()
+            .parent(owner)
+            .title("Reconnecting to Lobby")
+            .alwaysOnTop()
+            .add(content)
+            .build();
+    dialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
+  }
+
+  /** Shows (or updates) the overlay for the given 1-based reconnect attempt number. */
+  void show(final int attempt) {
+    SwingUtilities.invokeLater(
+        () -> {
+          messageLabel.setText(
+              "Lost connection to lobby. Reconnecting… (attempt " + attempt + ")");
+          dialog.pack();
+          if (!dialog.isVisible()) {
+            dialog.setVisible(true);
+          }
+        });
+  }
+
+  /** Dismisses the overlay after a successful reconnect. */
+  void dismiss() {
+    SwingUtilities.invokeLater(dialog::dispose);
+  }
+}

--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/ReconnectOverlay.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/ReconnectOverlay.java
@@ -21,7 +21,8 @@ class ReconnectOverlay {
   private final JLabel messageLabel;
 
   ReconnectOverlay(final Window owner, final Runnable onDisconnect) {
-    messageLabel = new JLabelBuilder().border(BorderFactory.createEmptyBorder(16, 24, 8, 24)).build();
+    messageLabel =
+        new JLabelBuilder().border(BorderFactory.createEmptyBorder(16, 24, 8, 24)).build();
 
     final var buttonPanel =
         new JPanelBuilder()
@@ -30,11 +31,7 @@ class ReconnectOverlay {
             .build();
 
     final var content =
-        new JPanelBuilder()
-            .borderLayout()
-            .addCenter(messageLabel)
-            .addSouth(buttonPanel)
-            .build();
+        new JPanelBuilder().borderLayout().addCenter(messageLabel).addSouth(buttonPanel).build();
 
     dialog =
         new JDialogBuilder()
@@ -50,8 +47,7 @@ class ReconnectOverlay {
   void show(final int attempt) {
     SwingUtilities.invokeLater(
         () -> {
-          messageLabel.setText(
-              "Lost connection to lobby. Reconnecting… (attempt " + attempt + ")");
+          messageLabel.setText("Lost connection to lobby. Reconnecting… (attempt " + attempt + ")");
           dialog.pack();
           if (!dialog.isVisible()) {
             dialog.setVisible(true);

--- a/game-app/game-headed/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/game-app/game-headed/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -58,12 +58,14 @@ final class LobbyGameTableModelTest {
   @Nested
   final class RemoveAndUpdateGameTest {
     private LobbyGameTableModel testObj;
+    private LobbyGameListingModel listingModel;
     @Mock private PlayerToLobbyConnection playerToLobbyConnection;
 
     @BeforeEach
     void setUp() {
-      testObj = new LobbyGameTableModel(true, playerToLobbyConnection);
-      testObj
+      listingModel = new LobbyGameListingModel(playerToLobbyConnection);
+      testObj = new LobbyGameTableModel(true, listingModel);
+      listingModel
           .getLobbyGameBroadcaster()
           .gameUpdated(
               LobbyGameListing.builder()
@@ -88,7 +90,7 @@ final class LobbyGameTableModelTest {
       final int commentColumnIndex = testObj.getColumnIndex(LobbyGameTableModel.Column.Comments);
       assertThat(testObj.getValueAt(0, commentColumnIndex), nullValue());
 
-      testObj
+      listingModel
           .getLobbyGameBroadcaster()
           .gameUpdated(
               LobbyGameListing.builder()
@@ -103,7 +105,7 @@ final class LobbyGameTableModelTest {
 
     @Test
     void updateGameAddsIfDoesNotExist() {
-      testObj
+      listingModel
           .getLobbyGameBroadcaster()
           .gameUpdated(
               LobbyGameListing.builder()
@@ -116,14 +118,14 @@ final class LobbyGameTableModelTest {
 
     @Test
     void removeGame() {
-      testObj.getLobbyGameBroadcaster().gameRemoved(id0);
+      listingModel.getLobbyGameBroadcaster().gameRemoved(id0);
       waitForSwingThreads();
       assertThat(testObj.getRowCount(), is(0));
     }
 
     @Test
     void removeGameThatDoesNotExistIsIgnored() {
-      testObj.getLobbyGameBroadcaster().gameRemoved(id1);
+      listingModel.getLobbyGameBroadcaster().gameRemoved(id1);
       waitForSwingThreads();
       assertThat(testObj.getRowCount(), is(1));
     }

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
@@ -1,8 +1,6 @@
 package org.triplea.http.client.web.socket.client.connections;
 
 import java.net.URI;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +27,6 @@ import org.triplea.http.client.web.socket.messages.envelopes.chat.ChatSentMessag
 import org.triplea.http.client.web.socket.messages.envelopes.chat.ConnectToChatMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerSlapSentMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUpdateSentMessage;
-import org.triplea.java.Retriable;
 
 /**
  * Represents a connection from a player to lobby. A player can do actions like get game listings,
@@ -59,16 +56,6 @@ public class PlayerToLobbyConnection {
                     LobbyHttpClientConfig.getConfig().getSystemId()))
             .build();
     webSocket.connect();
-
-//    webSocket.addConnectionClosedListener(
-//            Retriable.builder()
-//                    .withMaxAttempts()
-//                    .withFixedBackOff(Duration.of(3, ChronoUnit.SECONDS))
-//                    .build(() -> {
-//                      webSocket.connect();
-//                      return null;
-//                    })
-//    );
     gameListingClient = httpLobbyClient.newGameListingClient();
   }
 
@@ -158,5 +145,9 @@ public class PlayerToLobbyConnection {
 
   public void addConnectionResetListener(final Runnable listener) {
     webSocket.addConnectionResetListener(listener);
+  }
+
+  public void addReconnectionListener(final WebSocket.ReconnectionHandler handler) {
+    webSocket.addReconnectionListener(handler);
   }
 }

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
@@ -1,6 +1,8 @@
 package org.triplea.http.client.web.socket.client.connections;
 
 import java.net.URI;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +29,7 @@ import org.triplea.http.client.web.socket.messages.envelopes.chat.ChatSentMessag
 import org.triplea.http.client.web.socket.messages.envelopes.chat.ConnectToChatMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerSlapSentMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUpdateSentMessage;
+import org.triplea.java.Retriable;
 
 /**
  * Represents a connection from a player to lobby. A player can do actions like get game listings,
@@ -56,6 +59,16 @@ public class PlayerToLobbyConnection {
                     LobbyHttpClientConfig.getConfig().getSystemId()))
             .build();
     webSocket.connect();
+
+//    webSocket.addConnectionClosedListener(
+//            Retriable.builder()
+//                    .withMaxAttempts()
+//                    .withFixedBackOff(Duration.of(3, ChronoUnit.SECONDS))
+//                    .build(() -> {
+//                      webSocket.connect();
+//                      return null;
+//                    })
+//    );
     gameListingClient = httpLobbyClient.newGameListingClient();
   }
 
@@ -141,5 +154,9 @@ public class PlayerToLobbyConnection {
 
   public Collection<String> fetchPlayersInGame(final String gameId) {
     return httpLobbyClient.getPlayerLobbyActionsClient().fetchPlayersInGame(gameId);
+  }
+
+  public void addConnectionResetListener(final Runnable listener) {
+    webSocket.addConnectionResetListener(listener);
   }
 }

--- a/lib/swing-lib/src/main/java/org/triplea/swing/JDialogBuilder.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/JDialogBuilder.java
@@ -3,13 +3,13 @@ package org.triplea.swing;
 import com.google.common.base.Preconditions;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.Window;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.swing.JDialog;
-import javax.swing.JFrame;
 import org.triplea.swing.key.binding.KeyCode;
 import org.triplea.swing.key.binding.SwingKeyBinding;
 
@@ -28,7 +28,7 @@ import org.triplea.swing.key.binding.SwingKeyBinding;
  */
 public class JDialogBuilder {
 
-  private JFrame parent;
+  private Window parent;
   private String title;
   private boolean alwaysOnTop;
   private Dimension size;
@@ -59,7 +59,7 @@ public class JDialogBuilder {
     return dialog;
   }
 
-  public JDialogBuilder parent(final JFrame parent) {
+  public JDialogBuilder parent(final Window parent) {
     this.parent = parent;
     return this;
   }

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -36,13 +37,13 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
   private static final Gson gson = new Gson();
 
   /** These are called whenever connection is closed, whether by us or server. */
-  private final Collection<Runnable> connectionClosedListeners = new ArrayList<>();
+  private final Collection<Runnable> connectionClosedListeners = new CopyOnWriteArrayList<>();
 
-  private final Collection<Runnable> connectionResetListeners = new ArrayList<>();
+  private final Collection<Runnable> connectionResetListeners = new CopyOnWriteArrayList<>();
 
-  private final Collection<Consumer<String>> connectionTerminatedListeners = new ArrayList<>();
+  private final Collection<Consumer<String>> connectionTerminatedListeners = new CopyOnWriteArrayList<>();
 
-  private final Collection<WebSocket.ReconnectionHandler> reconnectionHandlers = new ArrayList<>();
+  private final Collection<WebSocket.ReconnectionHandler> reconnectionHandlers = new CopyOnWriteArrayList<>();
 
   private final URI websocketUri;
   private final Consumer<String> errorHandler;

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -114,12 +114,6 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
   }
 
   @Override
-  public void reconnectionFailed() {
-    reconnectionHandlers.forEach(WebSocket.ReconnectionHandler::onReconnectFailed);
-  }
-
-  /** Starts a non-blocking close of the websocket connection. */
-  @Override
   public void close() {
     webSocketConnection.close();
   }

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -4,7 +4,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -41,9 +40,11 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
 
   private final Collection<Runnable> connectionResetListeners = new CopyOnWriteArrayList<>();
 
-  private final Collection<Consumer<String>> connectionTerminatedListeners = new CopyOnWriteArrayList<>();
+  private final Collection<Consumer<String>> connectionTerminatedListeners =
+      new CopyOnWriteArrayList<>();
 
-  private final Collection<WebSocket.ReconnectionHandler> reconnectionHandlers = new CopyOnWriteArrayList<>();
+  private final Collection<WebSocket.ReconnectionHandler> reconnectionHandlers =
+      new CopyOnWriteArrayList<>();
 
   private final URI websocketUri;
   private final Consumer<String> errorHandler;

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -42,6 +42,8 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
 
   private final Collection<Consumer<String>> connectionTerminatedListeners = new ArrayList<>();
 
+  private final Collection<WebSocket.ReconnectionHandler> reconnectionHandlers = new ArrayList<>();
+
   private final URI websocketUri;
   private final Consumer<String> errorHandler;
   private final Function<URI, WebSocketConnection> webSocketConnectionFactory;
@@ -96,8 +98,24 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
   }
 
   @Override
+  public void addReconnectionListener(final WebSocket.ReconnectionHandler handler) {
+    reconnectionHandlers.add(handler);
+  }
+
+  @Override
   public void reconnected() {
     connectionResetListeners.forEach(Runnable::run);
+    reconnectionHandlers.forEach(WebSocket.ReconnectionHandler::onReconnected);
+  }
+
+  @Override
+  public void onReconnecting(final int attempt) {
+    reconnectionHandlers.forEach(h -> h.onReconnecting(attempt));
+  }
+
+  @Override
+  public void reconnectionFailed() {
+    reconnectionHandlers.forEach(WebSocket.ReconnectionHandler::onReconnectFailed);
   }
 
   /** Starts a non-blocking close of the websocket connection. */

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -38,6 +38,8 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
   /** These are called whenever connection is closed, whether by us or server. */
   private final Collection<Runnable> connectionClosedListeners = new ArrayList<>();
 
+  private final Collection<Runnable> connectionResetListeners = new ArrayList<>();
+
   private final Collection<Consumer<String>> connectionTerminatedListeners = new ArrayList<>();
 
   private final URI websocketUri;
@@ -55,9 +57,9 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
 
   @Builder
   public GenericWebSocketClient(
-      @Nonnull final URI websocketUri,
-      @Nonnull final Consumer<String> errorHandler,
-      @Nonnull final Map<String, String> headers) {
+      @Nonnull URI websocketUri,
+      @Nonnull Consumer<String> errorHandler,
+      @Nonnull Map<String, String> headers) {
     this(
         new WebSocketProtocolSwapper().apply(websocketUri),
         errorHandler,
@@ -76,10 +78,14 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
     Preconditions.checkArgument(
         websocketUri.getScheme().equals("ws") || websocketUri.getScheme().equals("wss"),
         "Websocket URI scheme must be either ws or wss, but was: " + websocketUri);
-
     this.websocketUri = websocketUri;
     this.errorHandler = errorHandler;
     this.webSocketConnectionFactory = webSocketConnectionFactory;
+  }
+
+  @Override
+  public boolean isOpen() {
+    return webSocketConnection.isOpen();
   }
 
   @Override
@@ -87,6 +93,11 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
     addListener(ServerErrorMessage.TYPE, message -> errorHandler.accept(message.getError()));
     webSocketConnection = webSocketConnectionFactory.apply(websocketUri);
     webSocketConnection.connect(this, errorHandler);
+  }
+
+  @Override
+  public void reconnected() {
+    connectionResetListeners.forEach(Runnable::run);
   }
 
   /** Starts a non-blocking close of the websocket connection. */
@@ -125,6 +136,11 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
   }
 
   @Override
+  public void addConnectionResetListener(Runnable listener) {
+    connectionResetListeners.add(listener);
+  }
+
+  @Override
   @Synchronized
   public void messageReceived(final String message) {
     final MessageEnvelope converted = gson.fromJson(message, MessageEnvelope.class);
@@ -135,6 +151,7 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
     }
   }
 
+  /** Invoked when the client disconnects */
   @Override
   public void connectionClosed() {
     connectionClosedListeners.forEach(Runnable::run);

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
@@ -37,8 +37,5 @@ public interface WebSocket {
 
     /** Called when a reconnect attempt succeeds. */
     void onReconnected();
-
-    /** Called when all reconnect attempts are exhausted. */
-    void onReconnectFailed();
   }
 }

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
@@ -9,6 +9,8 @@ public interface WebSocket {
 
   void close();
 
+  boolean isOpen();
+
   <T extends WebSocketMessage> void addListener(
       MessageType<T> messageType, Consumer<T> messageHandler);
 
@@ -24,4 +26,6 @@ public interface WebSocket {
    *     string arg is the close reason reported from server.
    */
   void addConnectionTerminatedListener(Consumer<String> connectionTerminatedListener);
+
+  void addConnectionResetListener(Runnable listener);
 }

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
@@ -28,4 +28,17 @@ public interface WebSocket {
   void addConnectionTerminatedListener(Consumer<String> connectionTerminatedListener);
 
   void addConnectionResetListener(Runnable listener);
+
+  void addReconnectionListener(ReconnectionHandler handler);
+
+  interface ReconnectionHandler {
+    /** Called on each reconnect attempt. currentAttempt is 1-based. */
+    void onReconnecting(int currentAttempt);
+
+    /** Called when a reconnect attempt succeeds. */
+    void onReconnected();
+
+    /** Called when all reconnect attempts are exhausted. */
+    void onReconnectFailed();
+  }
 }

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -44,7 +44,6 @@ class WebSocketConnection {
 
   @VisibleForTesting static final String CLIENT_DISCONNECT_MESSAGE = "Client disconnect.";
 
-  private static final int MAX_RECONNECT_ATTEMPTS = 5;
   private static final long RECONNECT_BACKOFF_MILLIS = 5000;
 
   private WebSocketConnectionListener listener;
@@ -203,50 +202,44 @@ class WebSocketConnection {
   }
 
   /**
-   * Spawns a virtual thread that retries the connection up to {@link #MAX_RECONNECT_ATTEMPTS}
-   * times, notifying the listener on each attempt. On success calls {@link
-   * WebSocketConnectionListener#reconnected()}; on full exhaustion calls {@link
-   * WebSocketConnectionListener#reconnectionFailed()}.
+   * Spawns a virtual thread that retries the connection indefinitely with a fixed back-off between
+   * attempts, notifying the listener on each attempt. The loop exits only when the thread is
+   * interrupted (i.e. {@link #close()} is called, which happens when the lobby frame is closed or
+   * the user clicks "Disconnect & Exit" in the reconnect overlay). On success calls {@link
+   * WebSocketConnectionListener#reconnected()}.
    */
   private void reconnectAsync() {
     reconnectThread =
         Thread.ofVirtual()
             .name("websocket-reconnect-thread")
             .start(
-            () -> {
-              for (int attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
-                listener.onReconnecting(attempt);
-                connectionIsOpen = false;
-                httpClient = HttpClient.newHttpClient();
-                try {
-                  connectAsync().get(DEFAULT_CONNECT_TIMEOUT_MILLIS * 2L, TimeUnit.MILLISECONDS);
-                  log.info("Successfully reconnected on attempt {}", attempt);
-                  listener.reconnected();
-                  return;
-                } catch (final InterruptedException e) {
-                  Thread.currentThread().interrupt();
-                  log.info("Reconnect interrupted on attempt {}", attempt);
-                  break;
-                } catch (final Exception e) {
-                  log.info(
-                      "Reconnect attempt {}/{} failed: {}",
-                      attempt,
-                      MAX_RECONNECT_ATTEMPTS,
-                      e.getMessage());
-                  if (attempt < MAX_RECONNECT_ATTEMPTS) {
+                () -> {
+                  int attempt = 1;
+                  while (!Thread.currentThread().isInterrupted()) {
+                    listener.onReconnecting(attempt++);
+                    connectionIsOpen = false;
+                    httpClient = HttpClient.newHttpClient();
                     try {
-                      Thread.sleep(RECONNECT_BACKOFF_MILLIS);
-                    } catch (final InterruptedException ex) {
-                      Thread.currentThread().interrupt();
+                      connectAsync().get(DEFAULT_CONNECT_TIMEOUT_MILLIS * 2L, TimeUnit.MILLISECONDS);
+                      log.info("Successfully reconnected on attempt {}", attempt - 1);
+                      listener.reconnected();
                       return;
+                    } catch (final InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                      log.info("Reconnect thread interrupted, stopping retries");
+                      return;
+                    } catch (final Exception e) {
+                      log.info("Reconnect attempt {} failed: {}", attempt - 1, e.getMessage());
+                      try {
+                        Thread.sleep(RECONNECT_BACKOFF_MILLIS);
+                      } catch (final InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                        log.info("Reconnect thread interrupted during back-off, stopping retries");
+                        return;
+                      }
                     }
                   }
-                }
-              }
-              log.info("All {} reconnect attempts exhausted", MAX_RECONNECT_ATTEMPTS);
-              pingSender.cancel();
-              listener.reconnectionFailed();
-            });
+                });
   }
 
   /**

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -44,6 +44,9 @@ class WebSocketConnection {
 
   @VisibleForTesting static final String CLIENT_DISCONNECT_MESSAGE = "Client disconnect.";
 
+  private static final int MAX_RECONNECT_ATTEMPTS = 5;
+  private static final long RECONNECT_BACKOFF_MILLIS = 5000;
+
   private WebSocketConnectionListener listener;
 
   /**
@@ -71,6 +74,8 @@ class WebSocketConnection {
   private final URI serverUri;
 
   private boolean closed = false;
+
+  @Nullable private Thread reconnectThread;
 
   private WebSocket client;
 
@@ -134,6 +139,9 @@ class WebSocketConnection {
   /** Does an async close of the current websocket connection. */
   void close() {
     closed = true;
+    if (reconnectThread != null) {
+      reconnectThread.interrupt();
+    }
     // Client can be null if the connection hasn't completely opened yet.
     // This null check prevents a potential NPE, which should rarely ever occur.
     if (client != null && !client.isOutputClosed()) {
@@ -170,16 +178,16 @@ class WebSocketConnection {
             });
   }
 
-  private CompletableFuture<Void> connectAsyncAndStartPingSender() {
+  private CompletableFuture<WebSocket> connectAsync() {
     var clientBuilder = httpClient.newWebSocketBuilder();
-
-    // add all headers
     headers.forEach(clientBuilder::header);
-
     return clientBuilder
         .connectTimeout(Duration.ofMillis(DEFAULT_CONNECT_TIMEOUT_MILLIS))
-        .buildAsync(this.serverUri, internalListener)
-        .thenRun(pingSender::start);
+        .buildAsync(this.serverUri, internalListener);
+  }
+
+  private CompletableFuture<Void> connectAsyncAndStartPingSender() {
+    return connectAsync().thenRun(pingSender::start);
   }
 
   private void retryConnection(final Consumer<String> errorHandler) {
@@ -190,16 +198,54 @@ class WebSocketConnection {
             throwable -> {
               log.info("Failed to connect", throwable);
               errorHandler.accept("Failed to connect: " + throwable.getMessage());
-
-              Interruptibles.sleep(5000);
-              connectAsyncAndStartPingSender()
-                  .exceptionally(
-                      t -> {
-                        log.info("Failed to connect", t);
-                        errorHandler.accept("Failed to connect: " + t.getMessage());
-                        return null;
-                      });
               return null;
+            });
+  }
+
+  /**
+   * Spawns a virtual thread that retries the connection up to {@link #MAX_RECONNECT_ATTEMPTS}
+   * times, notifying the listener on each attempt. On success calls {@link
+   * WebSocketConnectionListener#reconnected()}; on full exhaustion calls {@link
+   * WebSocketConnectionListener#reconnectionFailed()}.
+   */
+  private void reconnectAsync() {
+    reconnectThread =
+        Thread.ofVirtual()
+            .name("websocket-reconnect-thread")
+            .start(
+            () -> {
+              for (int attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+                listener.onReconnecting(attempt);
+                connectionIsOpen = false;
+                httpClient = HttpClient.newHttpClient();
+                try {
+                  connectAsync().get(DEFAULT_CONNECT_TIMEOUT_MILLIS * 2L, TimeUnit.MILLISECONDS);
+                  log.info("Successfully reconnected on attempt {}", attempt);
+                  listener.reconnected();
+                  return;
+                } catch (final InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  log.info("Reconnect interrupted on attempt {}", attempt);
+                  break;
+                } catch (final Exception e) {
+                  log.info(
+                      "Reconnect attempt {}/{} failed: {}",
+                      attempt,
+                      MAX_RECONNECT_ATTEMPTS,
+                      e.getMessage());
+                  if (attempt < MAX_RECONNECT_ATTEMPTS) {
+                    try {
+                      Thread.sleep(RECONNECT_BACKOFF_MILLIS);
+                    } catch (final InterruptedException ex) {
+                      Thread.currentThread().interrupt();
+                      return;
+                    }
+                  }
+                }
+              }
+              log.info("All {} reconnect attempts exhausted", MAX_RECONNECT_ATTEMPTS);
+              pingSender.cancel();
+              listener.reconnectionFailed();
             });
   }
 
@@ -271,29 +317,17 @@ class WebSocketConnection {
     @Override
     public @Nullable CompletionStage<?> onClose(
         final WebSocket webSocket, final int statusCode, final String reason) {
+      log.info("Connection closed, reason: '{}'", reason);
 
-      log.info("Connection closed");
-
-      log.info("Attempting to reconnect..");
-      retryConnection(
-          error -> {
-            log.info("Failed to reconnect: {}", error);
-          });
-
-      if (isOpen()) {
-        log.info("Successfully reconnected to server");
-        listener.reconnected();
-        return null;
-      } else {
-        log.info("Reconnect failed..");
+      if (closed || reason.equals(WebSocketConnection.CLIENT_DISCONNECT_MESSAGE)) {
         pingSender.cancel();
-        if (reason.equals(WebSocketConnection.CLIENT_DISCONNECT_MESSAGE)) {
-          listener.connectionClosed();
-        } else {
-          listener.connectionTerminated(reason.isBlank() ? "Server disconnected" : reason);
-        }
+        listener.connectionClosed();
         return null;
       }
+
+      log.info("Unexpected disconnect, attempting to reconnect...");
+      reconnectAsync();
+      return null;
     }
 
     @Override

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -44,6 +44,12 @@ class WebSocketConnection {
 
   @VisibleForTesting static final String CLIENT_DISCONNECT_MESSAGE = "Client disconnect.";
 
+  /**
+   * Close reason sent by the server when a player has been banned. This is a terminal condition; we
+   * do not attempt to reconnect.
+   */
+  @VisibleForTesting static final String SERVER_BAN_DISCONNECT_MESSAGE = "You have been banned";
+
   private static final long RECONNECT_BACKOFF_MILLIS = 5000;
 
   private WebSocketConnectionListener listener;
@@ -316,6 +322,13 @@ class WebSocketConnection {
       if (closed || reason.equals(WebSocketConnection.CLIENT_DISCONNECT_MESSAGE)) {
         pingSender.cancel();
         listener.connectionClosed();
+        return null;
+      }
+
+      if (reason.equals(SERVER_BAN_DISCONNECT_MESSAGE)) {
+        log.info("Connection terminated by server (ban): {}", reason);
+        pingSender.cancel();
+        listener.connectionTerminated(reason);
         return null;
       }
 

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -220,7 +220,8 @@ class WebSocketConnection {
                     connectionIsOpen = false;
                     httpClient = HttpClient.newHttpClient();
                     try {
-                      connectAsync().get(DEFAULT_CONNECT_TIMEOUT_MILLIS * 2L, TimeUnit.MILLISECONDS);
+                      connectAsync()
+                          .get(DEFAULT_CONNECT_TIMEOUT_MILLIS * 2L, TimeUnit.MILLISECONDS);
                       log.info("Successfully reconnected on attempt {}", attempt - 1);
                       listener.reconnected();
                       return;

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -94,6 +94,10 @@ class WebSocketConnection {
     this.headers = headers;
   }
 
+  public boolean isOpen() {
+    return !(client.isInputClosed() && client.isOutputClosed());
+  }
+
   /**
    * Sends pings with retries. Retry threshold is set up to account for disconnect at 60 seconds. We
    * send a ping every 45s, if that fails we'll try again at the 48s mark, again at 51s, again at
@@ -159,7 +163,7 @@ class WebSocketConnection {
         .exceptionally(
             throwable -> {
               // Do a single retry with fixed back-off
-              log.info("Failed to connect, will retrying", throwable);
+              log.info("Failed to connect, will retry", throwable);
               Interruptibles.sleep(1000);
               retryConnection(errorHandler);
               return null;
@@ -179,11 +183,22 @@ class WebSocketConnection {
   }
 
   private void retryConnection(final Consumer<String> errorHandler) {
+    connectionIsOpen = false;
+    httpClient = HttpClient.newHttpClient();
     connectAsyncAndStartPingSender()
         .exceptionally(
             throwable -> {
               log.info("Failed to connect", throwable);
               errorHandler.accept("Failed to connect: " + throwable.getMessage());
+
+              Interruptibles.sleep(5000);
+              connectAsyncAndStartPingSender()
+                  .exceptionally(
+                      t -> {
+                        log.info("Failed to connect", t);
+                        errorHandler.accept("Failed to connect: " + t.getMessage());
+                        return null;
+                      });
               return null;
             });
   }
@@ -256,13 +271,29 @@ class WebSocketConnection {
     @Override
     public @Nullable CompletionStage<?> onClose(
         final WebSocket webSocket, final int statusCode, final String reason) {
-      pingSender.cancel();
-      if (reason.equals(WebSocketConnection.CLIENT_DISCONNECT_MESSAGE)) {
-        listener.connectionClosed();
+
+      log.info("Connection closed");
+
+      log.info("Attempting to reconnect..");
+      retryConnection(
+          error -> {
+            log.info("Failed to reconnect: {}", error);
+          });
+
+      if (isOpen()) {
+        log.info("Successfully reconnected to server");
+        listener.reconnected();
+        return null;
       } else {
-        listener.connectionTerminated(reason.isBlank() ? "Server disconnected" : reason);
+        log.info("Reconnect failed..");
+        pingSender.cancel();
+        if (reason.equals(WebSocketConnection.CLIENT_DISCONNECT_MESSAGE)) {
+          listener.connectionClosed();
+        } else {
+          listener.connectionTerminated(reason.isBlank() ? "Server disconnected" : reason);
+        }
+        return null;
       }
-      return null;
     }
 
     @Override

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -213,8 +213,13 @@ class WebSocketConnection {
    * interrupted (i.e. {@link #close()} is called, which happens when the lobby frame is closed or
    * the user clicks "Disconnect & Exit" in the reconnect overlay). On success calls {@link
    * WebSocketConnectionListener#reconnected()}.
+   *
+   * If a reconnect is already in process, then no-ops.
    */
   private void reconnectAsync() {
+    if (reconnectThread != null && reconnectThread.isAlive()) {
+      return;
+    }
     reconnectThread =
         Thread.ofVirtual()
             .name("websocket-reconnect-thread")

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -214,7 +214,7 @@ class WebSocketConnection {
    * the user clicks "Disconnect & Exit" in the reconnect overlay). On success calls {@link
    * WebSocketConnectionListener#reconnected()}.
    *
-   * If a reconnect is already in process, then no-ops.
+   * <p>If a reconnect is already in process, then no-ops.
    */
   private void reconnectAsync() {
     if (reconnectThread != null && reconnectThread.isAlive()) {

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
@@ -6,6 +6,13 @@ interface WebSocketConnectionListener {
 
   void connectionClosed();
 
+  /**
+   * Invoked when connection is dropped and client is able to reconnect successfully. Note: The
+   * websocket server instance of the new connection might be different compared to the websocket
+   * server of the original connection.
+   */
+  void reconnected();
+
   void connectionTerminated(String reason);
 
   void handleError(Throwable error);

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
@@ -16,7 +16,6 @@ interface WebSocketConnectionListener {
    */
   void reconnected();
 
-
   void connectionTerminated(String reason);
 
   void handleError(Throwable error);

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
@@ -6,12 +6,18 @@ interface WebSocketConnectionListener {
 
   void connectionClosed();
 
+  /** Invoked on each reconnect attempt. {@code attempt} is 1-based. */
+  void onReconnecting(int attempt);
+
   /**
    * Invoked when connection is dropped and client is able to reconnect successfully. Note: The
    * websocket server instance of the new connection might be different compared to the websocket
    * server of the original connection.
    */
   void reconnected();
+
+  /** Invoked when all reconnect attempts are exhausted and the connection cannot be restored. */
+  void reconnectionFailed();
 
   void connectionTerminated(String reason);
 

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
@@ -16,8 +16,6 @@ interface WebSocketConnectionListener {
    */
   void reconnected();
 
-  /** Invoked when all reconnect attempts are exhausted and the connection cannot be restored. */
-  void reconnectionFailed();
 
   void connectionTerminated(String reason);
 

--- a/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -100,6 +100,16 @@ class WebSocketConnectionTest {
     }
 
     @Test
+    @DisplayName("Server ban causes connectionTerminated, not a reconnect attempt")
+    void onCloseDueToServerBan() {
+      listener.onClose(
+          mock(WebSocket.class), 0, WebSocketConnection.SERVER_BAN_DISCONNECT_MESSAGE);
+      verify(webSocketConnectionListener)
+          .connectionTerminated(WebSocketConnection.SERVER_BAN_DISCONNECT_MESSAGE);
+      verify(webSocketConnectionListener, never()).onReconnecting(anyInt());
+    }
+
+    @Test
     void onError() {
       listener.onError(mock(WebSocket.class), exception);
       verify(webSocketConnectionListener).handleError(exception);

--- a/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -91,9 +92,11 @@ class WebSocketConnectionTest {
     }
 
     @Test
-    void onCloseDueToTermination() {
+    void onCloseDueToUnexpectedDisconnect() {
       listener.onClose(mock(WebSocket.class), 0, REASON);
-      verify(webSocketConnectionListener).connectionTerminated(REASON);
+      // Reconnect is attempted asynchronously on a virtual thread; onReconnecting fires first
+      verify(webSocketConnectionListener, timeout(2000)).onReconnecting(1);
+      verify(webSocketConnectionListener, never()).connectionTerminated(any());
     }
 
     @Test

--- a/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -102,8 +102,7 @@ class WebSocketConnectionTest {
     @Test
     @DisplayName("Server ban causes connectionTerminated, not a reconnect attempt")
     void onCloseDueToServerBan() {
-      listener.onClose(
-          mock(WebSocket.class), 0, WebSocketConnection.SERVER_BAN_DISCONNECT_MESSAGE);
+      listener.onClose(mock(WebSocket.class), 0, WebSocketConnection.SERVER_BAN_DISCONNECT_MESSAGE);
       verify(webSocketConnectionListener)
           .connectionTerminated(WebSocketConnection.SERVER_BAN_DISCONNECT_MESSAGE);
       verify(webSocketConnectionListener, never()).onReconnecting(anyInt());


### PR DESCRIPTION
## Feature

In short, we automatically attempt reconnect to lobby if disconnected.


Detailed: Updates the lobby window to show a popup when disconnected from the lobby. The popup is not modal so the user can still interact with the game list and copy/paste text. The 'disconnected' popup indicates reconnection attempts and has a button the user can click to terminate. The user can also still 'X' out of the lobby frame to terminate as well. If a reconnection attempt is successful, then the pop-up window closes. If a user types while disconnected, the message goes nowhere and does nothing.

## Screenshot of new popup

<img width="907" height="654" alt="Screenshot from 2026-04-25 19-00-02" src="https://github.com/user-attachments/assets/dd06f688-7168-413f-8f9a-f546c581260a" />


## Why

This update helps us with lobby deployments. If the lobby has downtime due to restarting, then players will reconnect automatically. Today, bots already reconnect automatically, after this update - everything will reconnect to lobby when lobby is back. Previously, the biggest impact of lobby updates was disconnecting players, this feature helps.

