### PR TITLE
fix(NPE): resolve NPE for gamePlayer with null data

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -119,6 +119,19 @@ public class GameData implements Serializable, GameState {
   private List<Tuple<IAttachment, List<Tuple<String, String>>>> attachmentOrderAndValues =
       new ArrayList<>();
 
+  @Setter private static GameData current;
+
+  /**
+   * A reference to the latest 'live' game data. If you need to grab a live game data reference,
+   * this is a good choice rather than searching from GameDataComponents looking for one (where it
+   * might be null). On the other hand, USE GREAT CAUTION: avoid using 'current()' with
+   * GameDataComponent's themselves. The reason is they can be cloned and then the cloned instances
+   * could have a reference to the live game data, so be careful of that.
+   */
+  public static GameData current() {
+    return current;
+  }
+
   private transient GameDataEventListeners gameDataEventListeners = new GameDataEventListeners();
 
   private static Unlocker acquireLock(Lock lock) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
@@ -229,7 +229,8 @@ public class GamePlayer extends NamedAttachable implements NamedUnitHolder {
       if (techAttachment == null) {
         // don't crash, as a map xml may not set the tech attachment for all players, so just create
         // a new tech attachment for them
-        techAttachment = new TechAttachment(Constants.TECH_ATTACHMENT_NAME, this, getData());
+        techAttachment =
+            new TechAttachment(Constants.TECH_ATTACHMENT_NAME, this, GameData.current());
       }
     }
     return techAttachment;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
@@ -230,7 +230,10 @@ public class GamePlayer extends NamedAttachable implements NamedUnitHolder {
         // don't crash, as a map xml may not set the tech attachment for all players, so just create
         // a new tech attachment for them
         techAttachment =
-            new TechAttachment(Constants.TECH_ATTACHMENT_NAME, this, GameData.current());
+            new TechAttachment(
+                Constants.TECH_ATTACHMENT_NAME,
+                this,
+                super.getData() != null ? super.getData() : GameData.current());
       }
     }
     return techAttachment;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -58,6 +58,7 @@ public abstract class AbstractGame implements IGame {
       final Messengers messengers,
       final ClientNetworkBridge clientNetworkBridge) {
     gameData = data;
+    GameData.setCurrent(data);
     this.messengers = messengers;
     this.clientNetworkBridge = clientNetworkBridge;
     vault = new Vault(messengers);

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -194,6 +194,7 @@ public class ClientGame extends AbstractGame {
       return;
     }
     isGameOver = true;
+    GameData.setCurrent(null);
     try {
       messengers.unregisterChannelSubscriber(gameModifiedChannel, IGame.GAME_MODIFICATION_CHANNEL);
       messengers.unregisterRemote(getRemoteStepAdvancerName(messengers.getLocalNode()));

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -360,6 +360,7 @@ public class ServerGame extends AbstractGame {
     }
 
     isGameOver = true;
+    GameData.setCurrent(null);
     delegateExecutionStoppedLatch.countDown();
     // tell the players (especially the AI's) that the game is stopping, so stop doing stuff.
     for (final Player player : gamePlayers.values()) {


### PR DESCRIPTION
To repro: save a game of greyhawk_wars in 2.5, load in 2.7. Proceed through, select at least one of the "I am a human" buttons, then proceed. Note at the
start of the next turn, NPE.

Cause: the 2.5 save attaches a null GameData to the GamePlayer for neutrals. In this map we have a tech attachment that touches the nuetrals, which then tries to fetch a game data.

Fix: add a static gameData accessible to places that just need a reference to the live game data. A lot of care is needed when using this, we clone game entities like crazy and should be sure that the clones use the cloned game data, not the live copy.

Fixes#13685

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
