### PR TITLE
Fixes AI not placing unplaced factories

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -276,12 +276,10 @@ class ProPurchaseAi {
     // Find all purchase/place territories
     final Map<Territory, ProPurchaseTerritory> purchaseTerritories =
         ProPurchaseUtils.findPurchaseTerritories(proData, player);
-        ProLogger.trace("purchaseTerritories=" + purchaseTerritories);
     final Set<Territory> placeTerritories =
         new HashSet<>(
             CollectionUtils.getMatches(
                 data.getMap().getTerritoriesOwnedBy(player), Matches.territoryIsLand()));
-                ProLogger.trace("placeTerritories=" + placeTerritories);
     for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
       for (final ProPlaceTerritory ppt : t.getCanPlaceTerritories()) {
         placeTerritories.add(ppt.getTerritory());
@@ -570,15 +568,12 @@ class ProPurchaseAi {
       }
     }
     // Evaluate the best territories for factories
-    evaluateFactoryPlaceTerritories(placeTerritories);
-      final List<Territory> rankedTerritories = evaluateFactoryPlaceTerritories(placeTerritories);
+    final List<Territory> rankedTerritories = evaluateFactoryPlaceTerritories(placeTerritories);
 
     // Place regular units, then construction units, and lastly factories
     placeUnits(prioritizedTerritories, placeDelegate, Matches.unitIsNotConstruction());
     placeUnits(prioritizedTerritories, placeDelegate, Matches.unitIsConstruction());
     placeFactories(rankedTerritories, placeDelegate);
-
-
 
     territoryManager = null;
   }
@@ -2526,7 +2521,7 @@ class ProPurchaseAi {
       }
     }
   }
-//  Matches.unitIsNotConstruction
+
   private void placeUnits(
       final List<ProPlaceTerritory> prioritizedTerritories,
       final IAbstractPlaceDelegate placeDelegate,
@@ -2545,25 +2540,24 @@ class ProPurchaseAi {
         ProLogger.trace(t + " can't place units with error: " + placeableUnits.getErrorMessage());
         continue;
       }
-        // Find remaining unit production
-        int remainingUnitProduction = placeableUnits.getMaxUnits();
-        if (remainingUnitProduction == -1) {
-          remainingUnitProduction = Integer.MAX_VALUE;
-        }
-        ProLogger.trace(t + ", remainingUnitProduction=" + remainingUnitProduction);
 
-        // Place as many units as possible
-        final List<Unit> unitsThatCanBePlaced = new ArrayList<>(placeableUnits.getUnits());
-        final int placeCount = Math.min(remainingUnitProduction, unitsThatCanBePlaced.size());
-        final List<Unit> unitsToPlace = unitsThatCanBePlaced.subList(0, placeCount);
-        ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
-        doPlace(t, unitsToPlace, placeDelegate);
+      // Find remaining unit production
+      int remainingUnitProduction = placeableUnits.getMaxUnits();
+      if (remainingUnitProduction == -1) {
+        remainingUnitProduction = Integer.MAX_VALUE;
+      }
+      ProLogger.trace(t + ", remainingUnitProduction=" + remainingUnitProduction);
+
+      // Place as many units as possible
+      final List<Unit> unitsThatCanBePlaced = new ArrayList<>(placeableUnits.getUnits());
+      final int placeCount = Math.min(remainingUnitProduction, unitsThatCanBePlaced.size());
+      final List<Unit> unitsToPlace = unitsThatCanBePlaced.subList(0, placeCount);
+      ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
+      doPlace(t, unitsToPlace, placeDelegate);
     }
   }
 
- private List<Territory> evaluateFactoryPlaceTerritories(
-      final Set<Territory> placeTerritories) {
-
+  private List<Territory> evaluateFactoryPlaceTerritories(final Set<Territory> placeTerritories) {
     final ProOtherMoveOptions enemyAttackOptions = territoryManager.getEnemyAttackOptions();
 
     // Find all owned land territories that weren't conquered and don't already have a factory
@@ -2664,41 +2658,41 @@ class ProPurchaseAi {
       }
       valuedTerritories.sort(Comparator.comparingDouble(TerritoryValue::value).reversed());
     }
-   ProLogger.debug("Evaluated territories for factory placement=" + valuedTerritories);
-      final List<Territory> rankedTerritories =
-              valuedTerritories.stream().map(TerritoryValue::territory).toList();
-   ProLogger.trace("Ranking evaluated territories=" + rankedTerritories);
+    ProLogger.debug("Evaluated territories for factory placement=" + valuedTerritories);
+    final List<Territory> rankedTerritories =
+        valuedTerritories.stream().map(TerritoryValue::territory).toList();
+    ProLogger.trace("Ranking evaluated territories=" + rankedTerritories);
     return rankedTerritories;
   }
 
   private void placeFactories(
-          final List<Territory> placeFactoryTerritories,
-          final IAbstractPlaceDelegate placeDelegate) {
-      if (player.getUnits().stream().anyMatch(Matches.unitCanProduceUnits())) {
-        ProLogger.info("Place units=" + player.getMatches(Matches.unitCanProduceUnits()));
+      final List<Territory> placeFactoryTerritories, final IAbstractPlaceDelegate placeDelegate) {
+    if (player.getUnits().stream().anyMatch(Matches.unitCanProduceUnits())) {
+      ProLogger.info("Place units=" + player.getMatches(Matches.unitCanProduceUnits()));
 
-        // Loop through prioritized territories and place units
-        for (final Territory t : placeFactoryTerritories) {
-            ProLogger.debug("Checking place for " + t.getName());
+      // Loop through prioritized territories and place units
+      for (final Territory t : placeFactoryTerritories) {
+        ProLogger.debug("Checking place for " + t.getName());
 
-          // Check if any units can be placed
-          final PlaceableUnits placeableUnits =
-                  placeDelegate.getPlaceableUnits(player.getMatches(Matches.unitCanProduceUnits()), t);
-          if (placeableUnits.isError()) {
-            ProLogger.trace(t + " can't place units with error: " + placeableUnits.getErrorMessage());
-            continue;
-          }
-            final List<Unit> unitsThatCanBePlaced = new ArrayList<>(placeableUnits.getUnits().stream().filter(Matches.unitCanProduceUnits()).toList());
-            final int placeCount = unitsThatCanBePlaced.size();
-            final List<Unit> unitsToPlace = unitsThatCanBePlaced.subList(0, placeCount);
-            ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
-            doPlace(t, unitsToPlace, placeDelegate);
+        // Check if any units can be placed
+        final PlaceableUnits placeableUnits =
+            placeDelegate.getPlaceableUnits(player.getMatches(Matches.unitCanProduceUnits()), t);
+        if (placeableUnits.isError()) {
+          ProLogger.trace(t + " can't place units with error: " + placeableUnits.getErrorMessage());
+          continue;
         }
-      } else {
-          return;
+        final List<Unit> unitsThatCanBePlaced =
+            new ArrayList<>(
+                placeableUnits.getUnits().stream().filter(Matches.unitCanProduceUnits()).toList());
+        final int placeCount = unitsThatCanBePlaced.size();
+        final List<Unit> unitsToPlace = unitsThatCanBePlaced.subList(0, placeCount);
+        ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
+        doPlace(t, unitsToPlace, placeDelegate);
       }
+    } else {
+      return;
+    }
   }
-
 
   private void addUnitsToPlaceTerritory(
       final ProPlaceTerritory placeTerritory,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -283,7 +283,6 @@ class ProPurchaseAi {
     for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
       for (final ProPlaceTerritory ppt : t.getCanPlaceTerritories()) {
         placeTerritories.add(ppt.getTerritory());
-        ProLogger.trace("placeTerritories=" + placeTerritories);
       }
     }
 
@@ -504,7 +503,7 @@ class ProPurchaseAi {
       }
     }
 
-    // Place remaining units (currently only implemented to handle land units, ex. WW2v3 China)
+    // Place remaining units (currently only implemented to handle land units, ex. WW2v3 China, and factories)
     if (player.getUnits().isEmpty()) {
       return;
     }
@@ -570,10 +569,10 @@ class ProPurchaseAi {
     // Evaluate the best territories for factories
     final List<Territory> rankedTerritories = evaluateFactoryPlaceTerritories(placeTerritories);
 
-    // Place regular units, then construction units, and lastly factories
+    // Place factories first, then regular units, and then other construction units.
+    placeFactories(rankedTerritories, placeDelegate);
     placeUnits(prioritizedTerritories, placeDelegate, Matches.unitIsNotConstruction());
     placeUnits(prioritizedTerritories, placeDelegate, Matches.unitIsConstruction());
-    placeFactories(rankedTerritories, placeDelegate);
 
     territoryManager = null;
   }
@@ -2658,7 +2657,7 @@ class ProPurchaseAi {
       }
       valuedTerritories.sort(Comparator.comparingDouble(TerritoryValue::value).reversed());
     }
-    ProLogger.debug("Evaluated territories for factory placement=" + valuedTerritories);
+    ProLogger.trace("Evaluated territories for factory placement=" + valuedTerritories);
     final List<Territory> rankedTerritories =
         valuedTerritories.stream().map(TerritoryValue::territory).toList();
     ProLogger.trace("Ranking evaluated territories=" + rankedTerritories);
@@ -2668,7 +2667,7 @@ class ProPurchaseAi {
   private void placeFactories(
       final List<Territory> placeFactoryTerritories, final IAbstractPlaceDelegate placeDelegate) {
     if (player.getUnits().stream().anyMatch(Matches.unitCanProduceUnits())) {
-      ProLogger.info("Place units=" + player.getMatches(Matches.unitCanProduceUnits()));
+      ProLogger.info("Place factories=" + player.getMatches(Matches.unitCanProduceUnits()));
 
       // Loop through prioritized territories and place units
       for (final Territory t : placeFactoryTerritories) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -276,13 +276,16 @@ class ProPurchaseAi {
     // Find all purchase/place territories
     final Map<Territory, ProPurchaseTerritory> purchaseTerritories =
         ProPurchaseUtils.findPurchaseTerritories(proData, player);
+        ProLogger.trace("purchaseTerritories=" + purchaseTerritories);
     final Set<Territory> placeTerritories =
         new HashSet<>(
             CollectionUtils.getMatches(
                 data.getMap().getTerritoriesOwnedBy(player), Matches.territoryIsLand()));
+                ProLogger.trace("placeTerritories=" + placeTerritories);
     for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
       for (final ProPlaceTerritory ppt : t.getCanPlaceTerritories()) {
         placeTerritories.add(ppt.getTerritory());
+        ProLogger.trace("placeTerritories=" + placeTerritories);
       }
     }
 
@@ -566,11 +569,16 @@ class ProPurchaseAi {
         }
       }
     }
+    // Evaluate the best territories for factories
+    evaluateFactoryPlaceTerritories(placeTerritories);
+      final List<Territory> rankedTerritories = evaluateFactoryPlaceTerritories(placeTerritories);
 
-    // Place regular then isConstruction units (placeDelegate.getPlaceableUnits doesn't handle
-    // combined)
+    // Place regular units, then construction units, and lastly factories
     placeUnits(prioritizedTerritories, placeDelegate, Matches.unitIsNotConstruction());
     placeUnits(prioritizedTerritories, placeDelegate, Matches.unitIsConstruction());
+    placeFactories(rankedTerritories, placeDelegate);
+
+
 
     territoryManager = null;
   }
@@ -2529,12 +2537,12 @@ class ProPurchaseAi {
       }
     }
   }
-
+//  Matches.unitIsNotConstruction
   private void placeUnits(
       final List<ProPlaceTerritory> prioritizedTerritories,
       final IAbstractPlaceDelegate placeDelegate,
       final Predicate<Unit> unitMatch) {
-    ProLogger.info("Place units=" + player.getUnits());
+    ProLogger.info("Place units=" + player.getMatches(unitMatch));
 
     // Loop through prioritized territories and place units
     for (final ProPlaceTerritory placeTerritory : prioritizedTerritories) {
@@ -2548,22 +2556,160 @@ class ProPurchaseAi {
         ProLogger.trace(t + " can't place units with error: " + placeableUnits.getErrorMessage());
         continue;
       }
+        // Find remaining unit production
+        int remainingUnitProduction = placeableUnits.getMaxUnits();
+        if (remainingUnitProduction == -1) {
+          remainingUnitProduction = Integer.MAX_VALUE;
+        }
+        ProLogger.trace(t + ", remainingUnitProduction=" + remainingUnitProduction);
 
-      // Find remaining unit production
-      int remainingUnitProduction = placeableUnits.getMaxUnits();
-      if (remainingUnitProduction == -1) {
-        remainingUnitProduction = Integer.MAX_VALUE;
-      }
-      ProLogger.trace(t + ", remainingUnitProduction=" + remainingUnitProduction);
-
-      // Place as many units as possible
-      final List<Unit> unitsThatCanBePlaced = new ArrayList<>(placeableUnits.getUnits());
-      final int placeCount = Math.min(remainingUnitProduction, unitsThatCanBePlaced.size());
-      final List<Unit> unitsToPlace = unitsThatCanBePlaced.subList(0, placeCount);
-      ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
-      doPlace(t, unitsToPlace, placeDelegate);
+        // Place as many units as possible
+        final List<Unit> unitsThatCanBePlaced = new ArrayList<>(placeableUnits.getUnits());
+        final int placeCount = Math.min(remainingUnitProduction, unitsThatCanBePlaced.size());
+        final List<Unit> unitsToPlace = unitsThatCanBePlaced.subList(0, placeCount);
+        ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
+        doPlace(t, unitsToPlace, placeDelegate);
     }
   }
+
+ private List<Territory> evaluateFactoryPlaceTerritories(
+      final Set<Territory> placeTerritories) {
+
+    final ProOtherMoveOptions enemyAttackOptions = territoryManager.getEnemyAttackOptions();
+
+    // Find all owned land territories that weren't conquered and don't already have a factory
+    final List<Territory> possibleFactoryTerritories =
+        CollectionUtils.getMatches(
+            data.getMap().getTerritories(),
+            ProMatches.territoryHasNoInfraFactoryAndIsNotConqueredOwnedLand(player));
+    final Set<Territory> placeFactoryTerritories = new HashSet<>();
+    final List<Territory> territoriesThatCantBeHeld = new ArrayList<>();
+    for (final Territory t : possibleFactoryTerritories) {
+
+      // Only consider territories with production of at least 2
+      final int production =
+          TerritoryAttachment.get(t).map(TerritoryAttachment::getProduction).orElse(0);
+      if (production < 2) {
+        continue;
+      }
+
+      // Check if no enemy attackers and that it wasn't conquered this turn
+      if (enemyAttackOptions.getMax(t) == null) {
+        placeFactoryTerritories.add(t);
+        ProLogger.trace("Possible factory since no enemy attackers: " + t.getName());
+      } else {
+
+        // Find current battle result
+        final List<Unit> defenders = t.getMatches(Matches.isUnitAllied(player));
+        final Set<Unit> enemyAttackingUnits =
+            new HashSet<>(enemyAttackOptions.getMax(t).getMaxUnits());
+        enemyAttackingUnits.addAll(enemyAttackOptions.getMax(t).getMaxAmphibUnits());
+        ProLogger.trace("enemyAttackingUnits=" + enemyAttackingUnits);
+        final ProBattleResult result =
+            calc.estimateDefendBattleResults(
+                proData,
+                t,
+                enemyAttackingUnits,
+                defenders,
+                enemyAttackOptions.getMax(t).getMaxBombardUnits());
+
+        // Check if it can't be held or if it can then that it wasn't conquered this turn
+        if (result.isHasLandUnitRemaining() || result.getTuvSwing() > 0) {
+          territoriesThatCantBeHeld.add(t);
+          ProLogger.trace(
+              "Can't hold territory: "
+                  + t.getName()
+                  + ", hasLandUnitRemaining="
+                  + result.isHasLandUnitRemaining()
+                  + ", TUVSwing="
+                  + result.getTuvSwing()
+                  + ", enemyAttackers="
+                  + enemyAttackingUnits.size()
+                  + ", myDefenders="
+                  + defenders.size());
+        } else {
+          placeFactoryTerritories.add(t);
+          ProLogger.trace(
+              "Possible factory: "
+                  + t.getName()
+                  + ", hasLandUnitRemaining="
+                  + result.isHasLandUnitRemaining()
+                  + ", TUVSwing="
+                  + result.getTuvSwing()
+                  + ", enemyAttackers="
+                  + enemyAttackingUnits.size()
+                  + ", myDefenders="
+                  + defenders.size());
+        }
+      }
+    }
+    ProLogger.debug("Possible factory territories: " + placeFactoryTerritories);
+
+    // Find strategic value for each territory
+    record TerritoryValue(Territory territory, double value) {}
+
+    final Map<Territory, Double> territoryValueMap =
+        ProTerritoryValueUtils.findTerritoryValues(
+            proData, player, territoriesThatCantBeHeld, List.of(), placeFactoryTerritories);
+    final List<TerritoryValue> valuedTerritories = new ArrayList<>();
+    for (final Territory t : placeFactoryTerritories) {
+      final int production =
+          TerritoryAttachment.get(t).map(TerritoryAttachment::getProduction).orElse(0);
+      final double baseValue = territoryValueMap.get(t) * production + 0.1 * production;
+      final boolean isAdjacentToSea =
+          Matches.territoryHasNeighborMatching(data.getMap(), Matches.territoryIsWater()).test(t);
+      final Set<Territory> nearbyLandTerritories =
+          data.getMap().getNeighbors(t, 9, ProMatches.territoryCanMoveLandUnits(player, false));
+      final int numNearbyEnemyTerritories =
+          CollectionUtils.countMatches(nearbyLandTerritories, Matches.isTerritoryEnemy(player));
+      ProLogger.trace(
+          t
+              + ", strategic value="
+              + territoryValueMap.get(t)
+              + ", value="
+              + baseValue
+              + ", numNearbyEnemyTerritories="
+              + numNearbyEnemyTerritories);
+      if ((numNearbyEnemyTerritories >= 4 && territoryValueMap.get(t) >= 1) || isAdjacentToSea) {
+        valuedTerritories.add(new TerritoryValue(t, baseValue));
+      }
+      valuedTerritories.sort(Comparator.comparingDouble(TerritoryValue::value).reversed());
+    }
+   ProLogger.debug("Evaluated territories for factory placement=" + valuedTerritories);
+      final List<Territory> rankedTerritories =
+              valuedTerritories.stream().map(TerritoryValue::territory).toList();
+   ProLogger.trace("Ranking evaluated territories=" + rankedTerritories);
+    return rankedTerritories;
+  }
+
+  private void placeFactories(
+          final List<Territory> placeFactoryTerritories,
+          final IAbstractPlaceDelegate placeDelegate) {
+      if (player.getUnits().stream().anyMatch(Matches.unitCanProduceUnits())) {
+        ProLogger.info("Place units=" + player.getMatches(Matches.unitCanProduceUnits()));
+
+        // Loop through prioritized territories and place units
+        for (final Territory t : placeFactoryTerritories) {
+            ProLogger.debug("Checking place for " + t.getName());
+
+          // Check if any units can be placed
+          final PlaceableUnits placeableUnits =
+                  placeDelegate.getPlaceableUnits(player.getMatches(Matches.unitCanProduceUnits()), t);
+          if (placeableUnits.isError()) {
+            ProLogger.trace(t + " can't place units with error: " + placeableUnits.getErrorMessage());
+            continue;
+          }
+            final List<Unit> unitsThatCanBePlaced = new ArrayList<>(placeableUnits.getUnits().stream().filter(Matches.unitCanProduceUnits()).toList());
+            final int placeCount = unitsThatCanBePlaced.size();
+            final List<Unit> unitsToPlace = unitsThatCanBePlaced.subList(0, placeCount);
+            ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
+            doPlace(t, unitsToPlace, placeDelegate);
+        }
+      } else {
+          return;
+      }
+  }
+
 
   private void addUnitsToPlaceTerritory(
       final ProPlaceTerritory placeTerritory,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -503,7 +503,8 @@ class ProPurchaseAi {
       }
     }
 
-    // Place remaining units (currently only implemented to handle land units, ex. WW2v3 China, and factories)
+    // Place remaining units (currently only implemented to handle land units, ex. WW2v3 China, and
+    // factories)
     if (player.getUnits().isEmpty()) {
       return;
     }


### PR DESCRIPTION
This is my first pull request as a developer, please correct me if I did anything wrong.

AI wasn't able to place unplaced factories from previous rounds or factories gained by triggers. It was treating them as regular units and trying to place them in territories with factories, resulting in a failed placement. This commit adds two separate methods, one evaluating the territories for factory placement, and another for placing the factories. Attempts to fix: https://github.com/triplea-game/triplea/issues/14457

## Notes to Reviewer
The AI does not yet consider different types of factories, so if there are several types of unplaced factories, they will be placed more or less randomly in the evaluated territories. It depends on the order of the unplaced factories list. It places the first factory in the best evaluated territory, the second in the next best, and so on. This is not the end of the world but might call for another PR fix in the future.