### PR TITLE
Fix(sounds): fix crash for paths within Jars, instead search the Jar

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -141,7 +141,8 @@ public class ResourceLoader implements Closeable {
 
   private Optional<URL> findResource(final String searchPathString) {
     // first attempt to find the resource as a per-map override
-    return loader.resources(searchPathString)
+    return loader
+        .resources(searchPathString)
         .findFirst()
         // otherwise, attempt to load the resource from the generic assets folder
         .or(() -> loader.resources(ASSETS_FOLDER + '/' + searchPathString).findFirst());
@@ -257,18 +258,26 @@ public class ResourceLoader implements Closeable {
 
   private static List<URL> listJarResources(final URI jarUri) throws IOException {
     // jarUri format: jar:file:/path/to/app.jar!/entry/path
+    // e.g. jar:file:/opt/triplea/triplea.jar!/assets/flags
     final String spec = jarUri.getSchemeSpecificPart();
     final int bang = spec.indexOf('!');
-    final String jarFilePart = spec.substring(0, bang); // file:/path/to/app.jar
+    // jarFilePart: the file: URI pointing to the JAR on disk, e.g. file:/opt/triplea/triplea.jar
+    final String jarFilePart = spec.substring(0, bang);
+    // entryPath: the path inside the JAR, e.g. assets/flags or assets/flags/germany.png
     final String entryPath = spec.substring(bang + 2); // strip leading "!/"
 
     try (var jar = new JarFile(Path.of(URI.create(jarFilePart)).toFile())) {
+      // If entryPath points directly to a file inside the JAR (not a directory),
+      // return just that single resource, e.g. assets/sounds/hit.wav
       final var singleEntry = jar.getEntry(entryPath);
       if (singleEntry != null && !singleEntry.isDirectory()) {
         return asUrl(URI.create("jar:" + jarFilePart + "!/" + entryPath))
             .map(List::of)
             .orElse(List.of());
       }
+      // Otherwise treat entryPath as a directory prefix and return all files beneath it.
+      // Matches entries like assets/flags/germany.png, assets/flags/usa.png, etc.
+      // Directories themselves are excluded so only loadable resource files are returned.
       final String prefix = entryPath.endsWith("/") ? entryPath : entryPath + "/";
       return jar.stream()
           .filter(e -> e.getName().startsWith(prefix) && !e.isDirectory())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -5,10 +5,11 @@ import games.strategy.triplea.ui.OrderedProperties;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.Closeable;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -18,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.jar.JarFile;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
@@ -52,9 +54,11 @@ public class ResourceLoader implements Closeable {
    *     "/assets/folder-in-assets/image.png"}
    */
   public static String getAssetsFileLocation(String... assetsImageFileStrings) {
-    String assetsFileLocation =
-        ASSETS_FOLDER + File.separator + String.join(File.separator, assetsImageFileStrings);
-    return assetsFileLocation.replace(File.separatorChar, '/');
+    StringBuilder sb = new StringBuilder(ASSETS_FOLDER);
+    for (String element : assetsImageFileStrings) {
+      sb.append('/').append(element);
+    }
+    return sb.toString();
   }
 
   public ResourceLoader(@Nonnull final Path assetFolderPath) {
@@ -136,7 +140,11 @@ public class ResourceLoader implements Closeable {
   }
 
   private Optional<URL> findResource(final String searchPathString) {
-    return loader.resources(searchPathString).findFirst();
+    // first attempt to find the resource as a per-map override
+    return loader.resources(searchPathString)
+        .findFirst()
+        // otherwise, attempt to load the resource from the generic assets folder
+        .or(() -> loader.resources(ASSETS_FOLDER + '/' + searchPathString).findFirst());
   }
 
   public Optional<Path> optionalResource(final String pathString) {
@@ -213,6 +221,68 @@ public class ResourceLoader implements Closeable {
       return Optional.ofNullable(bufferedImage);
     } catch (final IOException e) {
       log.error("Image loading failed: " + imagePathString, e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Returns all resources found at the given path. If the path resolves to a directory (on disk or
+   * inside a JAR), all direct children are returned. If it resolves to a single file, that file is
+   * returned. Returns an empty list if the path does not exist.
+   *
+   * @param directoryPath '/'-separated resource path
+   */
+  public List<URL> listResources(final String directoryPath) {
+    final URL dirUrl = getResource(directoryPath);
+    if (dirUrl == null) {
+      return List.of();
+    }
+    try {
+      final URI uri = dirUrl.toURI();
+      if ("jar".equals(uri.getScheme())) {
+        return listJarResources(uri);
+      }
+      final Path dir = Path.of(uri);
+      if (Files.isDirectory(dir)) {
+        try (var files = Files.list(dir)) {
+          return files.map(p -> asUrl(p.toUri())).flatMap(Optional::stream).toList();
+        }
+      }
+      return List.of(dirUrl);
+    } catch (final URISyntaxException | IOException e) {
+      log.error("Failed to list resources at: " + directoryPath, e);
+      return List.of();
+    }
+  }
+
+  private static List<URL> listJarResources(final URI jarUri) throws IOException {
+    // jarUri format: jar:file:/path/to/app.jar!/entry/path
+    final String spec = jarUri.getSchemeSpecificPart();
+    final int bang = spec.indexOf('!');
+    final String jarFilePart = spec.substring(0, bang); // file:/path/to/app.jar
+    final String entryPath = spec.substring(bang + 2); // strip leading "!/"
+
+    try (var jar = new JarFile(Path.of(URI.create(jarFilePart)).toFile())) {
+      final var singleEntry = jar.getEntry(entryPath);
+      if (singleEntry != null && !singleEntry.isDirectory()) {
+        return asUrl(URI.create("jar:" + jarFilePart + "!/" + entryPath))
+            .map(List::of)
+            .orElse(List.of());
+      }
+      final String prefix = entryPath.endsWith("/") ? entryPath : entryPath + "/";
+      return jar.stream()
+          .filter(e -> e.getName().startsWith(prefix) && !e.isDirectory())
+          .map(e -> asUrl(URI.create("jar:" + jarFilePart + "!/" + e.getName())))
+          .flatMap(Optional::stream)
+          .toList();
+    }
+  }
+
+  private static Optional<URL> asUrl(final URI uri) {
+    try {
+      return Optional.of(uri.toURL());
+    } catch (final MalformedURLException e) {
+      log.error("Failed to convert URI to URL: " + uri, e);
       return Optional.empty();
     }
   }

--- a/game-app/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
+++ b/game-app/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
@@ -5,24 +5,17 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.settings.ClientSetting;
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javazoom.jl.decoder.JavaLayerException;
 import javazoom.jl.player.FactoryRegistry;
@@ -303,43 +296,8 @@ public class ClipPlayer {
    * @param resourceAndPathUrl (URL uses '/', not File.separator or '\')
    */
   private List<URL> findClipFiles(final String resourceAndPathUrl) {
-    final URL thisSoundUrl = resourceLoader.getResource(resourceAndPathUrl);
-    if (thisSoundUrl == null) {
-      return List.of();
-    }
-    final Path thisSoundPath;
-    try {
-      thisSoundPath = Path.of(thisSoundUrl.toURI());
-    } catch (final URISyntaxException e) {
-      throw new IllegalStateException("Invalid URL format", e);
-    }
-
-    if (Files.isDirectory(thisSoundPath)) {
-      try (Stream<Path> files = Files.list(thisSoundPath)) {
-        return files
-            .filter(ClipPlayer::hasMp3Extension)
-            .flatMap(
-                soundFile -> {
-                  try {
-                    return Stream.of(soundFile.toUri().toURL());
-                  } catch (final MalformedURLException e) {
-                    log.error("Error " + e.getMessage() + " with sound file: " + soundFile, e);
-                    return Stream.empty();
-                  }
-                })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
-      } catch (final IOException e) {
-        log.error("Failed to list files in directory " + thisSoundPath, e);
-      }
-    } else if (hasMp3Extension(thisSoundPath) && Files.isReadable(thisSoundPath)) {
-      return List.of(thisSoundUrl);
-    }
-
-    return List.of();
-  }
-
-  private static boolean hasMp3Extension(final Path soundFile) {
-    return soundFile.toString().endsWith(MP3_SUFFIX);
+    return resourceLoader.listResources(resourceAndPathUrl).stream()
+        .filter(url -> url.toString().endsWith(MP3_SUFFIX))
+        .toList();
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -1,19 +1,28 @@
 package games.strategy.triplea;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -102,6 +111,104 @@ final class ResourceLoaderTest {
       assertEquals("def", properties.getProperty("abc"));
       assertEquals("456", properties.getProperty("123"));
       assertEquals(2, properties.size());
+    }
+  }
+
+  @Nested
+  class ListResourcesTest {
+
+    @Test
+    @DisplayName("Returns empty list when the resource path does not exist")
+    void returnsEmptyWhenPathDoesNotExist(@TempDir final Path tempDir) {
+      var loader = new ResourceLoader(tempDir);
+
+      var result = loader.listResources("nonexistent/path");
+
+      assertThat("path does not exist so result should be empty", result, is(empty()));
+    }
+
+    @Test
+    @DisplayName("Returns all files when path points to a directory on disk")
+    void returnsFilesInDiskDirectory(@TempDir final Path tempDir) throws Exception {
+      var dir = Files.createDirectories(tempDir.resolve("sounds/game_start"));
+      var file1 = Files.createFile(dir.resolve("sound1.mp3"));
+      var file2 = Files.createFile(dir.resolve("sound2.mp3"));
+      var loader = new ResourceLoader(tempDir);
+
+      var result = loader.listResources("sounds/game_start");
+
+      assertThat(
+          "directory with two files should return both file URLs",
+          result,
+          containsInAnyOrder(file1.toUri().toURL(), file2.toUri().toURL()));
+    }
+
+    @Test
+    @DisplayName("Returns the single file URL when path points to a file on disk")
+    void returnsSingleFileOnDisk(@TempDir final Path tempDir) throws Exception {
+      var dir = Files.createDirectories(tempDir.resolve("sounds/game_start"));
+      var file = Files.createFile(dir.resolve("sound.mp3"));
+      var loader = new ResourceLoader(tempDir);
+
+      var result = loader.listResources("sounds/game_start/sound.mp3");
+
+      assertThat(
+          "path points directly to a file, so only that file URL should be returned",
+          result,
+          contains(file.toUri().toURL()));
+    }
+
+    @Test
+    @DisplayName("Returns all files under a directory entry inside a JAR")
+    void returnsFilesInJarDirectory(@TempDir final Path tempDir) throws Exception {
+      var jarPath = buildJar(
+          tempDir.resolve("test.jar"),
+          "sounds/game_start/",
+          "sounds/game_start/sound1.mp3",
+          "sounds/game_start/sound2.mp3");
+      var loader = new ResourceLoader(jarPath);
+
+      var result = loader.listResources("sounds/game_start");
+
+      assertThat(
+          "JAR directory entry should yield both contained files",
+          result,
+          hasSize(2));
+      assertThat(
+          "returned URLs should reference the expected sound files",
+          result.stream().map(URL::toString).toList(),
+          containsInAnyOrder(
+              containsString("sound1.mp3"),
+              containsString("sound2.mp3")));
+    }
+
+    @Test
+    @DisplayName("Returns the single file URL when path points to a file inside a JAR")
+    void returnsSingleFileInJar(@TempDir final Path tempDir) throws Exception {
+      var jarPath = buildJar(tempDir.resolve("test.jar"), "sounds/game_start/sound.mp3");
+      var loader = new ResourceLoader(jarPath);
+
+      var result = loader.listResources("sounds/game_start/sound.mp3");
+
+      assertThat(
+          "JAR entry for a single file should return exactly one URL",
+          result,
+          hasSize(1));
+      assertThat(
+          "returned URL should reference the expected sound file",
+          result.get(0).toString(),
+          containsString("sounds/game_start/sound.mp3"));
+    }
+
+    /** Creates a JAR at {@code dest} containing entries with the given names. */
+    private static Path buildJar(final Path dest, final String... entryNames) throws Exception {
+      try (var jos = new JarOutputStream(Files.newOutputStream(dest))) {
+        for (var name : entryNames) {
+          jos.putNextEntry(new JarEntry(name));
+          jos.closeEntry();
+        }
+      }
+      return dest;
     }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -161,25 +161,21 @@ final class ResourceLoaderTest {
     @Test
     @DisplayName("Returns all files under a directory entry inside a JAR")
     void returnsFilesInJarDirectory(@TempDir final Path tempDir) throws Exception {
-      var jarPath = buildJar(
-          tempDir.resolve("test.jar"),
-          "sounds/game_start/",
-          "sounds/game_start/sound1.mp3",
-          "sounds/game_start/sound2.mp3");
+      var jarPath =
+          buildJar(
+              tempDir.resolve("test.jar"),
+              "sounds/game_start/",
+              "sounds/game_start/sound1.mp3",
+              "sounds/game_start/sound2.mp3");
       var loader = new ResourceLoader(jarPath);
 
       var result = loader.listResources("sounds/game_start");
 
-      assertThat(
-          "JAR directory entry should yield both contained files",
-          result,
-          hasSize(2));
+      assertThat("JAR directory entry should yield both contained files", result, hasSize(2));
       assertThat(
           "returned URLs should reference the expected sound files",
           result.stream().map(URL::toString).toList(),
-          containsInAnyOrder(
-              containsString("sound1.mp3"),
-              containsString("sound2.mp3")));
+          containsInAnyOrder(containsString("sound1.mp3"), containsString("sound2.mp3")));
     }
 
     @Test
@@ -190,10 +186,7 @@ final class ResourceLoaderTest {
 
       var result = loader.listResources("sounds/game_start/sound.mp3");
 
-      assertThat(
-          "JAR entry for a single file should return exactly one URL",
-          result,
-          hasSize(1));
+      assertThat("JAR entry for a single file should return exactly one URL", result, hasSize(1));
       assertThat(
           "returned URL should reference the expected sound file",
           result.get(0).toString(),


### PR DESCRIPTION
Fixes sounds not playing. Issue: error during search of file paths for the sound files. Using a 'jar' path with "Path.of" causes an exception, which aborted the flow to find the sound files. Further, there is no logic to even find resources in a Jar file - that was added.

Tested when building locally & also packaged - verified the installed game also plays sounds.
