### PR TITLE
fix(multiplayer): listener leak

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
@@ -5,11 +5,16 @@ import games.strategy.engine.message.RemoteName;
 import games.strategy.net.Messengers;
 import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.settings.ClientSetting;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.web.socket.messages.envelopes.chat.ChatParticipant;
+import org.triplea.http.client.web.socket.messages.MessageType;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 import org.triplea.java.concurrency.AsyncRunner;
 
 /** Chat transmitter that sends and receives messages over Java NIO sockets. */
@@ -23,6 +28,7 @@ public class MessengersChatTransmitter implements ChatTransmitter {
   private final String chatName;
   private final String chatChannelName;
   private final ClientNetworkBridge clientNetworkBridge;
+  private final List<Runnable> listenerRemovals = new ArrayList<>();
 
   public MessengersChatTransmitter(
       final String chatName,
@@ -38,21 +44,27 @@ public class MessengersChatTransmitter implements ChatTransmitter {
   @Override
   public void setChatClient(final ChatClient chatClient) {
     chatChannelSubscriber = chatChannelSubscriber(chatClient);
-    clientNetworkBridge.addListener(
+    addTrackedListener(
         IChatChannel.ChatMessage.TYPE, message -> message.invokeCallback(chatChannelSubscriber));
-    clientNetworkBridge.addListener(
+    addTrackedListener(
         IChatChannel.PingMessage.TYPE, message -> message.invokeCallback(chatChannelSubscriber));
-    clientNetworkBridge.addListener(
+    addTrackedListener(
         IChatChannel.StatusChangedMessage.TYPE,
         message -> message.invokeCallback(chatChannelSubscriber));
-    clientNetworkBridge.addListener(
+    addTrackedListener(
         IChatChannel.SlapMessage.TYPE, message -> message.invokeCallback(chatChannelSubscriber));
-    clientNetworkBridge.addListener(
+    addTrackedListener(
         IChatChannel.SpeakAddedMessage.TYPE,
         message -> message.invokeCallback(chatChannelSubscriber));
-    clientNetworkBridge.addListener(
+    addTrackedListener(
         IChatChannel.SpeakerRemovedMessage.TYPE,
         message -> message.invokeCallback(chatChannelSubscriber));
+  }
+
+  private <T extends WebSocketMessage> void addTrackedListener(
+      final MessageType<T> messageType, final Consumer<T> listener) {
+    clientNetworkBridge.addListener(messageType, listener);
+    listenerRemovals.add(() -> clientNetworkBridge.removeListener(messageType, listener));
   }
 
   private IChatChannel chatChannelSubscriber(final ChatClient chatClient) {
@@ -96,7 +108,7 @@ public class MessengersChatTransmitter implements ChatTransmitter {
   public Collection<ChatParticipant> connect() {
     final String chatChannelName = ChatController.getChatChannelName(chatName);
     final IChatController controller = messengers.getRemoteChatController(chatName);
-    clientNetworkBridge.addListener(
+    addTrackedListener(
         IChatController.SetChatStatusMessage.TYPE, message -> message.invokeCallback(controller));
     messengers.addChatChannelSubscriber(chatChannelSubscriber, chatChannelName);
     return controller.joinChat();
@@ -113,6 +125,8 @@ public class MessengersChatTransmitter implements ChatTransmitter {
     }
     messengers.unregisterChannelSubscriber(
         chatChannelSubscriber, new RemoteName(chatChannelName, IChatChannel.class));
+    listenerRemovals.forEach(Runnable::run);
+    listenerRemovals.clear();
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -14,12 +14,17 @@ import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.ResourceLoader;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.NonNls;
+import org.triplea.http.client.web.socket.messages.MessageType;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 import org.triplea.sound.ISound;
 
 /**
@@ -47,6 +52,7 @@ public abstract class AbstractGame implements IGame {
 
   private final ClientNetworkBridge clientNetworkBridge;
   @Nullable private IDisplay display;
+  private final List<Runnable> displayListenerRemovals = new ArrayList<>();
   @Nullable private ISound sound;
 
   @Nullable private ResourceLoader resourceLoader;
@@ -131,27 +137,35 @@ public abstract class AbstractGame implements IGame {
 
     if (this.display != null) {
       messengers.unregisterChannelSubscriber(this.display, getDisplayChannel());
+      displayListenerRemovals.forEach(Runnable::run);
+      displayListenerRemovals.clear();
       this.display.shutDown();
     }
     if (display != null) {
       messengers.registerChannelSubscriber(display, getDisplayChannel());
 
-      clientNetworkBridge.addListener(
+      addTrackedDisplayListener(
           IDisplay.BombingResultsMessage.TYPE, message -> message.accept(display));
-      clientNetworkBridge.addListener(
+      addTrackedDisplayListener(
           IDisplay.NotifyRetreatMessage.TYPE,
           message -> message.accept(display, gameData.getPlayerList()));
-      clientNetworkBridge.addListener(
+      addTrackedDisplayListener(
           IDisplay.NotifyUnitsRetreatingMessage.TYPE,
           message -> message.accept(display, gameData.getUnits()));
-      clientNetworkBridge.addListener(
+      addTrackedDisplayListener(
           IDisplay.NotifyDiceMessage.TYPE, message -> message.accept(display));
-      clientNetworkBridge.addListener(
+      addTrackedDisplayListener(
           IDisplay.DisplayShutdownMessage.TYPE, message -> message.accept(display));
-      clientNetworkBridge.addListener(
+      addTrackedDisplayListener(
           IDisplay.GoToBattleStepMessage.TYPE, message -> message.accept(display));
     }
     this.display = display;
+  }
+
+  private <T extends WebSocketMessage> void addTrackedDisplayListener(
+      final MessageType<T> messageType, final Consumer<T> listener) {
+    clientNetworkBridge.addListener(messageType, listener);
+    displayListenerRemovals.add(() -> clientNetworkBridge.removeListener(messageType, listener));
   }
 
   public static RemoteName getSoundChannel() {

--- a/game-app/game-core/src/main/java/games/strategy/net/websocket/ClientNetworkBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/websocket/ClientNetworkBridge.java
@@ -27,12 +27,19 @@ public interface ClientNetworkBridge {
             final MessageType<T> messageType, final Consumer<T> messageConsumer) {}
 
         @Override
+        public <T extends WebSocketMessage> void removeListener(
+            final MessageType<T> messageType, final Consumer<T> messageConsumer) {}
+
+        @Override
         public void disconnect() {}
       };
 
   void sendMessage(WebSocketMessage webSocketMessage);
 
   <T extends WebSocketMessage> void addListener(
+      MessageType<T> messageType, Consumer<T> messageConsumer);
+
+  <T extends WebSocketMessage> void removeListener(
       MessageType<T> messageType, Consumer<T> messageConsumer);
 
   void disconnect();

--- a/game-app/game-core/src/main/java/games/strategy/net/websocket/WebsocketNetworkBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/net/websocket/WebsocketNetworkBridge.java
@@ -46,4 +46,12 @@ public class WebsocketNetworkBridge implements ClientNetworkBridge {
       genericWebSocketClient.addListener(messageType, messageConsumer);
     }
   }
+
+  @Override
+  public <T extends WebSocketMessage> void removeListener(
+      final MessageType<T> messageType, final Consumer<T> messageConsumer) {
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      genericWebSocketClient.removeListener(messageType, messageConsumer);
+    }
+  }
 }

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -57,6 +57,7 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
   private static class MessageListener<T extends WebSocketMessage> {
     @Nonnull MessageType<T> messageType;
     @Nonnull Consumer<Object> listener;
+    @Nonnull Consumer<T> originalHandler;
   }
 
   @Builder
@@ -131,7 +132,16 @@ public class GenericWebSocketClient implements WebSocket, WebSocketConnectionLis
         MessageListener.<T>builder() //
             .messageType(messageType)
             .listener(messageConsumer)
+            .originalHandler(messageHandler)
             .build());
+  }
+
+  @Override
+  @Synchronized
+  public <T extends WebSocketMessage> void removeListener(
+      final MessageType<T> messageType, final Consumer<T> messageHandler) {
+    listeners.removeIf(
+        l -> l.messageType.equals(messageType) && l.originalHandler.equals(messageHandler));
   }
 
   @Override

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
@@ -14,6 +14,9 @@ public interface WebSocket {
   <T extends WebSocketMessage> void addListener(
       MessageType<T> messageType, Consumer<T> messageHandler);
 
+  <T extends WebSocketMessage> void removeListener(
+      MessageType<T> messageType, Consumer<T> messageHandler);
+
   void sendMessage(WebSocketMessage message);
 
   void addConnectionClosedListener(Runnable connectionClosedListener);


### PR DESCRIPTION
Remove listeners on disconnect, prevents them from leaking and piling up. A potentially significant issue if a user repeatedly rejoins a game.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
