### PR TITLE
fix(bot games): the window opened by 'roll dice' menu did nothing

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -6,6 +6,7 @@ import games.strategy.engine.framework.ClientGame;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.random.IRandomStats;
+import games.strategy.engine.random.PlainRandomSource;
 import games.strategy.engine.random.RandomStatsDetails;
 import games.strategy.triplea.odds.calculator.BattleCalculatorDialog;
 import games.strategy.triplea.settings.ClientSetting;
@@ -255,6 +256,9 @@ final class GameMenu {
               final IntTextField diceSidesText = new IntTextField(1, 200);
               numberOfText.setText(String.valueOf(0));
               diceSidesText.setText(String.valueOf(game.getData().getDiceSides()));
+              // Use a local PlainRandomSource: this menu's rolls have no effect on the game and
+              // are shown only in a local dialog. Clients (network/bot games) have no
+              // game-level random source, so going through game.getRandomSource() would NPE.
               final JPanel panel = new JPanel();
               panel.setLayout(new GridBagLayout());
               panel.add(
@@ -299,7 +303,7 @@ final class GameMenu {
                 if (numberOfDice > 0) {
                   final int diceSides = Integer.parseInt(diceSidesText.getText());
                   final int[] dice =
-                      game.getRandomSource()
+                      new PlainRandomSource()
                           .getRandom(diceSides, numberOfDice, "Rolling Dice, no effect on game.");
                   final JPanel panelDice = new JPanel();
                   final BoxLayout layout = new BoxLayout(panelDice, BoxLayout.Y_AXIS);
@@ -316,7 +320,7 @@ final class GameMenu {
                   JOptionPane.showMessageDialog(
                       frame, panelDice, "Dice Rolled", JOptionPane.INFORMATION_MESSAGE);
                 }
-              } catch (final Exception ex) {
+              } catch (final NumberFormatException ex) {
                 // ignore malformed input
               }
             })


### PR DESCRIPTION
Fixes #6319

The dice rolling window did not have a random source, the NPE was
handled silently and the dice rolling window then just closed.
Only impacted bot games where a client does not have that random source
set. Fix is to use a fallback random source.
