### PR TITLE
fix(memory): allocate tile images lazily to avoid OOM on large maps

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -673,7 +673,10 @@ public class MapPanel extends ImageScrollerLargeView {
       final Collection<Tile> tileList = tileManager.getTiles(bounds);
       for (final Tile tile : tileList) {
         tile.drawImage(gameData, uiContext.getMapData());
-        g2d.drawImage(tile.getImage(), tile.getBounds().x, tile.getBounds().y, this);
+        final Image tileImage = tile.getImage();
+        if (tileImage != null) {
+          g2d.drawImage(tileImage, tile.getBounds().x, tile.getBounds().y, this);
+        }
       }
     }
   }
@@ -835,7 +838,10 @@ public class MapPanel extends ImageScrollerLargeView {
       } else {
         images.add(tile);
       }
-      g.drawImage(tile.getImage(), tile.getBounds().x, tile.getBounds().y, this);
+      final Image tileImage = tile.getImage();
+      if (tileImage != null) {
+        g.drawImage(tileImage, tile.getBounds().x, tile.getBounds().y, this);
+      }
     }
     g.translate(bounds.getX(), bounds.getY());
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 import lombok.Getter;
 
 /** Responsible for rendering a single map tile. */
@@ -23,8 +24,11 @@ public class Tile {
   private volatile boolean isDirty = true;
   private final AtomicBoolean isDrawing = new AtomicBoolean(false);
 
-  /** Current de facto immutable state of this tile. */
-  @Getter private Image image;
+  /**
+   * Current de facto immutable state of this tile. Null until {@link #drawImage} has rendered the
+   * tile at least once; callers must skip drawing when null.
+   */
+  @Getter @Nullable private Image image;
 
   @Getter private final Rectangle bounds;
   private final Object mutex = new Object();
@@ -32,7 +36,6 @@ public class Tile {
 
   Tile(final Rectangle bounds) {
     this.bounds = bounds;
-    this.image = Util.newImage(bounds.width, bounds.height, true);
   }
 
   public boolean needsRedraw() {


### PR DESCRIPTION
Tile previously allocated a 256 KB BufferedImage in its constructor for
every tile in the map, only to have drawImage() throw it away on first
render. On large maps with a small heap this caused OutOfMemoryError
inside TileManager.createTiles().

Defer the allocation: leave image null until drawImage() runs, and
null-check in MapPanel paint paths.

  Fixes #12569
