### PR TITLE
Fix neutral player order in sidebar Players/Resources tabs

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
@@ -2,7 +2,6 @@ package games.strategy.engine.data;
 
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.triplea.Constants;
-import games.strategy.triplea.util.PlayerOrderComparator;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.ArrayList;
@@ -72,12 +71,6 @@ public class PlayerList extends GameDataComponent implements Iterable<GamePlayer
 
   public List<GamePlayer> getPlayers() {
     return new ArrayList<>(players.values());
-  }
-
-  public List<GamePlayer> getSortedPlayers() {
-    final List<GamePlayer> players = getPlayers();
-    players.sort(new PlayerOrderComparator(getData()));
-    return players;
   }
 
   /** an iterator of a new ArrayList copy of the players. */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/StatsInfo.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/StatsInfo.java
@@ -88,7 +88,7 @@ public class StatsInfo extends InfoForFile {
   protected void gatherDataBeforeWriting(PrintGenerationData printData) {
     gameData = printData.getData();
     alliances = gameData.getAllianceTracker().getAlliances();
-    orderedPlayers = gameData.getPlayerList().getSortedPlayers();
+    orderedPlayers = gameData.getPlayerList().getPlayers();
     // extended stats covers stuff that doesn't show up in the game stats menu bar, like custom
     // resources or tech  tokens or # techs, etc.
     final ExtendedStats statPanel = new ExtendedStats(gameData, uiContext);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
@@ -110,7 +110,7 @@ class EconomyPanel extends JPanel implements GameDataChangeListener {
       // copy so that the object doesn't change underneath us
       final GameData gameData = EconomyPanel.this.gameData;
       try (GameData.Unlocker ignored = gameData.acquireReadLock()) {
-        final List<GamePlayer> players = gameData.getPlayerList().getSortedPlayers();
+        final List<GamePlayer> players = gameData.getPlayerList().getPlayers();
         final List<String> alliances = getAlliancesToShow(gameData.getAllianceTracker());
         collectedData = new String[players.size() + alliances.size()][resourceStats.size() + 1];
         int row = 0;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -146,7 +146,7 @@ class StatPanel extends JPanel implements GameDataChangeListener {
       // copy so that the object doesn't change underneath us
       final GameData gameDataSync = StatPanel.this.gameData;
       try (GameData.Unlocker ignored = gameDataSync.acquireReadLock()) {
-        final List<GamePlayer> players = gameDataSync.getPlayerList().getSortedPlayers();
+        final List<GamePlayer> players = gameDataSync.getPlayerList().getPlayers();
         final List<String> alliances = getAlliancesToShow(gameDataSync.getAllianceTracker());
         collectedData = new String[players.size() + alliances.size()][stats.length + 1];
         int row = 0;


### PR DESCRIPTION
Sidebar tabs sorted players via PlayerOrderComparator, which placed
optional/neutral players (e.g. Brazil, Spain, Sweden, Turkey in TWW)
at the bottom regardless of XML order. Use PlayerList.getPlayers()
directly so the sidebar matches the start screen's ordering.

Fixes #12849
