### PR TITLE
Dice-Server: change default dice server to 'new' MARTI

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
@@ -20,6 +20,6 @@ public final class UrlConstants {
   public static final String RELEASE_NOTES = "https://triplea-game.org/release_notes/";
   public static final String TRIPLEA_FORUM = "https://forums.triplea-game.org/";
   public static final String USER_GUIDE = "https://triplea-game.org/user-guide/";
-  public static final String MARTI_REGISTRATION = "https://dice.marti.triplea-game.org/";
+  public static final String MARTI_REGISTRATION = "https://dice.triplea-game.org/";
   public static final String PROD_LOBBY = "https://prod.triplea-game.org";
 }


### PR DESCRIPTION
- There was a dice server rewrite by @RoiEX and @steven.soloff that was nearly complete but shelved. That rewrite was recently dusted off, incorporated into deployment infrastrucure and is now live.

- This new dice server should work in a very similar way as the previous marti dice server.

- This update will allow us to migrate off of the old MARTI dice server once the 2.7 cut-over is completed (saving $24/month!)

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
