### PR TITLE
fix(battle window): size battle dialog to dice sides and icon size

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.ui;
 
-import static games.strategy.triplea.image.UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
 import static games.strategy.triplea.image.UnitImageFactory.ImageKey;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -529,18 +528,19 @@ public class BattleDisplay extends JPanel {
   }
 
   private void initLayout() {
+    final int unitIconHeight = uiContext.getUnitImageFactory().getUnitImageHeight();
     final JPanel attackerUnits = new JPanel();
     attackerUnits.setLayout(new BoxLayout(attackerUnits, BoxLayout.Y_AXIS));
     attackerUnits.add(getPlayerComponent(attacker));
     attackerUnits.add(Box.createGlue());
-    final JTable attackerTable = new BattleTable(attackerModel);
+    final JTable attackerTable = new BattleTable(attackerModel, unitIconHeight);
     attackerUnits.add(attackerTable);
     attackerUnits.add(attackerTable.getTableHeader());
     final JPanel defenderUnits = new JPanel();
     defenderUnits.setLayout(new BoxLayout(defenderUnits, BoxLayout.Y_AXIS));
     defenderUnits.add(getPlayerComponent(defender));
     defenderUnits.add(Box.createGlue());
-    final JTable defenderTable = new BattleTable(defenderModel);
+    final JTable defenderTable = new BattleTable(defenderModel, unitIconHeight);
     defenderUnits.add(defenderTable);
     defenderUnits.add(defenderTable.getTableHeader());
     final JPanel north = new JPanel();
@@ -695,10 +695,10 @@ public class BattleDisplay extends JPanel {
   private static final class BattleTable extends JTable {
     private static final long serialVersionUID = 6737857639382012817L;
 
-    BattleTable(final BattleModel model) {
+    BattleTable(final BattleModel model, final int unitIconHeight) {
       super(model);
       setDefaultRenderer(Object.class, new Renderer());
-      setRowHeight(DEFAULT_UNIT_ICON_SIZE + 5);
+      setRowHeight(unitIconHeight + 5);
       setBackground(new JButton().getBackground());
       setShowHorizontalLines(false);
       getTableHeader().setReorderingAllowed(false);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -11,6 +11,7 @@ import games.strategy.triplea.delegate.data.BattleListing;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
 import games.strategy.triplea.delegate.data.FightBattleDetails;
+import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.panels.map.MapPanel;
 import games.strategy.ui.Util;
@@ -66,13 +67,41 @@ public final class BattlePanel extends ActionPanel {
                 () -> Optional.ofNullable(battleDisplay).ifPresent(BattleDisplay::takeFocus));
           }
         });
-    final Dimension screenSize = Util.getScreenSize(battleWindow);
-    if (screenSize.width > 1024 && screenSize.height > 768) {
-      battleWindow.setMinimumSize(new Dimension(1024, 768));
-    } else {
-      battleWindow.setMinimumSize(new Dimension(800, 600));
-    }
     getMap().getUiContext().addShutdownWindow(battleWindow);
+  }
+
+  /**
+   * Sizes the battle window based on the map's dice sides and unit icon size, capped to fit on
+   * screen. Grows the window if it is currently smaller than required, but never shrinks a window
+   * the user has already enlarged.
+   */
+  private void resizeBattleWindowToFitContent() {
+    final UnitImageFactory unitImageFactory = getMap().getUiContext().getUnitImageFactory();
+    final int unitIconWidth = unitImageFactory.getUnitImageWidth();
+    final int unitIconHeight = unitImageFactory.getUnitImageHeight();
+    final int diceSides = getData().getDiceSides();
+
+    // Each cell in the BattleTable shows a unit icon plus an "xN" count label.
+    final int columnWidth = unitIconWidth + 35;
+    // Per side: 1 unit-icon column + (diceSides + 1) dice-strength columns.
+    final int tableWidth = (diceSides + 2) * columnWidth;
+    // Two tables side-by-side, plus the territory image (~100px) and frame insets.
+    final int desiredWidth = 2 * tableWidth + 180;
+
+    // Height needs room for the steps panel (which grows with AA / first-strike / sneak attack
+    // steps), the dice panel, the action button, and several rows of unit icons.
+    final int desiredHeight = Math.max(900, 6 * (unitIconHeight + 5) + 500);
+
+    final Dimension screenSize = Util.getScreenSize(battleWindow);
+    final int targetWidth = Math.min(desiredWidth, (int) (screenSize.width * 0.95));
+    final int targetHeight = Math.min(desiredHeight, (int) (screenSize.height * 0.95));
+
+    battleWindow.setMinimumSize(new Dimension(targetWidth, targetHeight));
+    final Dimension currentSize = battleWindow.getSize();
+    if (currentSize.width < targetWidth || currentSize.height < targetHeight) {
+      battleWindow.setSize(
+          Math.max(currentSize.width, targetWidth), Math.max(currentSize.height, targetHeight));
+    }
   }
 
   void setBattlesAndBombing(final BattleListing battleListing) {
@@ -256,6 +285,7 @@ public final class BattlePanel extends ActionPanel {
                   battleType);
           battleWindow.setTitle(battleDisplay.getDescription());
           battleWindow.getContentPane().add(battleDisplay);
+          resizeBattleWindowToFitContent();
 
           final var localPlayers = getMap().getUiContext().getLocalPlayers();
           if (ClientSetting.showBattlesWhenObserving.getValueOrThrow()


### PR DESCRIPTION
  Compute the battle window's minimum size from the map's dice sides and
  unit icon dimensions instead of using a fixed 1024x768. D12 maps and
  maps with oversized unit icons no longer have the unit-icon column
  squeezed and clipped. The BattleTable's row height now follows the
  actual unit icon height so taller icons aren't clipped vertically.
  The window is never shrunk if the user has already enlarged it.

  Fixes #12019
