### PR TITLE
fix(placement): resolve undo bug for fighters moved to carriers

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -170,6 +170,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
   public @Nullable String undoMove(final int moveIndex) {
     if (moveIndex < placements.size() && moveIndex >= 0) {
       final UndoablePlacement undoPlace = placements.get(moveIndex);
+      if (!undoPlace.getCanUndo()) {
+        return undoPlace.getReasonCantUndo();
+      }
       undoPlace.undo(bridge);
       placements.remove(moveIndex);
       updateUndoablePlacementIndexes();
@@ -327,14 +330,26 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       change.add(OriginalOwnerTracker.addOriginalOwnerChange(factoryAndInfrastructure, player));
     }
     // can we move planes to land there
+    final Collection<Unit> movedFighters = new ArrayList<>();
     final String movedAirTranscriptTextForHistory =
-        moveAirOntoNewCarriers(at, producer, placeableUnits, player, change);
+        moveAirOntoNewCarriers(at, producer, placeableUnits, player, change, movedFighters);
     final Change remove = ChangeFactory.removeUnits(player, placeableUnits);
     final Change place = ChangeFactory.addUnits(at, placeableUnits);
     change.add(remove);
     change.add(place);
     final UndoablePlacement currentPlacement =
         new UndoablePlacement(change, producer, at, placeableUnits);
+    if (!movedFighters.isEmpty()) {
+      // Any prior placement that produced one of the moved fighters now has its placed units
+      // sitting on this carrier. Block undoing those prior placements until this one is undone,
+      // otherwise the inverted change would try to remove a fighter from a territory it has
+      // already left, leaving it duplicated in both the carrier's sea zone and the player's hand.
+      for (final UndoablePlacement prior : placements) {
+        if (!CollectionUtils.intersection(prior.getUnits(), movedFighters).isEmpty()) {
+          prior.addDependent(currentPlacement);
+        }
+      }
+    }
     placements.add(currentPlacement);
     updateUndoablePlacementIndexes();
     final String transcriptText =
@@ -514,7 +529,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       final Territory producer,
       final Collection<Unit> units,
       final GamePlayer player,
-      final CompositeChange placeChange) {
+      final CompositeChange placeChange,
+      final Collection<Unit> movedFightersOut) {
     if (!at.isWater()) {
       return null;
     }
@@ -557,6 +573,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     }
     final Change change = ChangeFactory.moveUnits(producer, at, movedFighters);
     placeChange.add(change);
+    movedFightersOut.addAll(movedFighters);
     return MyFormatter.unitsToTextNoOwner(movedFighters)
         + " moved from "
         + producer.getName()

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
@@ -9,8 +9,11 @@ import games.strategy.triplea.delegate.data.PlacementDescription;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import lombok.Getter;
+import org.triplea.java.collections.CollectionUtils;
 
 /** Contains all the data to describe a placement and to undo it. */
 @Getter
@@ -19,6 +22,12 @@ public class UndoablePlacement extends AbstractUndoableMove {
 
   private final Territory placeTerritory;
   private Territory producerTerritory;
+
+  // placements this one depends on (must remain undone-able only after these are undone first;
+  // these can't be undone while we're around)
+  private final Set<UndoablePlacement> dependencies = new HashSet<>();
+  // placements that depend on this one — they must be undone before us
+  private final Set<UndoablePlacement> dependents = new HashSet<>();
 
   public UndoablePlacement(
       final CompositeChange change,
@@ -34,6 +43,25 @@ public class UndoablePlacement extends AbstractUndoableMove {
     this.producerTerritory = producerTerritory;
   }
 
+  /** Adds a placement that depends on this one (must be undone before this can be undone). */
+  public void addDependent(final UndoablePlacement dependent) {
+    dependents.add(dependent);
+    dependent.dependencies.add(this);
+  }
+
+  public boolean getCanUndo() {
+    return dependents.isEmpty();
+  }
+
+  public String getReasonCantUndo() {
+    if (dependents.isEmpty()) {
+      throw new IllegalStateException("no reason");
+    }
+    return "Placement "
+        + (CollectionUtils.getAny(dependents).getIndex() + 1)
+        + " must be undone first";
+  }
+
   @Override
   protected final void undoSpecific(final IDelegateBridge bridge) {
     final GameState data = bridge.getData();
@@ -46,6 +74,10 @@ public class UndoablePlacement extends AbstractUndoableMove {
       produced.remove(producerTerritory);
     }
     currentDelegate.setProduced(new HashMap<>(produced));
+    for (final UndoablePlacement dep : dependencies) {
+      dep.dependents.remove(this);
+    }
+    dependencies.clear();
   }
 
   @Override

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -1,17 +1,30 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.Constants.DAMAGE_FROM_BOMBING_DONE_TO_UNITS_INSTEAD_OF_TERRITORIES;
+import static games.strategy.triplea.Constants.MOVE_EXISTING_FIGHTERS_TO_NEW_CARRIERS;
 import static games.strategy.triplea.Constants.UNIT_PLACEMENT_RESTRICTIONS;
 import static games.strategy.triplea.delegate.GameDataTestUtil.unitType;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
 import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate.BidMode.NOT_BID;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -25,6 +38,9 @@ class PlaceDelegateTest extends PlaceDelegateTestCommon {
     delegate.initialize("place");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
+    // Replace the XML-loaded place delegate so undoMove resolves the same instance the test
+    // mutates via delegate.placeUnits.
+    gameData.addDelegate(delegate);
   }
 
   @Test
@@ -94,5 +110,55 @@ class PlaceDelegateTest extends PlaceDelegateTestCommon {
     final PlaceableUnits response =
         delegate.getPlaceableUnits(create(british, infantry, 1), westCanada);
     assertEquals(0, response.getMaxUnits());
+  }
+
+  // Regression test for https://github.com/triplea-game/triplea/issues/8434.
+  // When "Move existing fighters to new carriers" is enabled, placing a carrier may move a
+  // previously-placed fighter onto it. Undoing the fighter placement first would otherwise
+  // duplicate the unit (it would be removed from the producer territory it no longer occupies
+  // while also being added back to the player's hand). The carrier placement now becomes a
+  // dependent of the fighter placement, so the fighter can't be undone until the carrier is.
+  @Test
+  void testCannotUndoFighterPlacementWhileItIsOnANewlyPlacedCarrier() {
+    // Advance to the place step so undoSpecific can resolve the current placement delegate.
+    advanceToStep(delegate.getBridge(), "britishPlace");
+    gameData.getProperties().set(MOVE_EXISTING_FIGHTERS_TO_NEW_CARRIERS, true);
+    final var fighters = create(british, fighter, 1);
+    final var carriers = create(british, carrier, 1);
+    when(delegate.getBridge().getRemotePlayer().getNumberOfFightersToMoveToNewCarrier(any(), any()))
+        .thenAnswer(invocation -> invocation.<Collection<Unit>>getArgument(0));
+
+    assertValid(delegate.placeUnits(fighters, uk, NOT_BID));
+    assertValid(delegate.placeUnits(carriers, northSea, NOT_BID));
+
+    // Sanity check: the fighter has been moved from UK to the North Sea Zone (onto the carrier).
+    assertThat(uk.getMatches(Matches.unitIsOfType(fighter)), is(empty()));
+    assertThat(northSea.getMatches(Matches.unitIsOfType(fighter)), contains(fighters.toArray()));
+
+    final List<UndoablePlacement> placements = delegate.getMovesMade();
+    assertThat(placements, hasSize(2));
+    final UndoablePlacement fighterPlacement = placements.get(0);
+    final UndoablePlacement carrierPlacement = placements.get(1);
+    assertThat(fighterPlacement.getCanUndo(), is(false));
+    assertThat(carrierPlacement.getCanUndo(), is(true));
+
+    // Attempting to undo the fighter placement first must fail with an informative reason rather
+    // than corrupt the unit collection.
+    final String reason = delegate.undoMove(fighterPlacement.getIndex());
+    assertThat(reason, is(notNullValue()));
+    assertThat(reason, containsString("must be undone first"));
+    assertThat(delegate.getMovesMade(), hasSize(2));
+
+    // Undoing the carrier first puts the fighter back in UK and clears the dependency.
+    assertThat(delegate.undoMove(carrierPlacement.getIndex()), is(nullValue()));
+    assertThat(uk.getMatches(Matches.unitIsOfType(fighter)), contains(fighters.toArray()));
+    assertThat(northSea.getMatches(Matches.unitIsOfType(carrier)), is(empty()));
+    assertThat(delegate.getMovesMade(), hasSize(1));
+    assertThat(delegate.getMovesMade().get(0).getCanUndo(), is(true));
+
+    // Now the fighter placement undoes cleanly.
+    assertThat(delegate.undoMove(fighterPlacement.getIndex()), is(nullValue()));
+    assertThat(uk.getMatches(Matches.unitIsOfType(fighter)), is(empty()));
+    assertThat(delegate.getMovesMade(), is(empty()));
   }
 }


### PR DESCRIPTION
Fix incorrect handling of undo when a fighter is placed on
a factory, then a carrier placed next to the factory, and
the fighter moved onto the carrier. Previously, if you
did an undo the fighter, essentially nothing happened
(except you could place the fighter again).

This update changes the behavior to force you to undo
the carrier placement first, which then aligns correct
behavior. The carrier is removed, the fighter is put
back to the factory, and then an undo the fighter
removes it properly.

Fixes #8434
