### PR TITLE
AI(instructions): Add CLAUDE.md file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+See `AGENTS.md` (this directory) for project-wide guidance.
+
+Nested `AGENTS.md` files exist throughout the source tree (under `lib/`,
+`game-app/`, `http-clients/`, `gradle/`, `docs/`, etc.). When working in or
+beneath a directory that contains an `AGENTS.md`, read that file as well.
+Guidance from a nested `AGENTS.md` applies to its directory and descendants,
+and takes precedence over higher-level `AGENTS.md` files on conflict.


### PR DESCRIPTION
The CLAUDE.md file is a glorified symlink, instructs Claude to look at the AGENTS.md files. Generally the .copilot instructions and non-AGENTS.md files should all refer to the AGENTS files.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
