### PR TITLE
fix(move validation): handle missing battle delegate on hover

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2031,15 +2031,17 @@ public final class Matches {
       if (!territoryIsLand().test(t)) {
         return false;
       }
-      final BattleTracker bt = AbstractMoveDelegate.getBattleTracker(player.getData());
-      if (bt.wasConquered(t)) {
+      final GameData data = player.getData();
+      // Battle delegate may be absent on cloned/loading game data.
+      if (data.getDelegateOptional("battle").isPresent()
+          && AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
         return false;
       }
       final GamePlayer owner = t.getOwner();
       if (owner.isNull()) {
         return false;
       }
-      final RelationshipTracker rt = player.getData().getRelationshipTracker();
+      final RelationshipTracker rt = data.getRelationshipTracker();
       return !(!rt.canMoveAirUnitsOverOwnedLand(player, owner)
           || !rt.canLandAirUnitsOnOwnedLand(player, owner));
     };


### PR DESCRIPTION
The mouseMoved hover preview in MovePanel runs the move validator,
which calls airCanLandOnThisAlliedNonConqueredLandTerritory. That
predicate dereferences the "battle" delegate via player.getData(),
which can be absent on cloned/loading game data and crashes the UI
with "battle delegate not found".

Skip the wasConquered check when the delegate is absent.

Fixes #13676
