### PR TITLE
Extract HttpHeaders to lobby-client-data package so they can be shared

### DIFF
--- a/http-clients/lobby-client-data/src/main/java/org/triplea/http/client/HttpHeaders.java
+++ b/http-clients/lobby-client-data/src/main/java/org/triplea/http/client/HttpHeaders.java
@@ -1,0 +1,9 @@
+package org.triplea.http.client;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class HttpHeaders {
+  public static final String VERSION_HEADER = "Triplea-Version";
+  public static final String SYSTEM_ID_HEADER = "System-Id";
+}

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/ClientIdentifiers.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/ClientIdentifiers.java
@@ -9,8 +9,6 @@ import lombok.Builder;
 
 @Builder
 public class ClientIdentifiers {
-  public static final String VERSION_HEADER = "Triplea-Version";
-  private static final String SYSTEM_ID_HEADER = "System-Id";
 
   @Nonnull private final String applicationVersion;
   @Nonnull private final String systemId;
@@ -19,8 +17,8 @@ public class ClientIdentifiers {
   /** Creates headers containing 'System-Id' only. */
   public Map<String, String> createHeaders() {
     final Map<String, String> headerMap = new HashMap<>();
-    headerMap.put(VERSION_HEADER, applicationVersion);
-    headerMap.put(SYSTEM_ID_HEADER, systemId);
+    headerMap.put(HttpHeaders.VERSION_HEADER, applicationVersion);
+    headerMap.put(HttpHeaders.SYSTEM_ID_HEADER, systemId);
     Optional.ofNullable(apiKey)
         .ifPresent(apiKey -> headerMap.put("Authorization", "Bearer " + apiKey));
     return headerMap;


### PR DESCRIPTION
Allows servers access to the shared HTTP header constants, notably by adding those constants to the shared library between server & client.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
