### PR TITLE
fix(ai): avoid NPE in ProAi.selectCasualties for AA fire during movement

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -412,36 +412,42 @@ public abstract class AbstractProAi extends AbstractAi {
       final BattleDelegate delegate = data.getBattleDelegate();
       final IBattle battle = delegate.getBattleTracker().getPendingBattle(battleId);
 
-      // If defender and could lose battle then don't consider unit cost as just trying to survive
-      boolean needToCheck = true;
-      final boolean isAttacker = player.equals(battle.getAttacker());
-      if (!isAttacker) {
-        final Collection<Unit> attackers = battle.getAttackingUnits();
-        final Collection<Unit> defenders = new ArrayList<>(battle.getDefendingUnits());
-        defenders.removeAll(defaultCasualties.getKilled());
-        final double strengthDifference =
-            ProBattleUtils.estimateStrengthDifference(battleSite, attackers, defenders);
-        int minStrengthDifference = 60;
-        if (!Properties.getLowLuck(data.getProperties())) {
-          minStrengthDifference = 55;
+      // AA fire during movement has no associated pending battle; fall back to
+      // simple cost-based sorting since no attacker/defender context is available.
+      if (battle == null) {
+        selectFromSorted.sort(ProPurchaseUtils.getCostComparator(proData));
+      } else {
+        // If defender and could lose battle then don't consider unit cost as just trying to survive
+        boolean needToCheck = true;
+        final boolean isAttacker = player.equals(battle.getAttacker());
+        if (!isAttacker) {
+          final Collection<Unit> attackers = battle.getAttackingUnits();
+          final Collection<Unit> defenders = new ArrayList<>(battle.getDefendingUnits());
+          defenders.removeAll(defaultCasualties.getKilled());
+          final double strengthDifference =
+              ProBattleUtils.estimateStrengthDifference(battleSite, attackers, defenders);
+          int minStrengthDifference = 60;
+          if (!Properties.getLowLuck(data.getProperties())) {
+            minStrengthDifference = 55;
+          }
+          if (strengthDifference > minStrengthDifference) {
+            needToCheck = false;
+          }
         }
-        if (strengthDifference > minStrengthDifference) {
-          needToCheck = false;
-        }
-      }
 
-      // Use bubble sort to save expensive units
-      while (needToCheck) {
-        needToCheck = false;
-        for (int i = 0; i < selectFromSorted.size() - 1; i++) {
-          final Unit unit1 = selectFromSorted.get(i);
-          final Unit unit2 = selectFromSorted.get(i + 1);
-          final double unitCost1 = ProPurchaseUtils.getCost(proData, unit1);
-          final double unitCost2 = ProPurchaseUtils.getCost(proData, unit2);
-          if (unitCost1 > 1.5 * unitCost2) {
-            selectFromSorted.set(i, unit2);
-            selectFromSorted.set(i + 1, unit1);
-            needToCheck = true;
+        // Use bubble sort to save expensive units
+        while (needToCheck) {
+          needToCheck = false;
+          for (int i = 0; i < selectFromSorted.size() - 1; i++) {
+            final Unit unit1 = selectFromSorted.get(i);
+            final Unit unit2 = selectFromSorted.get(i + 1);
+            final double unitCost1 = ProPurchaseUtils.getCost(proData, unit1);
+            final double unitCost2 = ProPurchaseUtils.getCost(proData, unit2);
+            if (unitCost1 > 1.5 * unitCost2) {
+              selectFromSorted.set(i, unit2);
+              selectFromSorted.set(i + 1, unit1);
+              needToCheck = true;
+            }
           }
         }
       }


### PR DESCRIPTION
AA fire during movement has no associated pending battle, so looking up
the battle by ID returns null. ProAi.selectCasualties dereferenced this
null when calling battle.getAttacker(), crashing the AI's combat move.
Fall back to sorting by unit cost when no battle context is available,
mirroring the empty-enemyUnits branch and the existing null guard in
retreatQuery.

Fixes #12852
