### PR TITLE
Refactor MapDownload PR01 (Add ManagedMap)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListing.java
@@ -19,6 +19,9 @@ class DownloadMapsWindowMapsListing {
   private final Collection<MapDownloadItem> available;
   private final Map<MapDownloadItem, InstalledMap> installed;
   private final Map<MapDownloadItem, InstalledMap> outOfDate;
+  // @TODO: Complete redesign to contain model for maps replacing state holdings in UI components
+  // in the future
+  private final ManagedMapStore mapStore;
 
   DownloadMapsWindowMapsListing(final Collection<MapDownloadItem> downloads) {
     this(downloads, InstalledMapsListing.parseMapFiles());
@@ -29,9 +32,20 @@ class DownloadMapsWindowMapsListing {
       final Collection<MapDownloadItem> downloads,
       final InstalledMapsListing installedMapsListing) {
 
-    outOfDate = installedMapsListing.findOutOfDateMaps(downloads);
-    installed = installedMapsListing.findInstalledMapsFromDownloadList(downloads);
-    available = installedMapsListing.findNotInstalledMapsFromDownloadList(downloads);
+    mapStore = new ManagedMapStore();
+    mapStore.initialize(downloads, installedMapsListing);
+
+    available =
+        mapStore.getByStatus(ManagedMapStatus.AVAILABLE).stream()
+            .map(ManagedMap::getMapDownloadItem)
+            .toList();
+    outOfDate =
+        mapStore.getByStatus(ManagedMapStatus.UPDATE_AVAILABLE).stream()
+            .collect(Collectors.toMap(ManagedMap::getMapDownloadItem, ManagedMap::getInstalledMap));
+    installed =
+        mapStore.getByStatus(ManagedMapStatus.INSTALLED).stream()
+            .collect(Collectors.toMap(ManagedMap::getMapDownloadItem, ManagedMap::getInstalledMap));
+    installed.putAll(outOfDate); // currently outOfDate maps are to be shown as installed as well
   }
 
   List<MapDownloadItem> getAvailableExcluding(final Collection<MapDownloadItem> excluded) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ManagedMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ManagedMap.java
@@ -1,0 +1,77 @@
+package games.strategy.engine.framework.map.download;
+
+import games.strategy.engine.framework.map.file.system.loader.InstalledMap;
+import java.util.Objects;
+import lombok.Getter;
+import org.triplea.http.client.lobby.maps.listing.MapDownloadItem;
+
+enum ManagedMapStatus {
+  AVAILABLE,
+  DOWNLOADING,
+  INSTALLED,
+  UPDATE_AVAILABLE,
+  REMOVING,
+  ERROR
+}
+
+final class ManagedMap {
+  @Getter private ManagedMapStatus mapStatus;
+  @Getter private final MapDownloadItem mapDownloadItem;
+  @Getter private InstalledMap installedMap = null; // already downloaded
+
+  ManagedMap(final MapDownloadItem mapDownloadItem) {
+    this.mapStatus = ManagedMapStatus.AVAILABLE;
+    this.mapDownloadItem = Objects.requireNonNull(mapDownloadItem);
+  }
+
+  public ManagedMap(final MapDownloadItem mapDownloadItem, final InstalledMap installedMap) {
+    this(mapDownloadItem);
+    this.installedMap = Objects.requireNonNull(installedMap);
+    this.mapStatus =
+        installedMap.isOutOfDate(mapDownloadItem)
+            ? ManagedMapStatus.UPDATE_AVAILABLE
+            : ManagedMapStatus.INSTALLED;
+  }
+
+  String getMapName() {
+    return mapDownloadItem.getMapName();
+  }
+
+  void setMapStatus(final ManagedMapStatus newStatus) {
+    this.mapStatus = Objects.requireNonNull(newStatus);
+  }
+
+  boolean isInstalled() {
+    return mapStatus == ManagedMapStatus.INSTALLED;
+  }
+
+  boolean isDownloading() {
+    return mapStatus == ManagedMapStatus.DOWNLOADING;
+  }
+
+  boolean isUpdateAvailable() {
+    return mapStatus == ManagedMapStatus.UPDATE_AVAILABLE;
+  }
+
+  boolean isAvailable() {
+    return mapStatus == ManagedMapStatus.AVAILABLE;
+  }
+
+  @Override
+  public String toString() {
+    return getMapName() + " [" + mapStatus + "]";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ManagedMap)) return false;
+    final ManagedMap that = (ManagedMap) o;
+    return mapDownloadItem.getMapName().equals(that.mapDownloadItem.getMapName());
+  }
+
+  @Override
+  public int hashCode() {
+    return mapDownloadItem.getMapName().hashCode();
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ManagedMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ManagedMap.java
@@ -41,22 +41,6 @@ final class ManagedMap {
     this.mapStatus = Objects.requireNonNull(newStatus);
   }
 
-  boolean isInstalled() {
-    return mapStatus == ManagedMapStatus.INSTALLED;
-  }
-
-  boolean isDownloading() {
-    return mapStatus == ManagedMapStatus.DOWNLOADING;
-  }
-
-  boolean isUpdateAvailable() {
-    return mapStatus == ManagedMapStatus.UPDATE_AVAILABLE;
-  }
-
-  boolean isAvailable() {
-    return mapStatus == ManagedMapStatus.AVAILABLE;
-  }
-
   @Override
   public String toString() {
     return getMapName() + " [" + mapStatus + "]";
@@ -65,13 +49,14 @@ final class ManagedMap {
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
-    if (!(o instanceof ManagedMap)) return false;
-    final ManagedMap that = (ManagedMap) o;
+    if (!(o instanceof ManagedMap that)) return false;
     return mapDownloadItem.getMapName().equals(that.mapDownloadItem.getMapName());
   }
 
   @Override
   public int hashCode() {
+    // @todo currently the map name is assumed to be unique, solution is required, but the
+    // limitation already exists today
     return mapDownloadItem.getMapName().hashCode();
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ManagedMapStore.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ManagedMapStore.java
@@ -1,0 +1,93 @@
+package games.strategy.engine.framework.map.download;
+
+import games.strategy.engine.framework.map.file.system.loader.InstalledMap;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
+import org.triplea.http.client.lobby.maps.listing.MapDownloadItem;
+
+enum StoreState {
+  UNINITIALIZED,
+  INITIALIZING,
+  INITIALIZED
+}
+
+final class ManagedMapStore {
+
+  private final Map<String, ManagedMap> mapsByName = new HashMap<>();
+  @Getter private StoreState storeState;
+
+  ManagedMapStore() {
+    storeState = StoreState.UNINITIALIZED;
+  }
+
+  public void initialize(
+      Collection<MapDownloadItem> downloads, InstalledMapsListing installedMapsListing) {
+    storeState = StoreState.INITIALIZING;
+    downloads.forEach(
+        downloadItem -> {
+          Optional<InstalledMap> installedMapByName =
+              installedMapsListing.findInstalledMapByName(downloadItem.getMapName());
+          put(
+              installedMapByName
+                  .map(installedMap -> new ManagedMap(downloadItem, installedMap))
+                  .orElseGet(() -> new ManagedMap(downloadItem)));
+        });
+    storeState = StoreState.INITIALIZED;
+  }
+
+  ManagedMap get(final String mapName) {
+    return mapsByName.get(mapName);
+  }
+
+  boolean contains(final String mapName) {
+    return mapsByName.containsKey(mapName);
+  }
+
+  Collection<ManagedMap> getAll() {
+    return Collections.unmodifiableCollection(mapsByName.values());
+  }
+
+  List<ManagedMap> getAllSortedByName() {
+    final List<ManagedMap> result = new ArrayList<>(mapsByName.values());
+    result.sort(Comparator.comparing(ManagedMap::getMapName));
+    return result;
+  }
+
+  void put(final ManagedMap map) {
+    mapsByName.put(map.getMapName(), map);
+  }
+
+  void remove(final String mapName) {
+    mapsByName.remove(mapName);
+  }
+
+  void clear() {
+    mapsByName.clear();
+  }
+
+  void updateStatus(final String mapName, final ManagedMapStatus status) {
+    final ManagedMap map = mapsByName.get(mapName);
+    if (map != null) {
+      map.setMapStatus(status);
+    }
+  }
+
+  List<ManagedMap> getByStatus(final ManagedMapStatus status) {
+    return mapsByName.values().stream()
+        .filter(m -> m.getMapStatus() == status)
+        .sorted(Comparator.comparing(ManagedMap::getMapName))
+        .toList();
+  }
+
+  int size() {
+    return mapsByName.size();
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -91,9 +91,6 @@ public class InstalledMap {
    * date of the map-download.
    */
   public boolean isOutOfDate(final MapDownloadItem download) {
-    // Treat a missing/zero commit date as "no signal" rather than NPE-ing on auto-unbox
-    // or treating every map as up-to-date against epoch 0. The GitHub-fallback listing
-    // path sets 0L, and a server response with a null value would unbox to NPE.
     final long lastCommitMilli = download.getLastCommitDateEpochMilli();
     if (lastCommitMilli <= 0L) {
       return false;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -79,7 +79,7 @@ public class InstalledMap {
     if (xmlPath.isEmpty() || mapContentRoot.isEmpty()) {
       return Optional.empty();
     } else {
-      return Optional.of(
+      return Optional.ofNullable(
           LocalizeHtml.localizeImgLinksInHtml(
               GameNotes.loadGameNotes(xmlPath.get()), mapContentRoot.get()));
     }
@@ -90,12 +90,12 @@ public class InstalledMap {
    * comparing the last modified date on the map installation folder compared to the last commit
    * date of the map-download.
    */
-  boolean isOutOfDate(final MapDownloadItem download) {
+  public boolean isOutOfDate(final MapDownloadItem download) {
     // Treat a missing/zero commit date as "no signal" rather than NPE-ing on auto-unbox
     // or treating every map as up-to-date against epoch 0. The GitHub-fallback listing
     // path sets 0L, and a server response with a null value would unbox to NPE.
-    final Long lastCommitMilli = download.getLastCommitDateEpochMilli();
-    if (lastCommitMilli == null || lastCommitMilli <= 0L) {
+    final long lastCommitMilli = download.getLastCommitDateEpochMilli();
+    if (lastCommitMilli <= 0L) {
       return false;
     }
 


### PR DESCRIPTION
- ManagedMap store for map information including its (download) state
- ManagedMapStore canonical collection of ALL maps
- Hooked into DownloadMapsWindowMapsListing
- InstalledMap.isOutOfDate made public for reuse

## Notes to Reviewer
This is a first PR to get to a proper MVC concept for handling the map download/update/remove window. Later also the UI part shall be extracted from the current package `games.strategy.engine.framework.map.download`.
For now this PR introduces the new storage class `ManagedMap` and its collection class `ManagedMapStore` and makes use of it in `DownloadMapsWindowMapsListing` which has tests that verify the code works properly.
Manual UI test was also done.