### PR TITLE
fix(logging): rotate triplea.log archives into the same directory

### DIFF
--- a/game-app/game-headed/src/main/resources/logback.xml
+++ b/game-app/game-headed/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- rollover daily -->
-            <fileNamePattern>triplea-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>${user.home}/triplea/triplea-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <!-- each file should be at most 1MB, keep 3 days worth of history, but at most 10MB -->
             <maxFileSize>1MB</maxFileSize>
             <maxHistory>3</maxHistory>


### PR DESCRIPTION
Prefix the rolling policy's fileNamePattern with ${user.home}/triplea/
so rolled archives land in the same directory as the active log.

Before: <file> wrote to ${user.home}/triplea/triplea.log, but
<fileNamePattern> was the bare relative "triplea-%d{yyyy-MM-dd}.%i.log".
At rollover, logback tried to rename the active file across directories
(home -> JVM working directory). That cross-directory rename can fail
silently on some setups (notably Windows when working dir and home are
on different volumes/permissions). When the rename fails, logback keeps
appending to the active file, so triplea.log balloons well past the
configured maxFileSize=1MB (users have reported 8MB+). On setups where
the rename succeeds, the rolled files land in the JVM working directory
instead of next to the active log, so users can't find them and
totalSizeCap/maxHistory cleanup runs in the wrong place.

After: <file> and <fileNamePattern> resolve to the same directory.
Same-directory renames are atomic and reliable across OSes, so the
1MB size trigger actually fires, totalSizeCap=10MB and maxHistory=3
apply to the real archives, and rolled files sit next to triplea.log
where users expect them.

Fixes #13176
