### PR TITLE
fix(pbem dice roller): avoid ambiguous error if failed to roll dice

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -22,6 +22,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
+import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.ThreadRunner;
 import org.triplea.swing.SwingAction;
@@ -32,6 +33,7 @@ import org.triplea.util.ExitStatus;
  * any thread, and have a dialog that doesn't close until the dice roll finishes. If there is an
  * error we wait until we get a good roll before returning.
  */
+@Slf4j
 public class PbemDiceRoller implements IRandomSource {
   private final IRemoteDiceServer remoteDiceServer;
 
@@ -59,7 +61,7 @@ public class PbemDiceRoller implements IRandomSource {
         };
     return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action))
         .result
-        .orElseGet(() -> new int[0]);
+        .orElseThrow(() -> new RuntimeException("Dice roll interrupted before completing"));
   }
 
   @Override
@@ -248,10 +250,15 @@ public class PbemDiceRoller implements IRandomSource {
         appendText("\n");
         notifyError();
       } catch (final RuntimeException e) {
-        // Close screen in case an unexpected error occurs
-        // and rethrow exception for default error handling.
-        closeAndReturn();
-        throw e;
+        // Keep the dialog open so the user can retry or exit; we run on a worker thread,
+        // so a rethrow would be silently dropped and downstream battle logic would receive
+        // no dice.
+        log.error("Unexpected error rolling dice via {}", diceServer.getDisplayName(), e);
+        appendText("Unexpected error:\n");
+        final StringWriter writer = new StringWriter();
+        e.printStackTrace(new PrintWriter(writer));
+        appendText(writer.toString());
+        notifyError();
       }
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/dice/calculator/RolledDice.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/dice/calculator/RolledDice.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.delegate.dice.calculator;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Queues;
 import com.google.common.primitives.Ints;
@@ -40,6 +42,11 @@ public class RolledDice {
     final int diceSides = totalPowerAndTotalRolls.getDiceSides();
     final int[] random =
         diceGenerator.apply(diceSides, rollCount, player, IRandomStats.DiceType.COMBAT, annotation);
+    checkState(
+        random.length == rollCount,
+        "Random dice source returned %s dice, expected %s",
+        random.length,
+        rollCount);
     final List<Die> dice = getDiceHits(random, totalPowerAndTotalRolls.getActiveUnits());
     final int hitCount =
         (int) dice.stream().filter(die -> die.getType() == Die.DieType.HIT).count();

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/dice/calculator/RolledDiceTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/dice/calculator/RolledDiceTest.java
@@ -1,0 +1,26 @@
+package games.strategy.triplea.delegate.dice.calculator;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
+import org.junit.jupiter.api.Test;
+
+class RolledDiceTest {
+
+  @Test
+  void calculateRejectsRandomArrayShorterThanRollCount() {
+    final TotalPowerAndTotalRolls totalPowerAndTotalRolls = mock(TotalPowerAndTotalRolls.class);
+    when(totalPowerAndTotalRolls.calculateTotalRolls()).thenReturn(3);
+    when(totalPowerAndTotalRolls.getDiceSides()).thenReturn(6);
+    final GamePlayer player = mock(GamePlayer.class);
+    when(player.getName()).thenReturn("test");
+    final RandomDiceGenerator emptyGenerator = (max, count, p, type, annotation) -> new int[0];
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> RolledDice.calculate(totalPowerAndTotalRolls, player, emptyGenerator, "test"));
+  }
+}


### PR DESCRIPTION
Handles case where we fail to roll dice either due to error
or user interrupt. We go on to do better error handling
rather than crashing with an odd error message regarding
incorrect number of dice.

Fixes #14138
