### PR TITLE
fix(battle): count air units as defenders, not as an abandoned territory

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -664,11 +664,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final Set<Unit> enemyUnitsOfAbandonedToUnits =
           abandonedToUnits.stream()
               .map(Unit::getOwner)
-              .map(
-                  p ->
-                      Matches.unitIsEnemyOf(p)
-                          .and(Matches.unitIsNotAir())
-                          .and(Matches.unitIsNotInfrastructure()))
+              .map(p -> Matches.unitIsEnemyOf(p).and(Matches.unitIsNotInfrastructure()))
               .map(territory.getUnitCollection()::getMatches)
               .flatMap(Collection::stream)
               .collect(Collectors.toSet());


### PR DESCRIPTION
  setupTerritoriesAbandonedToTheEnemy filtered air units out of the
  defender count, so a territory whose only defender was an airship
  looked abandoned. With "Limited combat rounds", a stalemate can
  leave an airship alone against enemy ground units; on the owner's
  next turn the method then hit its "should not be possible" throw
  because a normal battle was simultaneously pending for the same
  territory.

  Counting air units as defenders lets the existing pending normal
  battle resolve ownership instead of crashing.

  Fixes #12351
