### PR TITLE
Introduce build convention plugins for common project setup 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
-    id("java")
-    id("pmd")
+    id("java-library")
     id("eclipse")
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.spotless).apply(false)
@@ -11,10 +10,7 @@ tasks.named<Wrapper>("wrapper") {
 }
 
 subprojects {
-    apply(plugin = "checkstyle")
-    apply(plugin = "jacoco")
-    apply(plugin = "java")
-    apply(plugin = "pmd")
+    apply(plugin = "java-library")
 
     dependencies {
         implementation(rootProject.libs.jlayer) {
@@ -57,73 +53,5 @@ subprojects {
         testImplementation(rootProject.libs.wiremock.junit5)
         testRuntimeOnly(rootProject.libs.junit.jupiter.engine)
         testRuntimeOnly(rootProject.libs.junit.platform.launcher)
-    }
-
-    tasks.withType<JavaCompile>().configureEach {
-        options.compilerArgs.add("-Xlint:none,-processing")
-        options.encoding = "UTF-8"
-        options.setIncremental(true)
-    }
-
-    tasks.withType<Test>().configureEach {
-        useJUnitPlatform() {}
-        testLogging {
-            setExceptionFormat("full")
-            events("skipped", "failed")
-        }
-
-        val outputByTest = mutableMapOf<String, StringBuilder>()
-
-        addTestOutputListener { descriptor, event ->
-            val key = "${descriptor.className}.${descriptor.name}"
-            outputByTest.getOrPut(key) { StringBuilder() }.append(event.message)
-        }
-
-        addTestListener(object : TestListener {
-            override fun beforeSuite(suite: TestDescriptor) {}
-            override fun afterSuite(suite: TestDescriptor, result: TestResult) {}
-            override fun beforeTest(testDescriptor: TestDescriptor) {}
-
-            override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {
-                val key = "${testDescriptor.className}.${testDescriptor.name}"
-                val output = outputByTest.remove(key)
-                if (result.resultType == TestResult.ResultType.FAILURE && !output.isNullOrEmpty()) {
-                    println("\n-- Output for ${testDescriptor.displayName} --\n$output")
-                }
-            }
-        })
-    }
-
-    extensions.getByType<CheckstyleExtension>().apply {
-        toolVersion = rootProject.libs.versions.checkstyle.get()
-        configFile = rootProject.file(".build/checkstyle.xml")
-        configProperties = mapOf("samedir" to configFile.parent)
-    }
-
-    tasks.named("checkstyleMain", Checkstyle::class.java) {
-        maxWarnings = 0
-        source(sourceSets.main.get().output.resourcesDir)
-    }
-
-    tasks.named("checkstyleTest", Checkstyle::class.java) {
-        maxWarnings = 0
-        source(sourceSets.test.get().output.resourcesDir)
-        exclude("**/map-xmls/*.xml")
-    }
-
-    tasks.named("jacocoTestReport", JacocoReport::class.java) {
-        reports {
-            xml.required = true
-            xml.outputLocation = project.layout.buildDirectory.file("jacoco.xml")
-            html.required = true
-        }
-    }
-
-    pmd {
-        setConsoleOutput(true)
-        ruleSetFiles = files(rootProject.file(".build/pmd.xml"))
-        ruleSets = listOf()
-        incrementalAnalysis = true
-        toolVersion = rootProject.libs.versions.pmd.get()
     }
 }

--- a/docs/development/build-overview-and-development.md
+++ b/docs/development/build-overview-and-development.md
@@ -21,16 +21,34 @@ This allows you to reference projects using non-hierarchical names, for example 
 ## Convention Plugins
 
 The TripleA build defines Gradle [Convention Plugins](https://docs.gradle.org/current/userguide/implementing_gradle_plugins_convention.html#header) to avoid cross-project configuration and duplication of configuration.
-There are currently the following types of projects:
+There are currently the following convention plugins:
+
+### `triplea-test-conventions`
+
+Configures testing for all TripleA projects.
+Applies the `jacoco` plugin and configures all `Test` tasks to use the JUnit platform with full exception formatting.
+Test output (stdout/stderr) is captured per-test and printed only when a test fails, to keep successful build output clean.
+Also configures Jacoco XML and HTML coverage reports.
+
+### `triplea-base-project`
+
+The base convention applied by all TripleA projects.
+Currently applies `triplea-test-conventions`.
 
 ### `triplea-java-library`
 
-This is a standard "vanilla" java library type.
-It applies the `java-library` plugin and applies universal configuration, code conventions, and sets up static analysis. 
+The standard convention for a TripleA Java library project.
+Applies the `java-library` plugin, sets Java 21 source and target compatibility, applies `triplea-base-project`, and configures [Spotless](https://github.com/diffplug/spotless) formatting (Google Java Format, remove unused imports, trailing whitespace removal, tabs to spaces, newline at end of file).
+
+### `triplea-java-application`
+
+The standard convention for a runnable TripleA application project.
+Applies the `application` plugin and `triplea-base-project`.
 
 ### `triplea-published-library`
 
-This convention expands on `triplea-java-library` to add tasks to publish a Java library project to Maven.
+Expands on `triplea-java-library` to add tasks to publish a Java library project to Maven.
+Applies the `maven-publish` plugin and reads the published version from the `JAR_VERSION` environment variable.
 
 ## Test Fixtures
 
@@ -42,7 +60,8 @@ The fixture in `:game-core` includes map data present in `/game-app/game-core/sr
 # Future Work
 
 To continue to improve build speeds and make the build structure more idiomatic, some near future work should:
-- Remove the use of `subprojects` and `allprojects` and replace these with Gradle [Convention Plugins](https://docs.gradle.org/current/userguide/implementing_gradle_plugins_convention.html#header).
+
+- Remove the use of `subprojects` for dependency declarations by migrating these to the appropriate (or new) Gradle [Convention Plugins](https://docs.gradle.org/current/userguide/implementing_gradle_plugins_convention.html#header).
 This will make the build easier to maintain by avoiding the pitfalls of cross-project configuration, it will prevent difficulties updating to future Gradle versions, and it will prepare the build to take advantage of future Gradle features like [Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html#header) that will further increase build speed.
 - Remove the need for bash scripts like those in `/game-app/run/` or `/verify` that exist only to launch Gradle builds with Gradle lifecycle tasks. 
 - Improve Dependency hygiene by enabling Gradle Dependabot alerts on GitHub, pruning unused project dependencies, properly using the `api` and `implementation` configurations to export dependencies only when necessary, etc.

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -3,15 +3,12 @@ package games.strategy.triplea;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -3,12 +3,15 @@ package games.strategy.triplea;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/gradle/build-logic/settings.gradle.kts
+++ b/gradle/build-logic/settings.gradle.kts
@@ -19,4 +19,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "build-logic"
 
-include("failure-summary-plugin", "triplea-java-library", "triplea-published-library")
+include("failure-summary-plugin", "triplea-test-conventions", "triplea-base-project",
+    "triplea-java-library", "triplea-java-application", "triplea-published-library", )

--- a/gradle/build-logic/triplea-base-project/build.gradle.kts
+++ b/gradle/build-logic/triplea-base-project/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    `kotlin-dsl`
+    checkstyle
+    pmd
+}
+
+dependencies {
+    implementation(project(":triplea-test-conventions"))
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:none,-processing")
+    options.encoding = "UTF-8"
+    options.setIncremental(true)
+}
+
+extensions.getByType<CheckstyleExtension>().apply {
+    toolVersion = rootProject.libs.versions.checkstyle.get()
+    configFile = rootProject.file(".build/checkstyle.xml")
+    configProperties = mapOf("samedir" to configFile.parent)
+}
+
+tasks.named("checkstyleMain", Checkstyle::class.java) {
+    maxWarnings = 0
+    source(sourceSets.main.get().output.resourcesDir)
+}
+
+tasks.named("checkstyleTest", Checkstyle::class.java) {
+    maxWarnings = 0
+    source(sourceSets.test.get().output.resourcesDir)
+    exclude("**/map-xmls/*.xml")
+}
+
+pmd {
+    setConsoleOutput(true)
+    ruleSetFiles = files(rootProject.file(".build/pmd.xml"))
+    ruleSets = listOf()
+    incrementalAnalysis = true
+    toolVersion = rootProject.libs.versions.pmd.get()
+}
+
+description = """This project creates a pre-compiled script plugin that defines basic conventions used by all projects in the build.  
+This avoids the need for `subprojects` and `allprojects`, and keeps project configuration local."""

--- a/gradle/build-logic/triplea-base-project/src/main/kotlin/triplea-base-project.gradle.kts
+++ b/gradle/build-logic/triplea-base-project/src/main/kotlin/triplea-base-project.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("triplea-test-conventions")
+}

--- a/gradle/build-logic/triplea-java-application/build.gradle.kts
+++ b/gradle/build-logic/triplea-java-application/build.gradle.kts
@@ -3,9 +3,8 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.spotless)
     implementation(project(":triplea-base-project"))
 }
 
-description = """This project creates a pre-compiled script plugin that defines a conventional library project used in the build.  
+description = """This project creates a pre-compiled script plugin that defines a conventional application project used in the build.  
 This avoids the need for `subprojects` and `allprojects`, and keeps project configuration local."""

--- a/gradle/build-logic/triplea-java-application/src/main/kotlin/triplea-java-application.gradle.kts
+++ b/gradle/build-logic/triplea-java-application/src/main/kotlin/triplea-java-application.gradle.kts
@@ -1,0 +1,9 @@
+/*
+  This convention defines a standard TripleA java application project.
+  It applies the `application` plugin and applies universal configuration.
+*/
+
+plugins {
+    id("application")
+    id("triplea-base-project")
+}

--- a/gradle/build-logic/triplea-java-library/src/main/kotlin/triplea-java-library.gradle.kts
+++ b/gradle/build-logic/triplea-java-library/src/main/kotlin/triplea-java-library.gradle.kts
@@ -6,6 +6,7 @@
 plugins {
     `java-library`
     id("com.diffplug.spotless")
+    id("triplea-base-project")
 }
 
 group = "triplea"

--- a/gradle/build-logic/triplea-test-conventions/build.gradle.kts
+++ b/gradle/build-logic/triplea-test-conventions/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    `kotlin-dsl`
+}
+
+description = """This project creates a pre-compiled script plugin that defines testing conventions used by all projects in the build."""

--- a/gradle/build-logic/triplea-test-conventions/src/main/kotlin/triplea-test-conventions.gradle.kts
+++ b/gradle/build-logic/triplea-test-conventions/src/main/kotlin/triplea-test-conventions.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    jacoco
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform() {}
+    testLogging {
+        setExceptionFormat("full")
+        events("skipped", "failed")
+    }
+
+    val outputByTest = mutableMapOf<String, StringBuilder>()
+
+    addTestOutputListener { descriptor, event ->
+        val key = "${descriptor.className}.${descriptor.name}"
+        outputByTest.getOrPut(key) { StringBuilder() }.append(event.message)
+    }
+
+    addTestListener(object : TestListener {
+        override fun beforeSuite(suite: TestDescriptor) {}
+        override fun afterSuite(suite: TestDescriptor, result: TestResult) {}
+        override fun beforeTest(testDescriptor: TestDescriptor) {}
+
+        override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {
+            val key = "${testDescriptor.className}.${testDescriptor.name}"
+            val output = outputByTest.remove(key)
+            if (result.resultType == TestResult.ResultType.FAILURE && !output.isNullOrEmpty()) {
+                println("\n-- Output for ${testDescriptor.displayName} --\n$output")
+            }
+        }
+    })
+}
+
+tasks.withType<JacocoReport>().configureEach {
+    reports {
+        xml.required = true
+        xml.outputLocation = project.layout.buildDirectory.file("jacoco.xml")
+        html.required = true
+    }
+}


### PR DESCRIPTION
Extracts shared Gradle configurations from the root `build.gradle.kts` `subprojects` block into dedicated convention plugins.

This refactoring centralizes reusable build logic for:
*   `triplea-test-conventions`: JUnit Platform, test logging, custom test output, and JaCoCo' includes the testing setup added in https://github.com/triplea-game/triplea/pull/14284.
*   `triplea-base-project`: Java compiler options, Checkstyle, and PMD. This plugin also applies `triplea-test-conventions`.
*   `triplea-java-application`: Applies the `application` plugin and `triplea-base-project`.
*   `triplea-java-library`: Applies `java-library`, Spotless, and `triplea-base-project`.
