### PR TITLE
fix(unit overflow): step by actual image width

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.ui.screen;
 
+import static games.strategy.triplea.image.UnitImageFactory.ImageKey;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
@@ -332,7 +334,9 @@ public class TileManager {
       throw new IllegalStateException("No where to place units: " + territory.getName());
     }
 
+    final var unitImageFactory = uiContext.getUnitImageFactory();
     Point lastPlace = null;
+    UnitCategory previousCategory = null;
     for (final UnitCategory category : UnitSeparator.getSortedUnitCategories(territory, mapData)) {
       final boolean overflow;
       if (placementPoints.hasNext()) {
@@ -342,10 +346,13 @@ public class TileManager {
         if (lastPlace == null) return; // should not occur, but better safe than sorry
         lastPlace = new Point(lastPlace);
         overflow = true;
+        // Step by an actual image width so adjacent overflow units sit edge-to-edge regardless
+        // of map.properties units.width. Direction differs because the draw anchor is top-left:
+        // overflow-left needs this unit's width; overflow-right needs the previous unit's.
         if (mapData.getPlacementOverflowToLeft(territory)) {
-          lastPlace.x -= uiContext.getUnitImageFactory().getUnitImageWidth();
+          lastPlace.x -= unitImageFactory.getImage(ImageKey.of(category)).getWidth(null);
         } else {
-          lastPlace.x += uiContext.getUnitImageFactory().getUnitImageWidth();
+          lastPlace.x += unitImageFactory.getImage(ImageKey.of(previousCategory)).getWidth(null);
         }
       }
       final UnitsDrawer drawable =
@@ -356,6 +363,7 @@ public class TileManager {
         tile.addDrawable(drawable);
         drawnOn.add(tile);
       }
+      previousCategory = category;
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -346,9 +346,6 @@ public class TileManager {
         if (lastPlace == null) return; // should not occur, but better safe than sorry
         lastPlace = new Point(lastPlace);
         overflow = true;
-        // Step by an actual image width so adjacent overflow units sit edge-to-edge regardless
-        // of map.properties units.width. Direction differs because the draw anchor is top-left:
-        // overflow-left needs this unit's width; overflow-right needs the previous unit's.
         if (mapData.getPlacementOverflowToLeft(territory)) {
           lastPlace.x -= unitImageFactory.getImage(ImageKey.of(category)).getWidth(null);
         } else {


### PR DESCRIPTION
The horizontal stepping for overflow units used the map-wide
units.width from map.properties, which leaves visible gaps when a
map's unit images vary in size (e.g. 1941 Global Command Decision
ranges from 54 to 98 px on a 96 px map default).

Step by the actual scaled image width instead. Direction is
asymmetric because the draw anchor is the image's top-left:
overflow-left steps by the current unit's width, overflow-right by
the previous unit's width.

Other call sites of getUnitImageWidth() (stack/damage label offsets,
the overflow underline, move-arrow code) intentionally still use the
map-wide width.

Fixes #12754
