### PR TITLE
fix(politics): create battles when war is declared (#9524)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -18,6 +18,7 @@ import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
+import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.remote.IPoliticsDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.ui.PoliticsText;
@@ -69,8 +70,12 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
             new FireTriggerParams(null, null, true, true, true, true));
       }
     }
-    chainAlliancesTogether(bridge);
+    final boolean newWarFromChainAlliances = chainAlliancesTogether(bridge);
     givesBackOriginalTerritories(bridge);
+    if (newWarFromChainAlliances) {
+      BattleDelegate.setUpBattlesForChangedRelationships(
+          MoveDelegate.getBattleTracker(getData()), bridge);
+    }
   }
 
   @Override
@@ -374,8 +379,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
    * @param paa the political action to change the relationships for
    */
   private void changeRelationships(final PoliticalActionAttachment paa) {
-    getMyselfOutOfAlliance(paa, player, bridge);
-    getNeutralOutOfWarWithAllies(paa, player, bridge);
+    boolean newWarDeclared = getMyselfOutOfAlliance(paa, player, bridge);
+    newWarDeclared |= getNeutralOutOfWarWithAllies(paa, player, bridge);
     final CompositeChange change = new CompositeChange();
     for (final PoliticalActionAttachment.RelationshipChange relationshipChange :
         paa.getRelationshipChanges()) {
@@ -404,11 +409,24 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
                   + newRelation.getName());
       MoveDelegate.getBattleTracker(getData())
           .addRelationshipChangesThisTurn(player1, player2, oldRelation, newRelation);
+      if (isNewWar(oldRelation, newRelation)) {
+        newWarDeclared = true;
+      }
     }
     if (!change.isEmpty()) {
       bridge.addChange(change);
     }
-    chainAlliancesTogether(bridge);
+    newWarDeclared |= chainAlliancesTogether(bridge);
+    if (newWarDeclared) {
+      BattleDelegate.setUpBattlesForChangedRelationships(
+          MoveDelegate.getBattleTracker(getData()), bridge);
+    }
+  }
+
+  private static boolean isNewWar(
+      final RelationshipType oldRelation, final RelationshipType newRelation) {
+    return !Matches.relationshipTypeIsAtWar().test(oldRelation)
+        && Matches.relationshipTypeIsAtWar().test(newRelation);
   }
 
   /**
@@ -465,17 +483,18 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     }
   }
 
-  private static void getMyselfOutOfAlliance(
+  private static boolean getMyselfOutOfAlliance(
       final PoliticalActionAttachment paa, final GamePlayer player, final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
     if (!Properties.getAlliancesCanChainTogether(data.getProperties())) {
-      return;
+      return false;
     }
     final Collection<GamePlayer> players = data.getPlayerList().getPlayers();
     final Collection<GamePlayer> p1AlliedWith =
         CollectionUtils.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(player));
     p1AlliedWith.remove(player);
     final CompositeChange change = new CompositeChange();
+    boolean newWarDeclared = false;
     for (final PoliticalActionAttachment.RelationshipChange relationshipChange :
         paa.getRelationshipChanges()) {
       final GamePlayer p1 = relationshipChange.player1;
@@ -510,6 +529,9 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
                         + " treaty");
             MoveDelegate.getBattleTracker(data)
                 .addRelationshipChangesThisTurn(p3, player, currentOther, newType);
+            if (isNewWar(currentOther, newType)) {
+              newWarDeclared = true;
+            }
           }
         }
       }
@@ -517,19 +539,21 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     if (!change.isEmpty()) {
       bridge.addChange(change);
     }
+    return newWarDeclared;
   }
 
-  private static void getNeutralOutOfWarWithAllies(
+  private static boolean getNeutralOutOfWarWithAllies(
       final PoliticalActionAttachment paa, final GamePlayer player, final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
     if (!Properties.getAlliancesCanChainTogether(data.getProperties())) {
-      return;
+      return false;
     }
 
     final Collection<GamePlayer> players = data.getPlayerList().getPlayers();
     final Collection<GamePlayer> p1AlliedWith =
         CollectionUtils.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(player));
     final CompositeChange change = new CompositeChange();
+    boolean newWarDeclared = false;
     for (final PoliticalActionAttachment.RelationshipChange relationshipChange :
         paa.getRelationshipChanges()) {
       final GamePlayer p1 = relationshipChange.player1;
@@ -570,6 +594,9 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
                           + " treaty");
               MoveDelegate.getBattleTracker(data)
                   .addRelationshipChangesThisTurn(p3, p4, currentOther, newType);
+              if (isNewWar(currentOther, newType)) {
+                newWarDeclared = true;
+              }
             }
           }
         }
@@ -578,12 +605,13 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     if (!change.isEmpty()) {
       bridge.addChange(change);
     }
+    return newWarDeclared;
   }
 
-  static void chainAlliancesTogether(final IDelegateBridge bridge) {
+  static boolean chainAlliancesTogether(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
     if (!Properties.getAlliancesCanChainTogether(data.getProperties())) {
-      return;
+      return false;
     }
     final Collection<RelationshipType> allTypes =
         data.getRelationshipTypeList().getAllRelationshipTypes();
@@ -597,8 +625,9 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       }
     }
     if (alliedType == null) {
-      return;
+      return false;
     }
+    boolean newWarDeclared = false;
     // first do alliances. then, do war (since we don't want to declare war on a potential ally).
     final Collection<GamePlayer> players = data.getPlayerList().getPlayers();
     for (final GamePlayer p1 : players) {
@@ -632,7 +661,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     }
     // now war
     if (warType == null) {
-      return;
+      return newWarDeclared;
     }
     for (final GamePlayer p1 : players) {
       final Set<GamePlayer> p1NewWar = new HashSet<>();
@@ -661,9 +690,13 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
                       + " on each other");
           MoveDelegate.getBattleTracker(data)
               .addRelationshipChangesThisTurn(p1, p3, current, warType);
+          if (isNewWar(current, warType)) {
+            newWarDeclared = true;
+          }
         }
       }
     }
+    return newWarDeclared;
   }
 
   private static void givesBackOriginalTerritories(final IDelegateBridge bridge) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -210,6 +210,20 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     resetMaxScrambleCount(bridge);
   }
 
+  /**
+   * Re-runs the battle setup that normally happens at the start of the battle phase. Intended to be
+   * called when a relationship change (e.g. declaring war) leaves the current player's units
+   * sharing a territory with new enemies, or sitting alone in a territory that just became enemy
+   * owned. Without this, those units would not start a battle nor capture the territory until a
+   * subsequent turn.
+   */
+  public static void setUpBattlesForChangedRelationships(
+      final BattleTracker battleTracker, final IDelegateBridge bridge) {
+    setupUnitsInSameTerritoryBattles(battleTracker, bridge);
+    setupTerritoriesAbandonedToTheEnemy(battleTracker, bridge);
+    battleTracker.clearFinishedBattles(bridge);
+  }
+
   private static void clearEmptyAirBattleAttacks(
       final BattleTracker battleTracker, final IDelegateBridge bridge) {
     // these are air battle and air raids where there is no defender, probably because no air is in

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/SetUpBattlesAfterRelationshipChangeTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/SetUpBattlesAfterRelationshipChangeTest.java
@@ -1,0 +1,97 @@
+package games.strategy.triplea.delegate.battle;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
+import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
+import static games.strategy.triplea.delegate.GameDataTestUtil.italians;
+import static games.strategy.triplea.delegate.GameDataTestUtil.russians;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.RelationshipType;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #9524: when a war breaks out (e.g. via politics) units already sitting
+ * on what is now an enemy territory must start a battle there or capture the territory if it is
+ * undefended. Without {@link BattleDelegate#setUpBattlesForChangedRelationships(BattleTracker,
+ * IDelegateBridge)} those units would just sit idle until a future turn.
+ */
+class SetUpBattlesAfterRelationshipChangeTest extends AbstractClientSettingTestCase {
+
+  private final GameData gameData = TestMapGameData.PACT_OF_STEEL_2.getGameData();
+  private final GamePlayer italians = italians(gameData);
+  private final GamePlayer russians = russians(gameData);
+  // Karelia S.S.R. is owned by Russians and is the territory we'll move Italian units into
+  // while the two players are at peace.
+  private final Territory karelia = territory("Karelia S.S.R.", gameData);
+
+  @Test
+  void newWarCreatesBattleWhereUnitsCoexist() {
+    setRelationship(italians, russians, "Neutrality");
+    addTo(karelia, armour(gameData).create(2, italians));
+    final IDelegateBridge bridge = newDelegateBridge(italians);
+    advanceToStep(bridge, "italianPolitics");
+
+    setRelationship(italians, russians, "War");
+    BattleDelegate.setUpBattlesForChangedRelationships(getBattleTracker(), bridge);
+
+    final IBattle battle = getBattleTracker().getPendingBattle(karelia, IBattle.BattleType.NORMAL);
+    assertThat("a battle should be pending in Karelia S.S.R.", battle, notNullValue());
+    assertThat(
+        "Italian units should be the attackers",
+        battle.getAttackingUnits().stream().allMatch(u -> u.getOwner().equals(italians)),
+        equalTo(true));
+  }
+
+  @Test
+  void newWarCapturesUndefendedEnemyTerritory() {
+    setRelationship(italians, russians, "Neutrality");
+    karelia.getUnitCollection().clear();
+    final List<Unit> italianTanks = armour(gameData).create(1, italians);
+    addTo(karelia, italianTanks);
+    final IDelegateBridge bridge = newDelegateBridge(italians);
+    advanceToStep(bridge, "italianPolitics");
+
+    setRelationship(italians, russians, "War");
+    BattleDelegate.setUpBattlesForChangedRelationships(getBattleTracker(), bridge);
+
+    assertThat(
+        "Karelia S.S.R. should now be Italian-owned after the war declaration",
+        karelia.getOwner(),
+        equalTo(italians));
+    assertThat(
+        "no normal battle should remain pending — territory was captured outright",
+        getBattleTracker().getPendingBattle(karelia, IBattle.BattleType.NORMAL),
+        nullValue());
+  }
+
+  private void setRelationship(
+      final GamePlayer p1, final GamePlayer p2, final String relationshipName) {
+    final RelationshipType target =
+        gameData.getRelationshipTypeList().getRelationshipType(relationshipName);
+    final RelationshipType current = gameData.getRelationshipTracker().getRelationshipType(p1, p2);
+    if (current.equals(target)) {
+      return;
+    }
+    gameData.performChange(ChangeFactory.relationshipChange(p1, p2, current, target));
+  }
+
+  private BattleTracker getBattleTracker() {
+    return GameDataTestUtil.battleDelegate(gameData).getBattleTracker();
+  }
+}


### PR DESCRIPTION
When a relationship change flips a pair to war, scan the current player's territories for newly co-located enemy units and undefended enemy territories so units already in place immediately start a battle or capture, instead of sitting idle until a future turn.

Fixes #9524

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
