### PR TITLE
fix(NPE): do not crash when hosting network game is cancelled

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
@@ -63,8 +63,7 @@ public class HeadedServerSetupModel {
    */
   public ServerModel showServer() {
     final ServerModel serverModel = new ServerModel(gameSelectorModel, new HeadedLaunchAction(ui));
-    serverModel.initialize();
-    onServerMessengerCreated(serverModel);
+    serverModel.initialize().ifPresent(u -> onServerMessengerCreated(serverModel));
     return serverModel;
   }
 


### PR DESCRIPTION
Repro: host a direct network game from the main welcome screen and click 'cancel'. Note, crashes with NPE.

Fix: avoids the NPE, cancels cleanly

Fixes: #14359

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
