### PR TITLE
Fix(edit mode combat crash): fix crash when AA guns fire in edit mode

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -562,11 +562,13 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
                 }
               }
             };
-        // push in reverse order of execution
-        stack.push(removeHits);
-        stack.push(notifyCasualties);
-        stack.push(calculateCasualties);
+        // In edit mode, AA dice are not rolled, so the rest of the AA-fire chain
+        // is skipped.
         if (!isEditMode) {
+          // push in reverse order of execution
+          stack.push(removeHits);
+          stack.push(notifyCasualties);
+          stack.push(calculateCasualties);
           stack.push(roll);
         }
       }


### PR DESCRIPTION
This regressed (or was re-introduced) when 186c994 ("Remove special handling of battle logic for edit mode.") was reverted in f3ae9b0e0.

Issue: when in edit mode, the 'dice' rolled is null and then goes on to trigger a NPE.

Fix: we skip rolling AA dice in edit mode, this update skips the casualty selection that otherwise went on to NPE

How to repro:
- Big World 2
- start new game
- send german bomber to bomb france
- enable edit mode before starting the combat
- click through to the battle
- do not scramble the french fighter jets
- note: NPE is raised

Fixes: #13955

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
