### PR TITLE
Fix(capitals): return empty instead of throwing when no capital

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -126,11 +126,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     if (!noNeighborCapitals.isEmpty()) {
       return Optional.of(CollectionUtils.getAny(noNeighborCapitals));
     }
-    // Added check for optional players- no error thrown for them
-    if (player.getOptional()) {
-      return Optional.empty();
-    }
-    throw new IllegalStateException("Capital not found for: " + player);
+    return Optional.empty();
   }
 
   /** will return empty list if none controlled, never returns null. */


### PR DESCRIPTION
Updates method contract which already returns an optional, to
return an empty optional if there is no player capital found.
Previously an exception was thrown, which is odd, and all
callers are set up to deal with the empty optional.
The exception likely should have been previously removed.

Resolves #13623
