### PR TITLE
fix(multiplayer): always release latch when players fail to join

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -240,13 +240,17 @@ public class ServerGame extends AbstractGame {
           () -> {
             try {
               blockingObserver.joinGame(bytes, playerManager.getPlayerMapping());
-              waitOnObserver.countDown();
             } catch (final Exception e) {
               if (e.getCause() instanceof ConnectionLostException) {
                 log.error("Connection lost to observer while joining: " + newNode.getName(), e);
               } else {
                 log.error("Failed to join game", e);
               }
+            } finally {
+              // Always release the awaiter so the host doesn't sit on the delegate
+              // write lock for serverObserverJoinWaitTime (default 180s) when a join
+              // aborts mid-flight.
+              waitOnObserver.countDown();
             }
           });
       try {


### PR DESCRIPTION
Moves latch release for when observers join to a finally block. If the observer aborts their join, the latch will be properly released rather than waiting for timeout.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
