### PR TITLE
Cleanup: remove unused settings related to first-time-checks

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -137,8 +137,6 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new BooleanClientSetting("SHOW_COMMENT_LOG");
   public static final BooleanClientSetting soundEnabled =
       new BooleanClientSetting("SOUND_ENABLED", true);
-  public static final ClientSetting<Boolean> firstTimeThisVersion =
-      new BooleanClientSetting("TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY", true);
   public static final ClientSetting<Long> lastCheckForEngineUpdate =
       new LongClientSetting("LAST_CHECK_FOR_ENGINE_UPDATE_EPOCH_MILLI", 0);
   public static final ClientSetting<Long> lastCheckForMapUpdates =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -293,16 +293,6 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     }
   },
 
-  TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY_BINDING(
-      "Show First Time Prompts",
-      SettingType.GAME,
-      "Setting to true will trigger for any first time prompts to be shown") {
-    @Override
-    public SelectionComponent<JComponent> newSelectionComponent() {
-      return booleanRadioButtons(ClientSetting.firstTimeThisVersion);
-    }
-  },
-
   SAVE_GAMES_FOLDER_PATH_BINDING(
       "Saved Games Folder",
       SettingType.FOLDER_LOCATIONS,


### PR DESCRIPTION
These settings no longer do anything, we re-wrote the 'first time
bootup' code which used to use this setting, and now no longer does.
