### PR TITLE
fix(history panel): avoid NPE when root history node is not expanded

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -369,7 +369,9 @@ public class HistoryPanel extends JPanel {
           root = root.getParentPath();
         }
         final Enumeration<TreePath> expandedDescendants = tree.getExpandedDescendants(root);
-        stayExpandedPaths.addAll(Collections.list(expandedDescendants));
+        if (expandedDescendants != null) {
+          stayExpandedPaths.addAll(Collections.list(expandedDescendants));
+        }
       } else {
         collapseUpFromLastParent(parent);
       }


### PR DESCRIPTION
Root history node can return null for its descendants.
This is a benign condition, it is expected.
This fix adds a null check to avoid NPE in this situation.

Fixes: #14376
