### PR TITLE
Maps-Listing: Use a response object instead of a direct list

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/listing/MapListingFetcher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/listing/MapListingFetcher.java
@@ -35,7 +35,8 @@ public class MapListingFetcher {
                   .applicationVersion(ProductVersionReader.getCurrentVersion().toMajorMinorString())
                   .systemId(SystemIdLoader.load().getValue())
                   .build())
-          .fetchMapListing();
+          .fetchMapListing()
+          .getMaps();
     } catch (FeignException e) {
       log.warn(
           "Failed to download the list of available maps from TripleA servers.\n"

--- a/http-clients/lobby-client-data/src/main/java/org/triplea/http/client/lobby/maps/listing/MapListingResponse.java
+++ b/http-clients/lobby-client-data/src/main/java/org/triplea/http/client/lobby/maps/listing/MapListingResponse.java
@@ -1,0 +1,17 @@
+package org.triplea.http.client.lobby.maps.listing;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
+public class MapListingResponse {
+  List<MapDownloadItem> maps;
+}

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
@@ -3,10 +3,10 @@ package org.triplea.http.client.maps.listing;
 import feign.FeignException;
 import feign.RequestLine;
 import java.net.URI;
-import java.util.List;
 import org.triplea.http.client.ClientIdentifiers;
 import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.ServerPaths;
+import org.triplea.http.client.lobby.maps.listing.MapListingResponse;
 
 /**
  * Http client to communicate with the maps server and get a listing of maps available for download.
@@ -22,5 +22,5 @@ public interface MapsClient {
    * @throws FeignException Thrown on non-2xx responses.
    */
   @RequestLine("GET " + ServerPaths.MAPS_LISTING_PATH)
-  List<org.triplea.http.client.lobby.maps.listing.MapDownloadItem> fetchMapListing();
+  MapListingResponse fetchMapListing();
 }


### PR DESCRIPTION
JSON responses are best when they are objects and not a raw list. A raw list is not flexible, you can't add additional attributes to the responses.

This update adds a response object for the maps listing and uses that as the respected return value for a maps-listing fetch.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
