### PR TITLE
Fix(AI crash): fix OOL cache collision

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -1,12 +1,12 @@
 package games.strategy.triplea.delegate.battle.casualty;
 
-import com.google.common.base.Objects;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
@@ -29,7 +29,7 @@ import org.triplea.java.collections.IntegerMap;
 
 @UtilityClass
 class CasualtyOrderOfLosses {
-  private final Map<String, List<AmphibType>> oolCache = new ConcurrentHashMap<>();
+  private final Map<OolCacheKey, List<AmphibType>> oolCache = new ConcurrentHashMap<>();
 
   void clearOolCache() {
     oolCache.clear();
@@ -64,7 +64,7 @@ class CasualtyOrderOfLosses {
       targetTypes.add(AmphibType.of(u));
     }
     // Calculate hashes and cache key
-    String key = computeOolCacheKey(parameters, targetTypes);
+    OolCacheKey key = computeOolCacheKey(parameters, targetTypes);
     // Check OOL cache
     final List<AmphibType> stored = oolCache.get(key);
     if (stored != null) {
@@ -261,14 +261,27 @@ class CasualtyOrderOfLosses {
     }
   }
 
-  static String computeOolCacheKey(
+  static OolCacheKey computeOolCacheKey(
       final Parameters parameters, final List<AmphibType> targetTypes) {
-    return parameters.player.getName()
-        + "|"
-        + parameters.battlesite.getName()
-        + "|"
-        + parameters.combatValue.getBattleSide()
-        + "|"
-        + Objects.hashCode(targetTypes);
+    return new OolCacheKey(
+        parameters.player.getName(),
+        parameters.battlesite.getName(),
+        parameters.combatValue.getBattleSide(),
+        targetTypes);
+  }
+
+  /**
+   * Content-based cache key for the order-of-losses cache. The compact constructor copies {@code
+   * targetTypes} so callers may continue to mutate their list after computing the key without
+   * affecting entries already stored in the cache.
+   */
+  record OolCacheKey(
+      String playerName,
+      String battlesiteName,
+      BattleState.Side side,
+      List<AmphibType> targetTypes) {
+    OolCacheKey {
+      targetTypes = List.copyOf(targetTypes);
+    }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
@@ -47,7 +47,7 @@ class CasualtyOrderOfLossesTest {
     final UnitType typeVeteranFootmen = new UnitType("Veteran-Footmen", gameData);
     typeVeteranFootmen.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
 
-    final String key1 =
+    final CasualtyOrderOfLosses.OolCacheKey key1 =
         CasualtyOrderOfLosses.computeOolCacheKey(
             withFakeParameters(),
             List.of(
@@ -55,7 +55,7 @@ class CasualtyOrderOfLossesTest {
                 CasualtyOrderOfLosses.AmphibType.of(
                     typeVeteranFootmen.createTemp(1, player).get(0))));
 
-    final String key2 =
+    final CasualtyOrderOfLosses.OolCacheKey key2 =
         CasualtyOrderOfLosses.computeOolCacheKey(
             withFakeParameters(),
             List.of(


### PR DESCRIPTION
The key location of the error is at:
```
static String computeOolCacheKey(Parameters parameters, List<AmphibType> targetTypes) {
return parameters.player.getName()
        + "|" + parameters.battlesite.getName()
        + "|" + parameters.combatValue.getBattleSide()
        + "|" + Objects.hashCode(targetTypes);   // <-- only the int hash, not the list
  }
```

Notice that we only hash the list and not the contents. This leads to a possibility of a cache collision. If we then have two different target types hash to the same key, then we can go to have an error for mismatched list lengths.

Fix: use a composite key for the hash key & use a record type that properly computes the hash key for the targetTypes list.

Fixes #14241

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
