### PR TITLE
fix(client prefs): downgrade error message to warn & reduce writes to ClientSettings

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -261,7 +261,11 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
     try {
       preferences.flush();
     } catch (final BackingStoreException e) {
-      log.error("Failed to persist client settings", e);
+      // Logged at warn (not error) because the most common cause is benign and transient:
+      // another TripleA process holds the JDK preferences file lock. The user-visible impact
+      // is at worst that a setting is not persisted across restarts; logging at error would
+      // trigger the in-game error reporter for a condition we cannot fix.
+      log.warn("Failed to persist client settings", e);
     }
   }
 

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -77,6 +77,8 @@ public final class MapDownloadController {
   @VisibleForTesting
   static void preventPromptToDownloadTutorialMap(
       final TutorialMapPreferences tutorialMapPreferences) {
-    tutorialMapPreferences.preventPromptToDownload();
+    if (tutorialMapPreferences.canPromptToDownload()) {
+      tutorialMapPreferences.preventPromptToDownload();
+    }
   }
 }

--- a/game-app/game-headed/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTest.java
+++ b/game-app/game-headed/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTest.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework.map.download;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,10 +21,21 @@ final class MapDownloadControllerTest {
     @Mock private TutorialMapPreferences tutorialMapPreferences;
 
     @Test
-    void shouldChangePreventPromptToDownloadPreference() {
+    void shouldChangePreventPromptToDownloadPreferenceWhenCanPromptToDownload() {
+      when(tutorialMapPreferences.canPromptToDownload()).thenReturn(true);
+
       preventPromptToDownloadTutorialMap();
 
       verify(tutorialMapPreferences).preventPromptToDownload();
+    }
+
+    @Test
+    void shouldSkipWriteWhenPromptToDownloadAlreadyPrevented() {
+      when(tutorialMapPreferences.canPromptToDownload()).thenReturn(false);
+
+      preventPromptToDownloadTutorialMap();
+
+      verify(tutorialMapPreferences, never()).preventPromptToDownload();
     }
 
     private void preventPromptToDownloadTutorialMap() {


### PR DESCRIPTION
1. The backingstore exception that we can get is relatively benign and not something we can actually fix. Thus, downgraded to a warning.

2. Instead of writing to client settings all the time for whether we can show the tutorial map, we add a check to see if it is necessary to flush that setting. This reduces contention on ClientSettings write at startup (multiple instances starting at the same time could see contention)

Resolves: #14073

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
