### PR TITLE
fix(move): reset unit state when only a combat move step exists (#10590)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.Splitter;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.GameStep;
 import games.strategy.engine.delegate.IDelegate;
@@ -229,7 +230,9 @@ public final class GameStepPropertiesHelper {
 
   /**
    * Resets unit state, such as movement, submerged, transport unload/load, airborne, etc. Normally
-   * occurs at end of noncombat move phase.
+   * occurs at end of noncombat move phase. When a player's turn has only a combat move step (no
+   * non-combat move step), the reset is performed at the end of the combat move so unit movement
+   * does not accumulate across rounds.
    */
   static boolean isResetUnitStateAtEnd(final GameData data) {
     try (GameData.Unlocker ignored = data.acquireReadLock()) {
@@ -238,8 +241,27 @@ public final class GameStepPropertiesHelper {
               .getStep()
               .getProperties()
               .getProperty(GameStep.PropertyKeys.RESET_UNIT_STATE_AT_END);
-      return prop != null ? Boolean.parseBoolean(prop) : isNonCombatDelegate(data);
+      if (prop != null) {
+        return Boolean.parseBoolean(prop);
+      }
+      return isNonCombatDelegate(data)
+          || (isCombatDelegate(data) && !hasFollowingNonCombatMoveForCurrentPlayer(data));
     }
+  }
+
+  private static boolean hasFollowingNonCombatMoveForCurrentPlayer(final GameState data) {
+    final GameSequence sequence = data.getSequence();
+    final GamePlayer player = sequence.getStep().getPlayerId();
+    if (player == null) {
+      return true;
+    }
+    for (int i = sequence.getStepIndex() + 1; i < sequence.size(); i++) {
+      final GameStep step = sequence.getStep(i);
+      if (player.equals(step.getPlayerId()) && GameStep.isNonCombatMoveStepName(step.getName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Indicates bid purchase or placement is enabled for the specified game. */

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameStepPropertiesHelperTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameStepPropertiesHelperTest.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate;
 import static games.strategy.triplea.delegate.GameStepPropertiesHelper.getCombinedTurns;
 import static games.strategy.triplea.delegate.GameStepPropertiesHelper.getRepairPlayers;
 import static games.strategy.triplea.delegate.GameStepPropertiesHelper.getTurnSummaryPlayers;
+import static games.strategy.triplea.delegate.GameStepPropertiesHelper.isResetUnitStateAtEnd;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -124,6 +125,84 @@ final class GameStepPropertiesHelperTest {
           GameStep.PropertyKeys.REPAIR_PLAYERS, joinPlayerNames(unknownPlayer, player2));
 
       assertThat(getRepairPlayers(gameData, player1), contains(player1, player2));
+    }
+  }
+
+  @Nested
+  final class IsResetUnitStateAtEndTest {
+    private final GameData ownGameData = new GameData();
+    private final GamePlayer ownPlayer = new GamePlayer("ownPlayer", ownGameData);
+    private final GamePlayer otherOwnPlayer = new GamePlayer("otherOwnPlayer", ownGameData);
+
+    @BeforeEach
+    void setUp() {
+      ownGameData.getPlayerList().addPlayerId(ownPlayer);
+      ownGameData.getPlayerList().addPlayerId(otherOwnPlayer);
+    }
+
+    private GameStep newStep(final String name, final GamePlayer stepPlayer) {
+      return newStep(name, stepPlayer, new Properties());
+    }
+
+    private GameStep newStep(
+        final String name, final GamePlayer stepPlayer, final Properties stepProperties) {
+      return new GameStep(name, name, stepPlayer, newDelegate(), ownGameData, stepProperties);
+    }
+
+    @Test
+    void resetsAtEndOfNonCombatMoveByDefault() {
+      ownGameData.getSequence().addStep(newStep("playerNonCombatMove", ownPlayer));
+      ownGameData.getSequence().setRoundAndStep(1, "playerNonCombatMove", ownPlayer);
+
+      assertThat(isResetUnitStateAtEnd(ownGameData), is(true));
+    }
+
+    @Test
+    void doesNotResetAtEndOfCombatMoveWhenNonCombatMoveFollowsForSamePlayer() {
+      ownGameData.getSequence().addStep(newStep("playerCombatMove", ownPlayer));
+      ownGameData.getSequence().addStep(newStep("playerNonCombatMove", ownPlayer));
+      ownGameData.getSequence().setRoundAndStep(1, "playerCombatMove", ownPlayer);
+
+      assertThat(isResetUnitStateAtEnd(ownGameData), is(false));
+    }
+
+    @Test
+    void resetsAtEndOfCombatMoveWhenNoFollowingNonCombatMove() {
+      ownGameData.getSequence().addStep(newStep("playerCombatMove", ownPlayer));
+      ownGameData.getSequence().addStep(newStep("playerPurchase", ownPlayer));
+      ownGameData.getSequence().setRoundAndStep(1, "playerCombatMove", ownPlayer);
+
+      assertThat(isResetUnitStateAtEnd(ownGameData), is(true));
+    }
+
+    @Test
+    void resetsAtEndOfCombatMoveWhenFollowingNonCombatMoveIsForOtherPlayer() {
+      ownGameData.getSequence().addStep(newStep("playerCombatMove", ownPlayer));
+      ownGameData.getSequence().addStep(newStep("otherNonCombatMove", otherOwnPlayer));
+      ownGameData.getSequence().setRoundAndStep(1, "playerCombatMove", ownPlayer);
+
+      assertThat(isResetUnitStateAtEnd(ownGameData), is(true));
+    }
+
+    @Test
+    void explicitFalsePropertyOverridesDefault() {
+      final Properties props = new Properties();
+      props.setProperty(GameStep.PropertyKeys.RESET_UNIT_STATE_AT_END, "false");
+      ownGameData.getSequence().addStep(newStep("playerCombatMove", ownPlayer, props));
+      ownGameData.getSequence().setRoundAndStep(1, "playerCombatMove", ownPlayer);
+
+      assertThat(isResetUnitStateAtEnd(ownGameData), is(false));
+    }
+
+    @Test
+    void explicitTruePropertyOverridesDefault() {
+      final Properties props = new Properties();
+      props.setProperty(GameStep.PropertyKeys.RESET_UNIT_STATE_AT_END, "true");
+      ownGameData.getSequence().addStep(newStep("playerCombatMove", ownPlayer, props));
+      ownGameData.getSequence().addStep(newStep("playerNonCombatMove", ownPlayer));
+      ownGameData.getSequence().setRoundAndStep(1, "playerCombatMove", ownPlayer);
+
+      assertThat(isResetUnitStateAtEnd(ownGameData), is(true));
     }
   }
 


### PR DESCRIPTION
When a player's turn defined a combat move step but no non-combat move
step, unit `alreadyMoved` was never reset between rounds, so units could
not move after their first move (units on territories with bonus
movement masked the bug). `GameStepPropertiesHelper.isResetUnitStateAtEnd`
now defaults to true for a combat move step when the same player has no
following non-combat move step in the round. Existing maps with both
phases are unaffected; the explicit `resetUnitStateAtEnd` step property
still overrides the default.

Resolves #10590
