### PR TITLE
fix(save game): write to temp file and rename to avoid corruption

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/save/game/GameDataWriter.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/save/game/GameDataWriter.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.io.IoUtils;
@@ -27,38 +28,53 @@ public class GameDataWriter {
     }
   }
 
+  /**
+   * Saves the game to {@code file}. Writes to a sibling temp file first and renames on success, so
+   * the existing file at {@code file} is preserved if the delegate lock cannot be acquired or the
+   * write fails partway through.
+   */
   public static void writeToFile(
       final GameData gameData,
       final DelegateExecutionManager delegateExecutionManager,
       final Path file) {
 
-    try (OutputStream fout = Files.newOutputStream(file)) {
-      GameDataWriter.writeToOutputStream(gameData, fout, delegateExecutionManager);
-    } catch (final IOException e) {
-      log.error("Failed to save game to file: " + file.toAbsolutePath(), e);
+    if (!acquireDelegateLock(delegateExecutionManager)) {
+      log.error("Error saving game.. could not lock delegate execution: {}", file.toAbsolutePath());
+      return;
+    }
+
+    try {
+      Path tempFile = null;
+      try {
+        tempFile = Files.createTempFile(file.getParent(), file.getFileName().toString(), ".tmp");
+        try (OutputStream out = Files.newOutputStream(tempFile)) {
+          GameDataManager.saveGame(out, gameData);
+        }
+        Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING);
+        tempFile = null;
+      } catch (final IOException e) {
+        log.error("Failed to save game to file: " + file.toAbsolutePath(), e);
+      } finally {
+        if (tempFile != null) {
+          try {
+            Files.deleteIfExists(tempFile);
+          } catch (final IOException e) {
+            log.warn("Failed to delete temp save file: " + tempFile.toAbsolutePath(), e);
+          }
+        }
+      }
+    } finally {
+      delegateExecutionManager.resumeDelegateExecution();
     }
   }
 
-  // error prone is detecting the identical boolean condition as an error, when it's
-  // intentional and is actually a retry.
-  @SuppressWarnings("IdentityBinaryExpression")
   private static void writeToOutputStream(
       final GameData gameData,
       final OutputStream out,
       final DelegateExecutionManager delegateExecutionManager)
       throws IOException {
-    final String errorMessage = "Error saving game.. ";
-
-    try {
-      // TODO: is this necessary to save a game?
-      // try twice
-      if (!delegateExecutionManager.blockDelegateExecution(6000)
-          && !delegateExecutionManager.blockDelegateExecution(6000)) {
-        log.error(errorMessage + " could not lock delegate execution");
-        return;
-      }
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
+    if (!acquireDelegateLock(delegateExecutionManager)) {
+      log.error("Error saving game..  could not lock delegate execution");
       return;
     }
 
@@ -66,6 +82,21 @@ public class GameDataWriter {
       GameDataManager.saveGame(out, gameData);
     } finally {
       delegateExecutionManager.resumeDelegateExecution();
+    }
+  }
+
+  // error prone is detecting the identical boolean condition as an error, when it's
+  // intentional and is actually a retry.
+  @SuppressWarnings("IdentityBinaryExpression")
+  private static boolean acquireDelegateLock(
+      final DelegateExecutionManager delegateExecutionManager) {
+    try {
+      // try twice
+      return delegateExecutionManager.blockDelegateExecution(6000)
+          || delegateExecutionManager.blockDelegateExecution(6000);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
     }
   }
 }


### PR DESCRIPTION
If the delegate lock could not be acquired within 12s, the destination
save file had already been opened in truncate mode, leaving the user's
previous save as a 0-byte file. Now the lock is acquired first, then
the save writes to a temp file in the same directory and renames onto
the target only on success. Failures preserve the existing file.

Fixes #12996

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
