### PR TITLE
DevX: add a pre-commit file with Makefile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  # Runs formatting (./gradlew spotlessApply)
+  - repo: local
+    hooks:
+      - id: format
+        name: Format
+        entry: make format
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+MAKEFLAGS += --always-make
+SHELL := bash
+.SHELLFLAGS := -eu -o pipefail -c
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+setup: ## Install pre-commit hooks
+	pre-commit install --hook-type pre-push
+
+format: ## Apply code formatting
+	./gradlew spotlessApply
+


### PR DESCRIPTION
- pre-commit file can be used to help ensure formatting has been applied before pushing

- Makefile is useful as an 'index' of dev commands, one of which being "make format"

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
