### PR TITLE
Fix(crash with sounds): Paths with spaces no longer cause crashes

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -13,13 +13,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.jar.JarFile;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
@@ -257,33 +258,26 @@ public class ResourceLoader implements Closeable {
   }
 
   private static List<URL> listJarResources(final URI jarUri) throws IOException {
-    // jarUri format: jar:file:/path/to/app.jar!/entry/path
-    // e.g. jar:file:/opt/triplea/triplea.jar!/assets/flags
     final String spec = jarUri.getSchemeSpecificPart();
     final int bang = spec.indexOf('!');
-    // jarFilePart: the file: URI pointing to the JAR on disk, e.g. file:/opt/triplea/triplea.jar
-    final String jarFilePart = spec.substring(0, bang);
-    // entryPath: the path inside the JAR, e.g. assets/flags or assets/flags/germany.png
-    final String entryPath = spec.substring(bang + 2); // strip leading "!/"
+    final Path jarPath = Path.of(URI.create(spec.substring(0, bang)));
+    final String entryPath = "/" + spec.substring(bang + 2);
 
-    try (var jar = new JarFile(Path.of(URI.create(jarFilePart)).toFile())) {
-      // If entryPath points directly to a file inside the JAR (not a directory),
-      // return just that single resource, e.g. assets/sounds/hit.wav
-      final var singleEntry = jar.getEntry(entryPath);
-      if (singleEntry != null && !singleEntry.isDirectory()) {
-        return asUrl(URI.create("jar:" + jarFilePart + "!/" + entryPath))
-            .map(List::of)
-            .orElse(List.of());
+    try (FileSystem fs = FileSystems.newFileSystem(jarPath)) {
+      final Path dir = fs.getPath(entryPath);
+      if (!Files.exists(dir)) {
+        return List.of();
       }
-      // Otherwise treat entryPath as a directory prefix and return all files beneath it.
-      // Matches entries like assets/flags/germany.png, assets/flags/usa.png, etc.
-      // Directories themselves are excluded so only loadable resource files are returned.
-      final String prefix = entryPath.endsWith("/") ? entryPath : entryPath + "/";
-      return jar.stream()
-          .filter(e -> e.getName().startsWith(prefix) && !e.isDirectory())
-          .map(e -> asUrl(URI.create("jar:" + jarFilePart + "!/" + e.getName())))
-          .flatMap(Optional::stream)
-          .toList();
+      if (!Files.isDirectory(dir)) {
+        return asUrl(dir.toUri()).map(List::of).orElse(List.of());
+      }
+      try (var stream = Files.walk(dir, 1)) {
+        return stream
+            .filter(Files::isRegularFile)
+            .map(p -> asUrl(p.toUri()))
+            .flatMap(Optional::stream)
+            .toList();
+      }
     }
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -158,12 +158,12 @@ final class ResourceLoaderTest {
       var jarPath =
           buildJar(
               tempDir.resolve("test.jar"),
-              "sounds/game_start/",
-              "sounds/game_start/sound1.mp3",
-              "sounds/game_start/sound2.mp3");
+              "sounds/game start/",
+              "sounds/game start/sound1.mp3",
+              "sounds/game start/sound2.mp3");
       try (var loader = new ResourceLoader(jarPath)) {
 
-        var result = loader.listResources("sounds/game_start");
+        var result = loader.listResources("sounds/game start");
 
         assertThat("JAR directory entry should yield both contained files", result, hasSize(2));
         assertThat(


### PR DESCRIPTION
Adds a test to expose crash and fixes. Typically windows users saw this, the "Program Files" usually did it.

Use java.nio.file.FileSystem instead of java.util.jar.JarFile for jar file reading, avoids issues of converting to and from URLs. That process is what prevouisly caused the crashes, as the URL needs to be properly encoded (spaces not allowed)

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
