### PR TITLE
fix(updating-maps-NPE): resolve potential NPE when updating maps

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -91,6 +91,14 @@ public class InstalledMap {
    * date of the map-download.
    */
   boolean isOutOfDate(final MapDownloadItem download) {
+    // Treat a missing/zero commit date as "no signal" rather than NPE-ing on auto-unbox
+    // or treating every map as up-to-date against epoch 0. The GitHub-fallback listing
+    // path sets 0L, and a server response with a null value would unbox to NPE.
+    final Long lastCommitMilli = download.getLastCommitDateEpochMilli();
+    if (lastCommitMilli == null || lastCommitMilli <= 0L) {
+      return false;
+    }
+
     // we cache lastModifiedDate for two reasons:
     // 1. *primarily* test can inject a value
     // 2. avoid file system access
@@ -101,7 +109,7 @@ public class InstalledMap {
       }
     }
 
-    final Instant lastCommitDate = Instant.ofEpochMilli(download.getLastCommitDateEpochMilli());
+    final Instant lastCommitDate = Instant.ofEpochMilli(lastCommitMilli);
     return lastModifiedDate.isBefore(lastCommitDate);
   }
 


### PR DESCRIPTION
If last commit date is not set, then we will hit a NPE in the updating
maps window. This update adds a defensive check to prevent a crash.
At some point how we detect out-of-date maps should change to something
more robust, in the meantime, we close down the potential crash here.

Resolves: #9516
