### PR TITLE
fix(ai): stop AI from buying redundant factories and place pooled factories

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -1229,6 +1229,17 @@ class ProPurchaseAi {
     if (resourceTracker.isEmpty()) {
       return;
     }
+
+    // Don't buy another factory if one is already sitting in the unplaced-units pool (from a
+    // prior turn carry-over with "Unplaced units live when not placed", or granted by a
+    // trigger). The place phase will place it via the construction pass.
+    if (player.getUnits().stream().anyMatch(Matches.unitCanProduceUnits())) {
+      ProLogger.debug(
+          "Not purchasing a factory since one is already unplaced: "
+              + player.getMatches(Matches.unitCanProduceUnits()));
+      return;
+    }
+
     ProLogger.info(
         "Purchase factory with resources: " + resourceTracker + ", hasExtraPUs=" + hasExtraPUs);
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -1062,6 +1062,39 @@ public class WeakAi extends AbstractAi {
         placeAllWeCanOn(data, t, placeDelegate, player);
       }
     }
+    // Second pass: place construction units (e.g. factories) at owned territories that don't
+    // already host a producer. The first pass only visits territories that already have a
+    // factory, so a trigger-granted or carried-over factory would otherwise never find a
+    // home and would accumulate in the pool.
+    placeConstructionsWeCanOn(placeDelegate, player, randomTerritories);
+  }
+
+  private static void placeConstructionsWeCanOn(
+      final IAbstractPlaceDelegate placeDelegate,
+      final GamePlayer player,
+      final List<Territory> territories) {
+    for (final Territory t : territories) {
+      if (!t.isOwnedBy(player) || t.anyUnitsMatch(Matches.unitCanProduceUnits())) {
+        continue;
+      }
+      final List<Unit> constructions = player.getMatches(Matches.unitIsConstruction());
+      if (constructions.isEmpty()) {
+        return;
+      }
+      final PlaceableUnits placeable = placeDelegate.getPlaceableUnits(constructions, t);
+      if (placeable.isError() || placeable.getUnits().isEmpty()) {
+        continue;
+      }
+      int max = placeable.getMaxUnits();
+      if (max == -1) {
+        max = Integer.MAX_VALUE;
+      }
+      final List<Unit> units = new ArrayList<>(placeable.getUnits());
+      final int count = Math.min(max, units.size());
+      if (count > 0) {
+        doPlace(t, units.subList(0, count), placeDelegate);
+      }
+    }
   }
 
   private static void placeAllWeCanOn(


### PR DESCRIPTION
  ProAI's purchaseFactory() ignored the unplaced-units pool, so it kept
  buying factories every turn even when one was already waiting (e.g.
  carried over via "Unplaced units live when not placed" or granted by a
  NationalTheme trigger). Skip the buy if the player already owns a
  unit that can produce units.

  WeakAI's place() only visited territories that already had a factory,
  so a pooled factory had no path to placement. Add a second pass that
  places construction units at owned territories without a producer,
  mirroring ProAI's two-pass pattern.

  Fixes #12436
