### PR TITLE
fix(battle calc): avoid crash when 'createWorkers' throws

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
@@ -42,6 +43,17 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
   // do not let multiple calculations or setting calc data happen at same time
   private final Object mutexCalcIsRunning = new Object();
 
+  private final Function<byte[], BattleCalculator> battleCalculatorFactory;
+
+  public ConcurrentBattleCalculator() {
+    this(BattleCalculator::new);
+  }
+
+  // Visible for testing; lets tests inject a factory that simulates worker construction failures.
+  ConcurrentBattleCalculator(final Function<byte[], BattleCalculator> battleCalculatorFactory) {
+    this.battleCalculatorFactory = battleCalculatorFactory;
+  }
+
   /** Return value may be ignored. Exceptions are being handled properly. */
   public CompletableFuture<Boolean> setGameData(@Nullable final GameData data) {
     // cancel any current setting of data
@@ -65,7 +77,14 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
     synchronized (mutexCalcIsRunning) {
       cancel();
       cancelCurrentOperation.incrementAndGet();
-      isDataSet = createWorkers(data);
+      // Reset eagerly so a thrown createWorkers leaves isDataSet=false rather than a stale true.
+      isDataSet = false;
+      try {
+        isDataSet = createWorkers(data);
+      } catch (final RuntimeException e) {
+        workers.clear();
+        throw e;
+      }
       return isDataSet;
     }
   }
@@ -130,14 +149,14 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
       }
       if (cancelCurrentOperation.get() >= 0) {
         // Create the first battle calc on the current thread to measure the end-to-end copy time.
-        workers.add(new BattleCalculator(serializedData));
+        workers.add(battleCalculatorFactory.apply(serializedData));
         int threadsToUse = getThreadsToUse((System.currentTimeMillis() - startTime), startMemory);
         // Now, create the remaining ones in parallel.
         workers.addAll(
             IntStream.range(1, threadsToUse)
                 .parallel()
                 .filter(j -> cancelCurrentOperation.get() >= 0)
-                .mapToObj(j -> new BattleCalculator(serializedData))
+                .mapToObj(j -> battleCalculatorFactory.apply(serializedData))
                 .collect(Collectors.toList()));
       }
     }
@@ -170,7 +189,7 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
     waitForGameDataReady();
     synchronized (mutexCalcIsRunning) {
       final long start = System.currentTimeMillis();
-      if (!isDataSet) {
+      if (!isDataSet || workers.isEmpty()) {
         // we could have attempted to set a new game data, while the old one was still being set,
         // causing it to abort with null data
         return new AggregateResults(0);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculatorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculatorTest.java
@@ -1,0 +1,74 @@
+package games.strategy.triplea.odds.calculator;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
+import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
+import static games.strategy.triplea.delegate.GameDataTestUtil.russians;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.TerritoryEffectHelper;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class ConcurrentBattleCalculatorTest extends AbstractClientSettingTestCase {
+
+  // Regression test for issue #14246. When createWorkers throws (e.g. BattleCalculator's
+  // constructor fails after deserialization) AFTER a prior successful setGameData, the
+  // calculator must not retain isDataSet=true with an empty workers list — otherwise the next
+  // calculate() call hits RunCountDistributor's parallelism>0 precondition with
+  // "The parallelism level has to be positive!".
+  @Test
+  void calculate_returnsEmptyResults_whenWorkerConstructionThrowsAfterPriorSuccess() {
+    final AtomicBoolean shouldFail = new AtomicBoolean(false);
+    final Function<byte[], BattleCalculator> factory =
+        bytes -> {
+          if (shouldFail.get()) {
+            throw new IllegalStateException("simulated worker construction failure");
+          }
+          return new BattleCalculator(bytes);
+        };
+    final ConcurrentBattleCalculator calc = new ConcurrentBattleCalculator(factory);
+
+    final GameData gameData = TestMapGameData.REVISED.getGameData();
+
+    // First setGameData succeeds: isDataSet becomes true and workers is populated.
+    assertTrue(calc.setGameData(gameData).join());
+
+    // Second setGameData fails inside createWorkers — exception is swallowed by exceptionally,
+    // future resolves to false. Without the fix, isDataSet stays true while workers is empty.
+    shouldFail.set(true);
+    assertFalse(calc.setGameData(gameData).join());
+
+    final Territory germany = gameData.getMap().getTerritoryOrNull("Germany");
+    final GamePlayer russians = russians(gameData);
+    final GamePlayer germans = germans(gameData);
+    final List<Unit> attackingUnits = infantry(gameData).create(2, russians);
+
+    final AggregateResults results =
+        assertDoesNotThrow(
+            () ->
+                calc.calculate(
+                    russians,
+                    germans,
+                    germany,
+                    attackingUnits,
+                    germany.getUnits(),
+                    List.of(),
+                    TerritoryEffectHelper.getEffects(germany),
+                    false,
+                    10));
+
+    assertThat(results.getResults(), empty());
+  }
+}


### PR DESCRIPTION
Core issue is if 'createWorkers' in battle calc fails with an exception, that is not raised to the caller and 'isDataSet' does not get updated properly.

Another way to look at this issue:   workers.size() is 0 when RunCountDistributor
is constructed at ConcurrentBattleCalculator.java:178, but isDataSet was true so
calculate didn't bail out at the early if (!isDataSet) check. That goes
on to create this error.

```
private boolean setGameDataInternal(@Nullable final GameData data) {
  synchronized (mutexCalcIsRunning) {
    cancel();
    cancelCurrentOperation.incrementAndGet();
    isDataSet = createWorkers(data);   // <-- if createWorkers throws...
    return isDataSet;
  }
}
```

Fix: Wrapped createWorkers(data) in setGameDataInternal with a try/catch that resets isDataSet=false and clears workers on any RuntimeException, then rethrows so .exceptionally(...) still resolves the latch to false.

Fixes: #14246

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
