### PR TITLE
fix(error message): log a warning instead of an error on bad save game loads

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -65,10 +65,7 @@ public final class GameDataManager {
     try (GZIPInputStream input = new GZIPInputStream(is)) {
       return loadGameUncompressed(input);
     } catch (final EOFException e) {
-      log.error(
-          "End of loading file has been reached unexpectedly.\n"
-              + "When reporting to TripleA include steps to produce such a corrupted file.",
-          e);
+      log.warn("Bad save game file (corrupted or truncated) try redownloading the save file.", e);
     } catch (final ZipException e) {
       log.error("Unzipping the file has failed. Check that the correct file was selected.", e);
     } catch (final Exception e) {


### PR DESCRIPTION
To repro: create a '*.tsvg' in saved games folder (via touch, or any other means), then try to load the game.

Fix: Updated error messaging to make it more clear that the save file is bad. Change the 'error' level to 'warn' as this is not a game engine issue per se but a corrupted save file (failed to download properly or what not).

Fixes #14129

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
