### PR TITLE
fix(UI): prevent large game note images from expanding game notes / chooser

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -69,6 +69,8 @@ public class GameChooser {
     }
 
     final JSplitPane mainSplit = new JSplitPane();
+    mainSplit.setDividerLocation(250);
+    mainSplit.setResizeWeight(0.0);
     dialog.add(mainSplit, BorderLayout.CENTER);
     final JPanel leftPanel = new JPanel();
     leftPanel.setLayout(new GridBagLayout());
@@ -161,12 +163,10 @@ public class GameChooser {
         });
 
     final Dimension screenSize = Util.getScreenSize(dialog);
-    if (screenSize.width > 1024 && screenSize.height > 768) {
-      dialog.setSize(new Dimension(1024, 768));
-    } else {
-      dialog.setSize(800, 600);
-    }
-    dialog.setLocationRelativeTo(owner);
+    final int width = Math.clamp((int) (screenSize.width * 0.6), 800, 1180);
+    final int height = Math.max(600, (int) (screenSize.height * 0.66));
+    dialog.setSize(new Dimension(width, height));
+    dialog.setLocationRelativeTo(null);
     dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
     dialog.setVisible(true); // Blocking and waits for user action
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameNotesView.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameNotesView.java
@@ -1,14 +1,24 @@
 package games.strategy.engine.framework.ui;
 
 import java.awt.Color;
+import java.awt.Container;
 import java.awt.Rectangle;
 import javax.swing.JEditorPane;
+import javax.swing.JViewport;
 import javax.swing.SwingUtilities;
+import javax.swing.text.Element;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.ImageView;
 
 /** Component for displaying HTML-formatted game notes. */
 public class GameNotesView extends JEditorPane {
   public GameNotesView() {
     setEditable(false);
+    setEditorKit(new ScalingHtmlEditorKit());
     setContentType("text/html");
     // Render CSS lengths per the W3C spec (1px = 1 screen pixel). Without this, Swing's legacy
     // renderer treats CSS px as pt and inflates dimensions by ~33% at 96 DPI. See issue #6157.
@@ -27,5 +37,50 @@ public class GameNotesView extends JEditorPane {
     super.setText(text);
     // Scroll to the top of the notes screen when the text is updated.
     SwingUtilities.invokeLater(() -> scrollRectToVisible(new Rectangle()));
+  }
+
+  /** HTML kit that scales embedded images down to fit the viewport width. */
+  private static final class ScalingHtmlEditorKit extends HTMLEditorKit {
+    @Override
+    public ViewFactory getViewFactory() {
+      final ViewFactory delegate = super.getViewFactory();
+      return elem -> {
+        final Object name = elem.getAttributes().getAttribute(StyleConstants.NameAttribute);
+        if (name == HTML.Tag.IMG) {
+          return new ScaledImageView(elem);
+        }
+        return delegate.create(elem);
+      };
+    }
+  }
+
+  /**
+   * ImageView that clamps its width to the enclosing viewport, scaling height proportionally so
+   * embedded PNGs in game notes don't force the dialog to grow past the viewport.
+   */
+  private static final class ScaledImageView extends ImageView {
+    ScaledImageView(Element elem) {
+      super(elem);
+    }
+
+    @Override
+    public float getPreferredSpan(int axis) {
+      final float naturalWidth = super.getPreferredSpan(View.X_AXIS);
+      final float naturalHeight = super.getPreferredSpan(View.Y_AXIS);
+      final int viewport = getViewportWidth();
+      if (viewport <= 0 || naturalWidth <= 0 || naturalWidth <= viewport) {
+        return super.getPreferredSpan(axis);
+      }
+      final float scale = viewport / naturalWidth;
+      return axis == View.X_AXIS ? viewport : naturalHeight * scale;
+    }
+
+    private int getViewportWidth() {
+      Container c = getContainer();
+      while (c != null && !(c instanceof JViewport)) {
+        c = c.getParent();
+      }
+      return c == null ? 0 : c.getWidth();
+    }
   }
 }


### PR DESCRIPTION
- set height and width of game notes/game chooser to a fraction of total screen size (with max/min bounds). Replaces hard coded sizing that is potentially too small on small monitors.
- update game chooser to put more space for game notes
- clamp the max sizse for game note images to avoid expansion

Fixes #12018

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
