### PR TITLE
fix(placement): avoid crash when placement algorithms do not agree

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -257,22 +257,14 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         final int newMaxForThisProducer =
             getMaxUnitsToBePlacedFrom(producer, unitsCanBePlacedByThisProducer, at, player);
         if (newMaxForThisProducer != maxPlaceable && neededExtra > newMaxForThisProducer) {
-          throw new IllegalStateException(
-              "getMaxUnitsToBePlaced originally returned: "
-                  + maxPlaceable
-                  + ", \nWhich is not the same as it is returning after using "
-                  + "freePlacementCapacity: "
-                  + newMaxForThisProducer
-                  + ", \nFor territory: "
-                  + at.getName()
-                  + ", Current Producer: "
-                  + producer.getName()
-                  + ", All Producers: "
-                  + producers
-                  + ", \nUnits Total: "
-                  + MyFormatter.unitsToTextNoOwner(units)
-                  + ", Units Left To Place By This Producer: "
-                  + MyFormatter.unitsToTextNoOwner(unitsCanBePlacedByThisProducer));
+          // Speculative count and freePlacementCapacity disagreed (the two algorithms
+          // for computing placements, that there are two different algorithms for the same
+          // thing is a problem in of itself).
+          // Trust the freshly-measured capacity and let any leftover units hit the
+          // "not enough territories" message.
+          if (newMaxForThisProducer != -1) {
+            maxPlaceable = newMaxForThisProducer;
+          }
         }
       }
       final Collection<Unit> placedUnits =
@@ -492,7 +484,14 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
           continue;
         }
         final Territory newProducer = tuple.getSecond();
-        int leftToPlace = getMaxUnitsToBePlacedFrom(newProducer, unitsLeftToPlace, at, player);
+        // Capacity is for the placement being split, not the current placement at `at`.
+        final Territory splitPlaceTerritory = placement.getPlaceTerritory();
+        int leftToPlace =
+            getMaxUnitsToBePlacedFrom(
+                newProducer,
+                unitsPlacedInTerritorySoFar(splitPlaceTerritory),
+                splitPlaceTerritory,
+                player);
         foundSpaceTotal += leftToPlace;
         // divide set of units that get placed
         final Collection<Unit> unitsForOldProducer = new ArrayList<>(placement.getUnits());

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -9,6 +9,7 @@ import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBrid
 import static games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate.BidMode.NOT_BID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -20,13 +21,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 // Note: This inherits from PlaceDelegateTestCommon and the tests defined there are included.
@@ -160,5 +165,47 @@ class PlaceDelegateTest extends PlaceDelegateTestCommon {
     assertThat(delegate.undoMove(fighterPlacement.getIndex()), is(nullValue()));
     assertThat(uk.getMatches(Matches.unitIsOfType(fighter)), is(empty()));
     assertThat(delegate.getMovesMade(), is(empty()));
+  }
+
+  // Regression test for https://github.com/triplea-game/triplea/issues/9165.
+  // Exercises freePlacementCapacity's split-placements pass: a prior sea-zone placement that
+  // exceeds a sibling producer's capacity must be split across producers, freeing up production
+  // for a new placement at the original producer.
+  @Test
+  void testFreePlacementCapacitySplitsPriorPlacementAcrossNeighborProducers() {
+    advanceToStep(delegate.getBridge(), "britishPlace");
+    final Territory eastCanadaSeaZone =
+        gameData.getMap().getTerritoryOrNull("East Canada Sea Zone");
+    assertThat(eastCanadaSeaZone, is(notNullValue()));
+
+    eastCanada.getUnitCollection().addAll(create(british, factory, 1));
+    // Seed East Canada at 1 of 2 capacity so a 2-transport placement won't fit whole and falls
+    // into the split pass. Use a mutable map: subsequent placements update it via put().
+    delegate.setProduced(new HashMap<>(Map.of(eastCanada, create(british, infantry, 1))));
+
+    assertValid(delegate.placeUnits(create(british, transport, 2), eastCanadaSeaZone, NOT_BID));
+    final List<UndoablePlacement> afterTransports = delegate.getMovesMade();
+    assertThat(afterTransports, hasSize(1));
+    assertThat(afterTransports.get(0).getProducerTerritory(), is(westCanada));
+    assertThat(afterTransports.get(0).getUnits(), hasSize(2));
+
+    final PlaceableUnits placeable =
+        delegate.getPlaceableUnits(create(british, infantry, 1), westCanada);
+    assertEquals(1, placeable.getMaxUnits());
+
+    assertValid(delegate.placeUnits(create(british, infantry, 1), westCanada, NOT_BID));
+
+    assertThat(westCanada.getMatches(Matches.unitIsOfType(infantry)), hasSize(1));
+
+    final List<UndoablePlacement> seaPlacementsAfter =
+        delegate.getMovesMade().stream()
+            .filter(p -> p.getPlaceTerritory().equals(eastCanadaSeaZone))
+            .collect(Collectors.toList());
+    assertThat(seaPlacementsAfter, hasSize(2));
+    final Set<Territory> producers =
+        seaPlacementsAfter.stream()
+            .map(UndoablePlacement::getProducerTerritory)
+            .collect(Collectors.toSet());
+    assertThat(producers, containsInAnyOrder(westCanada, eastCanada));
   }
 }


### PR DESCRIPTION
So, there are two placement algorithms "freePlacementCapacity"
and "getMaxUnitsToBePlacedFrom". They can disagree on placement
capacities. When that happens, we see crashes. Now, there should
not be two entirely different algorithms for this, but it's a
large effort to unify them at this juncture.

This update reduces the crash situation. IF the algorithms disagree,
then instead of a hard-fail, trust one algorithm and not the other
and allow for the existing error messaging to pop up regarding
exceeding placement capacities. Avoids the game crash.

Second, fix bug in freePlacementCapacity: update freePlacementCapacity
to query the correct territory and units when computing split capacity,
it was passing the current land units and land territory instead of the
sea zone's placed units and the sea territory

Fixes #9165

Before this fix, to repro:
  Using WaW and US:
    - place factories in SW and NW USA
    - next turn, purchase 12 subs and 12 infantry
    - place 7 subs into the SZ off of San Francisco
    - place 5 subs into that same SZ
    - now try to place 12 infantry into SF
    - notice: error message + crash
