### PR TITLE
Git-Blame: add an ignore for formatting commits (requires dev git config)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Google java format (#4948)
+d5fb80f3d23310229d4c826b0398e92b3fea99ab

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -64,6 +64,13 @@ If you are new to Open Source & GitHub:
   - [Create an SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
     (usually you will not need to add the SSH key to your keychain, just create it and add it to GitHub)
 
+## Config Git Ignore Commits
+
+Run:
+```
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ## Compile and launch TripleA (CLI)
 
 ```bash


### PR DESCRIPTION
1. Add a file '.git-blame-ignore-revs' (supported in somewhat recent versions of git) that can ignore mass-formatting change commits. Helps 'git blame' be more useful to skip uninteresting changes.
2. Add dev config instruction, developers need to run a git config command for this file to be picked up.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
