### PR TITLE
fix(IDEA launch): dirty hack to be able to run the game directly via IDEA

### DIFF
--- a/.idea/runConfigurations/HeadedGameRunner.xml
+++ b/.idea/runConfigurations/HeadedGameRunner.xml
@@ -1,5 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="HeadedGameRunner" type="Application" factoryName="Application" singleton="false" nameIsGenerated="true">
+    <classpathModifications>
+      <entry path="$PROJECT_DIR$/game-app/game-headed/build/assets" />
+    </classpathModifications>
     <option name="MAIN_CLASS_NAME" value="org.triplea.game.client.HeadedGameRunner" />
     <module name="triplea.game-headed.main" />
     <option name="VM_PARAMETERS" value="-Xss1250K -Dsun.java2d.uiScale.enabled=false --add-opens java.desktop/com.apple.eawt.event=ALL-UNNAMED" />

--- a/game-app/game-core/src/main/java/games/strategy/triplea/EngineImageLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/EngineImageLoader.java
@@ -4,6 +4,8 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
+import java.util.function.Function;
 import javax.imageio.ImageIO;
 import lombok.experimental.UtilityClass;
 
@@ -29,20 +31,30 @@ public class EngineImageLoader {
    * @return the loaded image
    */
   public BufferedImage loadImage(final String... assetsImageFileStrings) {
-    String imageFileLocation = ResourceLoader.getAssetsFileLocation(assetsImageFileStrings);
-    try (InputStream is =
-        EngineImageLoader.class.getClassLoader().getResourceAsStream(imageFileLocation)) {
-      if (is == null) {
-        throw new IllegalStateException(
-            "Error loading image at: "
-                + imageFileLocation
-                + ", input stream is null (check that the resource exists on the classpath at this location)");
-      } else {
-        return ImageIO.read(is);
-      }
+    // simple function to return a resource stream if we can read it
+    Function<String, Optional<InputStream>> tryStream =
+        path ->
+            Optional.ofNullable(EngineImageLoader.class.getClassLoader().getResourceAsStream(path));
+
+    // first attempt to read the resource is with the assets folder in the path, this is the typical case
+    final InputStream imageStream =
+        tryStream
+            .apply(ResourceLoader.getAssetsFileLocation(assetsImageFileStrings))
+            // Dirty hack Fallback for IDES to read the resource directly.
+            // This will work if the classpath to the 'assets' folder has been set explicitly in IDE,
+            // eg: check IDEA headedGameRunner launcher configuration.
+            .or(() -> tryStream.apply(String.join("/", assetsImageFileStrings)))
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Image not found error: "
+                            + assetsImageFileStrings
+                            + ", check that asset folder is present."));
+
+    try (imageStream) {
+      return ImageIO.read(imageStream);
     } catch (IOException e) {
-      throw new IllegalStateException(
-          "Error loading image at: " + imageFileLocation + ", " + e.getMessage(), e);
+      throw new RuntimeException("Unexpected error reading image file", e);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/EngineImageLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/EngineImageLoader.java
@@ -36,12 +36,14 @@ public class EngineImageLoader {
         path ->
             Optional.ofNullable(EngineImageLoader.class.getClassLoader().getResourceAsStream(path));
 
-    // first attempt to read the resource is with the assets folder in the path, this is the typical case
+    // first attempt to read the resource is with the assets folder in the path, this is the typical
+    // case
     final InputStream imageStream =
         tryStream
             .apply(ResourceLoader.getAssetsFileLocation(assetsImageFileStrings))
             // Dirty hack Fallback for IDES to read the resource directly.
-            // This will work if the classpath to the 'assets' folder has been set explicitly in IDE,
+            // This will work if the classpath to the 'assets' folder has been set explicitly in
+            // IDE,
             // eg: check IDEA headedGameRunner launcher configuration.
             .or(() -> tryStream.apply(String.join("/", assetsImageFileStrings)))
             .orElseThrow(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -37,7 +37,7 @@ import org.triplea.java.UrlStreams;
  */
 @Slf4j
 public class ResourceLoader implements Closeable {
-  private static final String ASSETS_FOLDER = "assets";
+  public static final String ASSETS_FOLDER = "assets";
 
   private final URLClassLoader loader;
 


### PR DESCRIPTION
With this fix, IDEA can launch TripleA natively (and not through gradle). This is a benefit as it helps the debugger, otherwise debugging client-network-games is not possible.

This is hacky fix, we add the 'assets' folder to the path directly. Then, as a fallback when resource loading, we try to read the asset path as if it were not in the assets fodler (which works when the assets folder is on the path explicitly)

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
