### PR TITLE
fix(battle UX): change button name from 'remain' to "don't submerge"

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -384,7 +384,7 @@ public class BattleDisplay extends JPanel {
 
   private RetreatResult showSubmergeDialog(final String message) {
     final String ok = "Submerge";
-    final String cancel = "Remain";
+    final String cancel = "Don't Submerge";
     final String wait = "Ask Me Later";
     final String[] options = {ok, cancel, wait};
     final int choice =


### PR DESCRIPTION
Helps with issue #6504 (does not resovle #6504 thought).

The button text 'remain' is confusing as we use that same word
later on in the same combats involving subs.
