### PR TITLE
fix(lobby games EDT issue): fix crash when lobby games reconnect

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameListingModel.java
@@ -38,10 +38,15 @@ class LobbyGameListingModel {
 
     connection.addMessageListener(
         LobbyGameUpdatedMessage.TYPE,
-        msg -> lobbyGameBroadcaster.gameUpdated(msg.getLobbyGameListing()));
+        msg ->
+            SwingUtilities.invokeLater(
+                () -> lobbyGameBroadcaster.gameUpdated(msg.getLobbyGameListing())));
 
     connection.addMessageListener(
-        LobbyGameRemovedMessage.TYPE, msg -> lobbyGameBroadcaster.gameRemoved(msg.getGameId()));
+        LobbyGameRemovedMessage.TYPE,
+        msg -> //
+        SwingUtilities.invokeLater( //
+                () -> lobbyGameBroadcaster.gameRemoved(msg.getGameId())));
 
     connection.fetchGameListing().forEach(lobbyGameBroadcaster::gameUpdated);
   }


### PR DESCRIPTION
- Root cause is updates to table model off of the EDT. This causes inconsistencies in sizes compared to update and render time.
- Fix: do table model updates on EDT

What this fixed? When bots reconnect, say after a lobby disconnect or simply on their own, there could be a crash for index-out-of-bounds. This update fixes that.

Fixes #14319

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
