### PR TITLE
fix(race condition): resolve crash if a latent move validation is executed during battle phase

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -1785,7 +1785,7 @@ public class MoveValidator {
             unitsWhichAreNotBeingTransportedOrDependent, Matches.unitIsLand());
     final int maxLandMoves = landUnits.isEmpty() ? 0 : getMaxMovement(landUnits).intValue();
     final int maxSteps =
-        GameStepPropertiesHelper.isCombatMove(data)
+        GameStepPropertiesHelper.isCombatMove(data, true)
             ? defaultRoute.numberOfSteps()
             : Math.max(defaultRoute.numberOfSteps(), maxLandMoves);
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/MoveValidatorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/move/validation/MoveValidatorTest.java
@@ -5,6 +5,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.in;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -247,6 +248,20 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
             new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
             germans);
     assertTrue(results.isMoveValid());
+  }
+
+  @Test
+  void testGetBestRouteDoesNotThrowOnNonMoveStep() {
+    // Regression for #11319: a mouse-hover during a battle step would call
+    // getBestRoute, which in turn called isCombatMove(data) (throwing variant)
+    // and crashed with "Cannot determine combat or not: <stepName>Battle".
+    while (!gameData.getSequence().getStep().getName().equals("britishBattle")) {
+      gameData.getSequence().next();
+    }
+    final Collection<Unit> units = infantry.create(1, british);
+    westCanada.getUnitCollection().addAll(units);
+    assertDoesNotThrow(
+        () -> MoveValidator.getBestRoute(westCanada, eastCanada, gameData, british, units, false));
   }
 
   @Test


### PR DESCRIPTION
The move validations can be queued and sent to a new thread for
evaluation. During that time, the step can change to a battle phase.
This is otherwise fine, except the move validation crashes.
We guard against this in a few place already, this update
adds another guard to prevent such a crash.

Fixes #11319
