### PR TITLE
Fix(map centering): fix map not centering on players capital

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -61,6 +61,7 @@ import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.java.concurrency.AsyncRunner;
 import org.triplea.sound.SoundPath;
+import org.triplea.swing.SwingAction;
 import org.triplea.swing.jpanel.JPanelBuilder;
 import org.triplea.util.Tuple;
 
@@ -149,7 +150,25 @@ public class TripleAPlayer extends AbstractBasePlayer {
     // (ISomeDelegate) getPlayerBridge().getRemote()
     // We should never touch the game data directly. All changes to game data are done through the
     // remote, which then changes the game using the DelegateBridge -> change factory
-    ui.requiredTurnSeries(this.getGamePlayer());
+    final boolean isFirstStepOfTurn;
+    try (GameData.Unlocker ignored = getGameData().acquireReadLock()) {
+      final var sequence = getGameData().getSequence();
+      final int currentIndex = sequence.getStepIndex();
+      if (currentIndex == 0) {
+        isFirstStepOfTurn = true;
+      } else {
+        final GamePlayer previousStepPlayer = sequence.getStep(currentIndex - 1).getPlayerId();
+        isFirstStepOfTurn = !getGamePlayer().equals(previousStepPlayer);
+      }
+    }
+
+    if (isFirstStepOfTurn) {
+      try {
+        SwingAction.invokeAndWait(() -> ui.startPlayerTurn(this.getGamePlayer()));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
     enableEditModeMenu();
     boolean badStep = false;
     if (GameStep.isTechStepName(name)) {

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1701,38 +1701,18 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
    * Invoked at the start of a player's turn to play a sound alerting the player it is their turn
    * and to center the map on the player's capital.
    */
-  public void requiredTurnSeries(final GamePlayer player) {
+  public void startPlayerTurn(final GamePlayer player) {
     if (player == null || !Interruptibles.sleep(300)) {
       return;
     }
-    Interruptibles.await(
-        () ->
-            SwingAction.invokeAndWait(
-                () -> {
-                  final Boolean play = requiredTurnSeries.get(player);
-                  if (play != null && play) {
-                    uiContext
-                        .getClipPlayer()
-                        .play(SoundPath.CLIP_REQUIRED_YOUR_TURN_SERIES, player);
-                    requiredTurnSeries.put(player, false);
-                  }
-                  // center on capital of player, if it is a new none-AI player
-                  if (uiContext.setCurrentPlayer(player)) {
-                    bottomBar.updateFromCurrentPlayer();
-                    if (!player.isAi()) {
-                      // assume missing offset means there is a new mapPanel build up for which
-                      // centering is not updating without repaint
-                      final boolean repaintRequired =
-                          (mapPanel.getXOffset() == 0 && mapPanel.getYOffset() == 0);
-                      try (GameData.Unlocker ignored = data.acquireReadLock()) {
-                        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(
-                                player, data.getMap())
-                            .ifPresent(territory -> mapPanel.centerOn(territory));
-                        if (repaintRequired) mapPanel.repaint();
-                      }
-                    }
-                  }
-                }));
+    uiContext.getClipPlayer().play(SoundPath.CLIP_REQUIRED_YOUR_TURN_SERIES, player);
+    bottomBar.updateFromCurrentPlayer();
+
+    try (GameData.Unlocker ignored = data.acquireReadLock()) {
+      TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap())
+          .ifPresent(territory -> mapPanel.centerOn(territory));
+      mapPanel.repaint();
+    }
   }
 
   private String getUnitInfo() {


### PR DESCRIPTION
A fix to move the map to a players capital at the start of their turn. The code that was supposed to be doing this was a complicated.

Fixes:
- add some logic to detect start of turn by looking at game steps.
- actually invoke the code that is supposed to run at the start of a players turn, at just the start of their turn.

Key issue:
- the code that runs at the start of a players turn made some assumptions about the 'player' variable and the player set on the 'uicontext'. Nothing could be done there as those values always match the latest player, and can't be used to determine if the turn has actually changed or not. The key is to move the detection of the new turn up a layer, and then we could simplify and fix.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
