### PR TITLE
fix(pro AI): handle missing place delegate when validating purchases

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
@@ -72,7 +72,10 @@ public final class ProPurchaseValidationUtils {
       final boolean isBid) {
     final GameData data = player.getData();
     final var placeDelegate =
-        (AbstractPlaceDelegate) data.getDelegate(isBid ? "placeBid" : "place");
+        (AbstractPlaceDelegate) data.getDelegateOptional(isBid ? "placeBid" : "place").orElse(null);
+    if (placeDelegate == null) {
+      return false;
+    }
     if (!isBid
         && !t.equals(factoryTerritory)
         && !units.stream()


### PR DESCRIPTION
Some maps don't register a place/placeBid delegate for every player
(e.g. World War I 1914 Balanced for Central Powers and the various
neutrals). When such a player is set to Hard AI, the combat-move
simulation crashed in canUnitsBePlaced as soon as it tried to look up
the delegate by name. Treat the absence as "cannot place" so callers
fall through to the existing empty-result path.

Fixes #12872

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
