### PR TITLE
fix(host network game): restore hosting screen for direct (non-lobby) host

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -108,9 +108,9 @@ public class ServerModel extends Observable implements IConnectionChangeListener
     this.launchAction = launchAction;
   }
 
-  public Optional<GameHostingResponse> initialize() {
+  public boolean initialize() {
     this.gameSelectorModel.addObserver(gameSelectorObserver);
-    return getServerProps().map(this::createServerMessenger);
+    return getServerProps().map(this::createServerMessenger).orElse(false);
   }
 
   static RemoteName getObserverWaitingToStartName(final INode node) {
@@ -213,8 +213,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
     return launchAction.getFallbackConnection(this::cancel);
   }
 
-  @Nullable
-  private GameHostingResponse createServerMessenger(final ServerConnectionProps props) {
+  private boolean createServerMessenger(final ServerConnectionProps props) {
     try {
       this.serverMessenger =
           new ServerMessenger(props.getName(), props.getPort(), objectStreamFactory);
@@ -241,11 +240,10 @@ public class ServerModel extends Observable implements IConnectionChangeListener
       messengers.registerRemote(
           launchAction.getStartupRemote(new DefaultServerModelView()), SERVER_REMOTE_NAME);
 
-      @Nullable final GameHostingResponse gameHostingResponse;
-
       if (System.getProperty(LOBBY_URI) != null) {
         final URI lobbyUri = URI.create(System.getProperty(LOBBY_URI));
-        gameHostingResponse = GameHostingClient.newClient(lobbyUri).sendGameHostingRequest();
+        final GameHostingResponse gameHostingResponse =
+            GameHostingClient.newClient(lobbyUri).sendGameHostingRequest();
 
         lobbyWatcherThread =
             new LobbyWatcherThread(
@@ -275,8 +273,6 @@ public class ServerModel extends Observable implements IConnectionChangeListener
 
         lobbyWatcherThread.createLobbyWatcher(
             gameToLobbyConnection, !launchAction.shouldMinimizeExpensiveAiUse());
-      } else {
-        gameHostingResponse = null;
       }
 
       chatController = new ChatController(CHAT_NAME, messengers, serverMessenger);
@@ -287,7 +283,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
 
       serverMessenger.setAcceptNewConnections(true);
       gameDataChanged();
-      return gameHostingResponse;
+      return true;
     } catch (final BindException e) {
       log.warn(
           "Could not open network port, please close any other TripleA games you are\n"
@@ -303,7 +299,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
         ExitStatus.FAILURE.exit();
       }
     }
-    return null;
+    return false;
   }
 
   private PlayerListing getPlayerListingInternal() {

--- a/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/HeadedServerSetupModel.java
@@ -63,7 +63,9 @@ public class HeadedServerSetupModel {
    */
   public ServerModel showServer() {
     final ServerModel serverModel = new ServerModel(gameSelectorModel, new HeadedLaunchAction(ui));
-    serverModel.initialize().ifPresent(u -> onServerMessengerCreated(serverModel));
+    if (serverModel.initialize()) {
+      onServerMessengerCreated(serverModel);
+    }
     return serverModel;
   }
 

--- a/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessServerSetupModel.java
+++ b/game-app/game-headless/src/main/java/org/triplea/game/server/HeadlessServerSetupModel.java
@@ -1,6 +1,7 @@
 package org.triplea.game.server;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static games.strategy.engine.framework.CliProperties.LOBBY_URI;
 
 import games.strategy.engine.framework.startup.LobbyWatcherThread;
@@ -10,7 +11,6 @@ import games.strategy.engine.framework.startup.ui.panels.main.game.selector.Game
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.triplea.http.client.lobby.game.hosting.request.GameHostingResponse;
 
 /** Setup panel model for headless server. */
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
@@ -22,12 +22,11 @@ public class HeadlessServerSetupModel {
   public HeadlessServerSetup createHeadlessServerSetup() {
     final ServerModel serverModel =
         new ServerModel(gameSelectorModel, new HeadlessLaunchAction(headlessGameServer));
-    return onServerMessengerCreated(serverModel, serverModel.initialize().orElse(null));
+    checkState(serverModel.initialize(), "failed to initialize bot, did it connect to lobby?");
+    return onServerMessengerCreated(serverModel);
   }
 
-  private HeadlessServerSetup onServerMessengerCreated(
-      final ServerModel serverModel, final GameHostingResponse gameHostingResponse) {
-    checkNotNull(gameHostingResponse, "hosting response is null, did the bot connect to lobby?");
+  private HeadlessServerSetup onServerMessengerCreated(final ServerModel serverModel) {
     checkNotNull(System.getProperty(LOBBY_URI));
 
     serverModel


### PR DESCRIPTION
Repro: from the welcome screen, click "Host Networked Game", fill in the dialog, hit OK. The hosting screen never appears.

Regressed in PR #14363

Fix: instead of relying on Optionals, use a direct boolean return value to indicate if we can host or not.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
