### PR TITLE
Bot Maps: live-load maps instead of caching them from startup

### DIFF
--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessServerStartupRemote.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessServerStartupRemote.java
@@ -1,16 +1,16 @@
 package org.triplea.game.server;
 
 import com.google.common.base.Preconditions;
-import games.strategy.engine.framework.AutoSaveFileUtils;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.mc.IServerStartupRemote;
 import games.strategy.net.INode;
 import java.io.BufferedInputStream;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.io.IoUtils;
+import org.triplea.performance.PerfTimer;
 
 @Slf4j
 public class HeadlessServerStartupRemote implements IServerStartupRemote {
@@ -66,11 +66,8 @@ public class HeadlessServerStartupRemote implements IServerStartupRemote {
 
   @Override
   public List<String> getAvailableGames() {
-    // Copy available games collection into a serializable collection
-    // so it can be sent over network.
-    List<String> availableGames = new ArrayList<>(headlessGameServer.getAvailableGames());
-    availableGames.addAll(AutoSaveFileUtils.getAutoSaveFiles());
-    return availableGames;
+    return PerfTimer.time(
+        "loading maps", () -> InstalledMapsListing.parseMapFiles().getSortedGameList());
   }
 
   @Override


### PR DESCRIPTION
Bots previously loaded maps at startup only, requiring
a restart to refresh their maps list. This update
changes that to "live-load" the maps each time the
list of maps is requested. This removes the need to
restart bots to pick up updated maps.

We leave timing info to help ensure there won't
be too much latency involved. Locally, the load
of all maps is sub-second.
