### PR TITLE
Remove WW2v3-1941_v2 map entry

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -3225,13 +3225,6 @@
   img: https://raw.githubusercontent.com/triplea-maps/Pacific1941/master/preview.png
   description: |
     <br>World War 2 in the Pacific starting in 1941 with many unit types.
-- mapName: WW2v3-1941_v2
-  mapCategory: EXPERIMENTAL
-  url: https://github.com/triplea-maps/WW2v3-1941_v2/archive/refs/heads/master.zip
-  version: 1
-  img: https://raw.githubusercontent.com/triplea-maps/WW2v3-1941_v2/master/preview.png
-  description: |
-    <br>Modified version of World II v3 - 1941
 - mapName: No Mans Land Navalland
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/No_Mans_Land_Navalland/archive/refs/heads/master.zip


### PR DESCRIPTION
Removed the WW2v3-1941_v2 map entry as it was a duplicate of the regular WW2v3-1941

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
