### PR TITLE
UI(reconnect window): do not hightlight 'disconnect' button by default

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/ReconnectOverlay.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/ReconnectOverlay.java
@@ -41,6 +41,9 @@ class ReconnectOverlay {
             .add(content)
             .build();
     dialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
+    // Switch focus to the overaly, so that a user does not activate the 'disconnect' button
+    // by pressing space (which is easy when chatting).
+    SwingUtilities.invokeLater(() -> dialog.getRootPane().requestFocusInWindow());
   }
 
   /** Shows (or updates) the overlay for the given 1-based reconnect attempt number. */


### PR DESCRIPTION
Fixes issue when reconnect window opens, the 'disconnect' button is the active button and pressing 'space' will trigger it. If a user is typing a message in chat when this happens, they may very likely activate that disconnect button (quickly) without intentionally wanting to do so.

This fix changes the focus to the overlay window instead of the button, thereby requiring the user to click the button or use tab to select the button and then space.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
