### PR TITLE
Fix(bot network play): Fix crash for Optional values being serialized

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
@@ -3,6 +3,7 @@ package games.strategy.engine.message;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Optional;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
 
@@ -55,6 +56,11 @@ class UnifiedInvocationHandler extends WrappedInvocationHandler {
     final RemoteMethodCallResults response = messenger.invokeAndWait(endPointName, remoteMethodMsg);
     if (response.getException() != null) {
       throw new RuntimeException("Exception on remote", response.getException());
+    }
+    // Wrap into Optional if the method declares Optional as its return type.
+    // Optional is not serializable, so it would come as an unwrapped value over the network.
+    if (method.getReturnType() == Optional.class) {
+      return Optional.ofNullable(response.getRVal());
     }
     return response.getRVal();
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
@@ -7,6 +7,7 @@ import games.strategy.net.INode;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicLong;
@@ -135,7 +136,10 @@ class EndPoint {
     MessageContext.setSenderNodeForThread(messageOriginator);
     try {
       final Object methodRVal = method.invoke(implementor, call.getArgs());
-      return new RemoteMethodCallResults(methodRVal);
+      // Optional is not Serializable; unwrap to the contained value or null for network transfer.
+      final Object serializable =
+          methodRVal instanceof Optional ? ((Optional<?>) methodRVal).orElse(null) : methodRVal;
+      return new RemoteMethodCallResults(serializable);
     } catch (final InvocationTargetException e) {
       return new RemoteMethodCallResults(e.getTargetException());
     } catch (final IllegalAccessException | IllegalArgumentException e) {


### PR DESCRIPTION
__Issue__
Fixes crash when playing bot games. After the first player move, the game appears frozen.

__Context__
Optional is not a serializable type. We were trying to serialize Optional as part of bot-network-play.

__Fix__
To fix this, we can have the server and client unwrap Optional values to a null value, send that over the wire, and then wrap the value back up into an Optional on the other end.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
