### PR TITLE
fix(toolbox UI): expand banned username width to 25

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/names/BannedUsernamesTab.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/names/BannedUsernamesTab.java
@@ -77,7 +77,7 @@ public final class BannedUsernamesTab implements Supplier<Component> {
   private JPanel buildAddUsernameBanPanel(final JTable table) {
     final JTextField addField =
         JTextFieldBuilder.builder()
-            .columns(10)
+            .columns(25)
             .maxLength(LobbyConstants.USERNAME_MAX_LENGTH)
             .toolTip(
                 "Username to ban, must be at least "


### PR DESCRIPTION
We previously already expanded the max input to 40, to match
our column length in database (that is done). But, the field
has a length of 10, which is visually very short. This update
bumps that length to 25 (but not a hardcap, the limit remains at 40)

Resolves #8094
