### PR TITLE
fix(forums): add handling for when forums is down or returns empty

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbTokenGenerator.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbTokenGenerator.java
@@ -112,7 +112,15 @@ public class NodeBbTokenGenerator {
     final HttpGet get = new HttpGet(forumUrl + "/api/user/username/" + encodedUsername);
     HttpProxy.addProxy(get);
     try (CloseableHttpResponse response = client.execute(get)) {
-      return YamlReader.readMap(EntityUtils.toString(response.getEntity()));
+      final String rawJson = EntityUtils.toString(response.getEntity());
+      if (rawJson == null || rawJson.isBlank()) {
+        throw new IllegalStateException(
+            "Forum returned an empty response when looking up user '"
+                + username
+                + "'. The forum may be unreachable. HTTP status: "
+                + response.getStatusLine());
+      }
+      return YamlReader.readMap(rawJson);
     }
   }
 
@@ -132,6 +140,12 @@ public class NodeBbTokenGenerator {
     HttpProxy.addProxy(post);
     try (CloseableHttpResponse response = client.execute(post)) {
       final String rawJson = EntityUtils.toString(response.getEntity());
+      if (rawJson == null || rawJson.isBlank()) {
+        throw new IllegalStateException(
+            "Forum returned an empty response when requesting a login token. "
+                + "The forum may be unreachable. HTTP status: "
+                + response.getStatusLine());
+      }
       final Map<String, Object> jsonObject = YamlReader.readMap(rawJson);
       if (jsonObject.containsKey("code")) {
         final String code = (String) Preconditions.checkNotNull(jsonObject.get("code"));


### PR DESCRIPTION
Instead of failing on YAML parsing an empty value, we add explicit error handling when forum returns an empty answer. The new error handling should produce a far cleaner error message

Resolves #14125

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
