### PR TITLE
Fix(crash): do not crash when blitzing through a territory being bombed

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -452,25 +452,34 @@ public class BattleTracker implements Serializable {
     this.conquered.addAll(
         CollectionUtils.getMatches(conqueredTerritories, Matches.isTerritoryEnemy(gamePlayer)));
     for (final Territory current : conqueredTerritories) {
+      // if a bombing raid is pending here (e.g. blitzing through a bombed factory),
+      // takeOver must wait for the bombing battle to resolve, so use a NonFightingBattle
+      // with a dependency rather than taking the territory over immediately.
+      final IBattle bombing = getPendingBombingBattle(current);
       IBattle nonFight = getPendingBattle(current, BattleType.NORMAL);
-      // TODO: if we ever want to scramble to a blitzed territory, then we need to fix this
       if (nonFight == null) {
         nonFight =
-            new FinishedBattle(
-                current,
-                gamePlayer,
-                this,
-                BattleType.NORMAL,
-                data,
-                BattleRecord.BattleResultDescription.CONQUERED,
-                WhoWon.ATTACKER);
+            bombing != null
+                ? new NonFightingBattle(current, gamePlayer, this, data)
+                : new FinishedBattle(
+                    current,
+                    gamePlayer,
+                    this,
+                    BattleType.NORMAL,
+                    data,
+                    BattleRecord.BattleResultDescription.CONQUERED,
+                    WhoWon.ATTACKER);
         pendingBattles.add(nonFight);
         getBattleRecords()
             .addBattle(gamePlayer, nonFight.getBattleId(), current, nonFight.getBattleType());
       }
       final Change change = nonFight.addAttackChange(route, units, null);
       addChange(bridge, changeTracker, change);
-      takeOver(current, gamePlayer, bridge, changeTracker, units);
+      if (bombing != null) {
+        addDependency(nonFight, bombing);
+      } else {
+        takeOver(current, gamePlayer, bridge, changeTracker, units);
+      }
     }
     // check the last territory
     if (conquerable.test(route.getEnd())) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
+import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
 import static games.strategy.triplea.delegate.GameDataTestUtil.battleDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.battleship;
 import static games.strategy.triplea.delegate.GameDataTestUtil.carrier;
@@ -16,6 +17,7 @@ import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
 import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -79,6 +81,58 @@ class WW2V3Year42Test {
     assertNotNull(battleTracker.getPendingNonBombingBattle(karrelia));
     assertNotNull(battleTracker.getPendingBombingBattle(karrelia));
     // the territory should not be conquered
+    assertEquals(karrelia.getOwner(), russians(gameData));
+  }
+
+  @Test
+  void testBombFactoryAndBlitzThrough() {
+    // Regression for issue #14278: bombing a factory and then blitzing a tank *through* that
+    // territory must not crash with "Bombing Raids should be dealt with first!". The bombing
+    // battle in the middle territory has to be wired as a dependency of the (deferred) takeover.
+    final Territory karrelia = territory("Karelia S.S.R.", gameData);
+    final Territory archangel = territory("Archangel", gameData);
+    final Territory baltic = territory("Baltic States", gameData);
+    final Territory sz5 = territory("5 Sea Zone", gameData);
+    final Territory germany = territory("Germany", gameData);
+    final GamePlayer germans = germans(gameData);
+    final AbstractMoveDelegate moveDelegate = gameData.getMoveDelegate();
+    // simulate v1-style rules where a tank can blitz through a factory territory
+    gameData
+        .getProperties()
+        .set(games.strategy.triplea.Constants.BLITZ_THROUGH_FACTORIES_AND_AA_RESTRICTED, false);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
+    advanceToStep(bridge, "CombatMove");
+    moveDelegate.setDelegateBridgeAndPlayer(bridge);
+    moveDelegate.start();
+    when(bridge.getRemotePlayer().shouldBomberBomb(any())).thenReturn(true);
+    // clear combat units from both territories so the tank can blitz through
+    removeFrom(
+        karrelia, karrelia.getUnitCollection().getMatches(Matches.unitCanBeDamaged().negate()));
+    removeFrom(
+        archangel, archangel.getUnitCollection().getMatches(Matches.unitCanBeDamaged().negate()));
+    // give Germans a tank in Baltic States to blitz with
+    addTo(baltic, armour(gameData).create(1, germans));
+    // bomber attacks the factory in Karelia
+    move(
+        germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()),
+        new Route(germany, sz5, karrelia));
+    // tank blitzes Baltic -> Karelia -> Archangel (Karelia is the middle territory)
+    move(
+        baltic.getUnitCollection().getMatches(Matches.unitCanBlitz()),
+        new Route(baltic, karrelia, archangel));
+    final BattleTracker battleTracker = MoveDelegate.getBattleTracker(gameData);
+    // bombing raid still pending against Karelia
+    assertNotNull(battleTracker.getPendingBombingBattle(karrelia));
+    // a non-bombing (non-fighting) battle must exist for the middle territory so the takeover
+    // can be deferred until the bombing raid resolves
+    final IBattle nonFight = battleTracker.getPendingNonBombingBattle(karrelia);
+    assertNotNull(nonFight);
+    // and that battle must depend on the bombing raid
+    assertTrue(
+        battleTracker
+            .getDependentOn(nonFight)
+            .contains(battleTracker.getPendingBombingBattle(karrelia)));
+    // Karelia hasn't been taken over yet
     assertEquals(karrelia.getOwner(), russians(gameData));
   }
 


### PR DESCRIPTION
This update patches an error when a user is bombing an empty (no units) territory and then sends a tank through blitzing into that territory and then beyond. When the tank moves beyond, there is a crash.

The game rules on whether this should be allowed is in question. This update fixes the crash at least.

Fixes #14278

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
