### PR TITLE
fix(edit mode): tolerate duplicate unit UUIDs when removing units

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -44,7 +44,13 @@ public class AddUnits extends Change {
 
   /** Returns an unmodifiable map of unit UUIDs to player names. */
   public static Map<UUID, String> buildUnitOwnerMap(final Collection<Unit> units) {
-    return units.stream().collect(Collectors.toMap(Unit::getId, u -> u.getOwner().getName()));
+    // Tolerate duplicate UUIDs: if a unit appears more than once (e.g. a corrupted save where
+    // two Unit objects share an id), keep the first owner. Without a merge function, toMap
+    // throws IllegalStateException and blocks edit-mode removal of the offending units.
+    return units.stream()
+        .collect(
+            Collectors.toMap(
+                Unit::getId, u -> u.getOwner().getName(), (existing, duplicate) -> existing));
   }
 
   @Override


### PR DESCRIPTION
  Collectors.toMap in AddUnits.buildUnitOwnerMap threw
  IllegalStateException when the units collection contained two Unit
  instances sharing a UUID, blocking edit-mode unit removal. Add a merge
  function that keeps the first owner so the change is constructed
  successfully (both entries map to the same owner anyway).

  Fixes #12503
