### PR TITLE
fix(unit images): avoid CME in getIcon by replacing computeIfAbsent

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -396,11 +396,14 @@ public class UnitImageFactory {
   @Synchronized
   public ImageIcon getIcon(final ImageKey imageKey) {
     final String fullName = imageKey.getFullName();
-    return icons.computeIfAbsent(
-        fullName,
-        name ->
-            new ImageIcon(
-                getTransformedImage(imageKey).orElseGet(() -> createNoImageImage(imageKey))));
+    ImageIcon icon = icons.get(fullName);
+    if (icon == null) {
+      icon =
+          new ImageIcon(
+              getTransformedImage(imageKey).orElseGet(() -> createNoImageImage(imageKey)));
+      icons.put(fullName, icon);
+    }
+    return icon;
   }
 
   public Dimension getImageDimensions(final ImageKey imageKey) {


### PR DESCRIPTION
HashMap.computeIfAbsent throws ConcurrentModificationException if the
mapping function causes any modCount change. Use get/put instead, matching
the pattern already used in getImage.

Fixes #12995
