### PR TITLE
fix(css & csv): 2 fixes, fix CSS 30% width increase and invalid CSVs

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameNotesView.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameNotesView.java
@@ -10,6 +10,9 @@ public class GameNotesView extends JEditorPane {
   public GameNotesView() {
     setEditable(false);
     setContentType("text/html");
+    // Render CSS lengths per the W3C spec (1px = 1 screen pixel). Without this, Swing's legacy
+    // renderer treats CSS px as pt and inflates dimensions by ~33% at 96 DPI. See issue #6157.
+    putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
     // If the foreground color isn't set, a dark theme may make the text color white, which will be
     // unreadable if the html sets a light background color.
     setForeground(Color.BLACK);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
@@ -53,14 +53,13 @@ class CountryChart extends InfoForFile {
     // later pattern territory, ut1, ut2, ut3, ...)
     final int numUnits = gameData.getUnitTypeList().size();
     writer
-        .append("Setup Chart for the ")
-        .append(player.getName())
+        .append(csvField("Setup Chart for the " + player.getName()))
         .append(DELIMITER.repeat(numUnits))
         .append(LINE_SEPARATOR);
 
     writer.append(DELIMITER);
     for (final UnitType currentType : gameData.getUnitTypeList()) {
-      writer.append(currentType.getName()).append(DELIMITER);
+      writer.append(csvField(currentType.getName())).append(DELIMITER);
     }
     writer.append(LINE_SEPARATOR);
 
@@ -68,7 +67,7 @@ class CountryChart extends InfoForFile {
     for (final Territory currentTerritory :
         CollectionUtils.getMatches(
             gameData.getMap().getTerritories(), Matches.territoryHasUnitsOwnedBy(player))) {
-      writer.append(currentTerritory.getName());
+      writer.append(csvField(currentTerritory.getName()));
       final List<Map<UnitType, Integer>> currentList = infoMap.get(currentTerritory);
       for (final Map<UnitType, Integer> currentMap : currentList) {
         for (final int here : currentMap.values()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/InfoForFile.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/InfoForFile.java
@@ -16,6 +16,25 @@ abstract class InfoForFile {
   public static final String LINE_SEPARATOR = "\r\n";
   private final Path chosenOutFile;
 
+  /**
+   * Escapes a string for inclusion in a CSV cell per RFC 4180. Wraps the value in double quotes
+   * (and doubles any inner quotes) when it contains characters that could be misinterpreted by a
+   * spreadsheet reader — including a space, since common importers (LibreOffice, Excel) auto-detect
+   * space as a delimiter and would otherwise split a name like "Cestra Regina" across columns.
+   */
+  protected static String csvField(final String value) {
+    if (value == null) {
+      return "";
+    }
+    for (int i = 0; i < value.length(); i++) {
+      final char c = value.charAt(i);
+      if (c == ',' || c == '"' || c == '\r' || c == '\n' || c == ' ') {
+        return "\"" + value.replace("\"", "\"\"") + "\"";
+      }
+    }
+    return value;
+  }
+
   InfoForFile() {
     this.chosenOutFile = null;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
@@ -37,7 +37,7 @@ class PuInfo extends InfoForFile {
     for (int i = 0; i < numResources / 2 - 1 + numResources % 2; i++) {
       writer.write(DELIMITER);
     }
-    writer.write("Resource Chart");
+    writer.write(csvField("Resource Chart"));
     for (int i = 0; i < numResources / 2 - numResources % 2; i++) {
       writer.write(DELIMITER);
     }
@@ -45,12 +45,12 @@ class PuInfo extends InfoForFile {
     // Print Resources
     writer.write(DELIMITER);
     for (final Resource currentResource : resourceList.getResources()) {
-      writer.write(currentResource.getName() + DELIMITER);
+      writer.write(csvField(currentResource.getName()) + DELIMITER);
     }
     writer.write(LINE_SEPARATOR);
     // Print Player's and Resource Amount's
     for (final GamePlayer currentPlayer : gamePlayers) {
-      writer.write(currentPlayer.getName());
+      writer.write(csvField(currentPlayer.getName()));
       final Map<Resource, Integer> resourceMap = infoMap.get(currentPlayer);
       for (final int amountResource : resourceMap.values()) {
         writer.write(DELIMITER + amountResource);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
@@ -34,49 +34,49 @@ class UnitInformation extends InfoForFile {
 
   @Override
   protected void writeIntoFile(Writer writer) throws IOException {
-    writer.append("Unit Information").append(DELIMITER.repeat(20)).append(LINE_SEPARATOR);
+    writer.append(csvField("Unit Information")).append(DELIMITER.repeat(20)).append(LINE_SEPARATOR);
     writer
-        .append("Unit")
+        .append(csvField("Unit"))
         .append(DELIMITER)
-        .append("Cost")
+        .append(csvField("Cost"))
         .append(DELIMITER)
-        .append("Movement")
+        .append(csvField("Movement"))
         .append(DELIMITER)
-        .append("Attack")
+        .append(csvField("Attack"))
         .append(DELIMITER)
-        .append("Defense")
+        .append(csvField("Defense"))
         .append(DELIMITER)
-        .append("CanBlitz")
+        .append(csvField("CanBlitz"))
         .append(DELIMITER)
-        .append("Artillery?")
+        .append(csvField("Artillery?"))
         .append(DELIMITER)
-        .append("ArtillerySupportable?")
+        .append(csvField("ArtillerySupportable?"))
         .append(DELIMITER)
-        .append("Can Produce Units?")
+        .append(csvField("Can Produce Units?"))
         .append(DELIMITER)
-        .append("Marine?")
+        .append(csvField("Marine?"))
         .append(DELIMITER)
-        .append("Transport Cost")
+        .append(csvField("Transport Cost"))
         .append(DELIMITER)
-        .append("AA Gun?")
+        .append(csvField("AA Gun?"))
         .append(DELIMITER)
-        .append("Air Unit?")
+        .append(csvField("Air Unit?"))
         .append(DELIMITER)
-        .append("Strategic Bomber?")
+        .append(csvField("Strategic Bomber?"))
         .append(DELIMITER)
-        .append("Carrier Cost")
+        .append(csvField("Carrier Cost"))
         .append(DELIMITER)
-        .append("Sea Unit?")
+        .append(csvField("Sea Unit?"))
         .append(DELIMITER)
-        .append("Hit Points?")
+        .append(csvField("Hit Points?"))
         .append(DELIMITER)
-        .append("Transport Capacity")
+        .append(csvField("Transport Capacity"))
         .append(DELIMITER)
-        .append("Carrier Capacity")
+        .append(csvField("Carrier Capacity"))
         .append(DELIMITER)
-        .append("Submarine?")
+        .append(csvField("Submarine?"))
         .append(DELIMITER)
-        .append("Destroyer?")
+        .append(csvField("Destroyer?"))
         .append(LINE_SEPARATOR);
     writeData(writer);
   }
@@ -85,11 +85,11 @@ class UnitInformation extends InfoForFile {
     for (final Entry<UnitType, UnitAttachment> entry : unitInfoMap.entrySet()) {
       final UnitType currentType = entry.getKey();
       final UnitAttachment currentAttachment = entry.getValue();
-      if (currentType.getName().equals(Constants.UNIT_TYPE_AAGUN)) {
-        writer.append(currentType.getName());
-      } else {
-        writer.append(StringUtils.capitalize(currentType.getName()));
-      }
+      final String unitName =
+          currentType.getName().equals(Constants.UNIT_TYPE_AAGUN)
+              ? currentType.getName()
+              : StringUtils.capitalize(currentType.getName());
+      writer.append(csvField(unitName));
       writer
           .append(DELIMITER)
           .append(Integer.toString(getCostInformation(currentType, gameData)))

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -413,6 +413,8 @@ class ObjectivePanel extends JPanel implements GameDataChangeListener {
       final JEditorPane textArea = new JEditorPane();
       textArea.setEditable(false);
       textArea.setContentType("text/html");
+      // Render CSS lengths per W3C spec instead of Swing's legacy ~1.33x inflation. Issue #6157.
+      textArea.putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
       final JScrollPane scrollPane = new JScrollPane(textArea);
       scrollPane.setBorder(null);
       editorComponent = scrollPane;
@@ -443,6 +445,8 @@ class ObjectivePanel extends JPanel implements GameDataChangeListener {
     EditorPaneTableCellRenderer() {
       setEditable(false);
       setContentType("text/html");
+      // Render CSS lengths per W3C spec instead of Swing's legacy ~1.33x inflation. Issue #6157.
+      putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
     }
 
     @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/MoveHelpMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/MoveHelpMenu.java
@@ -18,6 +18,9 @@ class MoveHelpMenu {
           final JEditorPane editorPane = new JEditorPane();
           editorPane.setEditable(false);
           editorPane.setContentType("text/html");
+          // Render CSS lengths per W3C spec instead of Swing's legacy ~1.33x inflation. Issue
+          // #6157.
+          editorPane.putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
           final String hints =
               "<font size='+1'>Selecting Units</font><br>"
                   + "Clicking on a unit stack adds <u>1 unit</u> of the stack to the selection.<br>"

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitHelpMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitHelpMenu.java
@@ -33,6 +33,8 @@ class UnitHelpMenu {
     final JEditorPane editorPane = new JEditorPane();
     editorPane.setContentType("text/html");
     editorPane.setEditable(false);
+    // Render CSS lengths per W3C spec instead of Swing's legacy ~1.33x inflation. Issue #6157.
+    editorPane.putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
     final JScrollPane scroll = new JScrollPane(editorPane);
     scroll.setBorder(BorderFactory.createEmptyBorder());
     editorPane.setText(text);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/printgenerator/InfoForFileTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/printgenerator/InfoForFileTest.java
@@ -1,0 +1,40 @@
+package games.strategy.triplea.printgenerator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+class InfoForFileTest {
+
+  @Test
+  void csvFieldReturnsValueUnchangedWhenNoSpecialChars() {
+    assertThat(InfoForFile.csvField("Athens"), is("Athens"));
+  }
+
+  @Test
+  void csvFieldReturnsEmptyStringForNull() {
+    assertThat(InfoForFile.csvField(null), is(""));
+  }
+
+  @Test
+  void csvFieldQuotesValueContainingSpace() {
+    assertThat(InfoForFile.csvField("Cestra Regina"), is("\"Cestra Regina\""));
+  }
+
+  @Test
+  void csvFieldQuotesValueContainingComma() {
+    assertThat(InfoForFile.csvField("Foo,Bar"), is("\"Foo,Bar\""));
+  }
+
+  @Test
+  void csvFieldDoublesInnerDoubleQuotes() {
+    assertThat(InfoForFile.csvField("a\"b"), is("\"a\"\"b\""));
+  }
+
+  @Test
+  void csvFieldQuotesValueContainingNewline() {
+    assertThat(InfoForFile.csvField("a\nb"), is("\"a\nb\""));
+    assertThat(InfoForFile.csvField("a\rb"), is("\"a\rb\""));
+  }
+}

--- a/lib/swing-lib/src/main/java/org/triplea/swing/JEditorPaneWithClickableLinks.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/JEditorPaneWithClickableLinks.java
@@ -16,6 +16,9 @@ public class JEditorPaneWithClickableLinks extends JEditorPane {
 
   public JEditorPaneWithClickableLinks(final String htmlTextContent) {
     super("text/html", htmlTextContent);
+    // Render CSS lengths per the W3C spec (1px = 1 screen pixel) instead of Swing's
+    // legacy ~1.33x inflation. See issue #6157.
+    putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
     setEditable(false);
     setOpaque(false);
     setBorder(new EmptyBorder(10, 0, 20, 0));

--- a/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -226,6 +226,9 @@ public final class SwingComponents {
     final JEditorPane descriptionPane = new JEditorPane();
     descriptionPane.setEditable(false);
     descriptionPane.setContentType("text/html");
+    // Render CSS lengths per the W3C spec (1px = 1 screen pixel) instead of Swing's
+    // legacy ~1.33x inflation. See issue #6157.
+    descriptionPane.putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
     return descriptionPane;
   }
 


### PR DESCRIPTION
1) Swing's legacy renderer treats px as pt and converts at
  96/72 = 1.333× - exactly the 30% inflation reported in the issue #6157
  The fix is to instruct Swing to use W3C complaint rendering, which
  keeps px as px. We expect some rendering differences after this
  update, map descriptions should adjust accordingly.

2)  Fix invalid CSV being generated. There was no handling for spaces
  or quoting, which broke the CSV structure when rendered.
  Fixes issue #6368
