### PR TITLE
Fix(battle): resolve crash when subs submerge and fighters cannot land

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -58,6 +58,12 @@ public class CheckGeneralBattleEnd implements BattleStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+    // A prior step (e.g. EvaderRetreat after subs submerge) may have already ended the battle.
+    // Re-ending it would double-fire defenderWins/attackerWins and corrupt BattleTracker state
+    // (see #14119: duplicate entries in defendingAirThatCanNotLand cause an AddUnits crash).
+    if (battleState.getStatus().isOver()) {
+      return;
+    }
     if (hasSideLost(OFFENSE)) {
       battleActions.endBattle(IBattle.WhoWon.DEFENDER, bridge);
     } else if (hasSideLost(DEFENSE)) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEndTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEndTest.java
@@ -65,6 +65,23 @@ class CheckGeneralBattleEndTest {
     verify(battleActions).endBattle(IBattle.WhoWon.DEFENDER, delegateBridge);
   }
 
+  /**
+   * Regression test for <a href="https://github.com/triplea-game/triplea/issues/14119">#14119</a>:
+   * a prior step (e.g. {@code EvaderRetreat} when the last attacking sub submerges) may already
+   * have ended the battle. {@code CheckGeneralBattleEnd} must skip in that case, otherwise it fires
+   * {@code defenderWins} a second time and corrupts {@code BattleTracker} state.
+   */
+  @Test
+  void doesNotEndBattleIfAlreadyOver() {
+    final BattleState battleState =
+        givenBattleStateBuilder().attackingUnits(List.of()).over(true).build();
+
+    final CheckGeneralBattleEnd checkGeneralBattleEnd = givenCheckGeneralBattleEnd(battleState);
+    checkGeneralBattleEnd.execute(executionStack, delegateBridge);
+
+    verify(battleActions, never()).endBattle(any(), any());
+  }
+
   @Test
   void defenderWinsIfOnlyOffenseInfrastructureUnits() {
     final BattleState battleState =


### PR DESCRIPTION
When subs submerge and defenders win, we get two calls to 'addToDefendingAirThatCanNotLand' which adds a duplicate unit onto the same list. This goes on to throw an error.

The reason for the duplicate is because we call the method once when the subs submerge, and then again at the end of the battle call stack in 'CheckGeneralBattleEnd'.

To fix, we abort that second invocation if the battle is already marked as over.

Fixes #14119

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
