### PR TITLE
fix(settings UI): folder selections will start at current value

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -305,9 +305,15 @@ final class SelectionComponentFactory {
           new JButtonBuilder()
               .title("Select")
               .actionListener(
-                  () ->
-                      SwingComponents.showJFileChooser(folderSelectionMode)
-                          .ifPresent(file -> field.setText(file.toAbsolutePath().toString())))
+                  () -> {
+                    final String currentValue = field.getText();
+                    final Optional<Path> selected =
+                        currentValue.isEmpty()
+                            ? SwingComponents.showJFileChooser(folderSelectionMode)
+                            : SwingComponents.showJFileChooser(
+                                folderSelectionMode, Path.of(currentValue));
+                    selected.ifPresent(file -> field.setText(file.toAbsolutePath().toString()));
+                  })
               .build();
 
       @Override

--- a/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -261,13 +261,32 @@ public final class SwingComponents {
    * @return Empty if the user selects nothing, otherwise the users selection.
    */
   public static Optional<Path> showJFileChooser(final FolderSelectionMode folderSelectionMode) {
+    return showJFileChooser(newJFileChooser(folderSelectionMode));
+  }
+
+  /**
+   * Shows a dialog the user can use to select a folder or file, opening with {@code startingPath}
+   * pre-selected so the dialog defaults to the current value.
+   */
+  public static Optional<Path> showJFileChooser(
+      final FolderSelectionMode folderSelectionMode, final Path startingPath) {
+    checkNotNull(startingPath);
+    final JFileChooser fileChooser = newJFileChooser(folderSelectionMode);
+    fileChooser.setSelectedFile(startingPath.toFile());
+    return showJFileChooser(fileChooser);
+  }
+
+  private static JFileChooser newJFileChooser(final FolderSelectionMode folderSelectionMode) {
     final JFileChooser fileChooser = new JFileChooser();
     if (folderSelectionMode == FolderSelectionMode.DIRECTORIES) {
       fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
     } else {
       fileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
     }
+    return fileChooser;
+  }
 
+  private static Optional<Path> showJFileChooser(final JFileChooser fileChooser) {
     final int result = fileChooser.showOpenDialog(null);
     return (result == JFileChooser.APPROVE_OPTION)
         ? Optional.of(fileChooser.getSelectedFile().toPath())


### PR DESCRIPTION
The folder selections in settings would always start from
a default location. This update changes that so that the
folder selection starts at the current value rather than
a default location.

Fixes #13865
