### PR TITLE
Improve error handling in case of incorrect user credentials

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbTokenGenerator.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbTokenGenerator.java
@@ -95,7 +95,13 @@ public class NodeBbTokenGenerator {
 
   private void checkUser(final Map<?, ?> jsonObject, final String username) {
     if (!jsonObject.containsKey("uid")) {
-      throw new IllegalStateException(String.format("User %s doesn't exist.", username));
+      throw new IllegalStateException(
+          String.format(
+              "Couldn't find an account with the username User %s in the selected forum. Please double-check:"
+                  + "\n1) The selected forum"
+                  + "\n2) The spelling of your username"
+                  + "\n3) If your account is correctly registered at the selected forum",
+              username));
     }
     Object banned = jsonObject.get("banned");
     if (banned instanceof Integer ? (Integer) banned == 1 : (Boolean) banned) {
@@ -154,7 +160,8 @@ public class NodeBbTokenGenerator {
               Preconditions.checkNotNull((Map<?, ?>) jsonObject.get("payload")).get("token");
         }
         throw new IllegalStateException(
-            "Incorrect password or server error.\nReturn Code: "
+            "Incorrect password or server error. Please double-check your entered password"
+                + "\nReturn Code: "
                 + code
                 + "\nMessage from server: "
                 + jsonObject.get("message"));


### PR DESCRIPTION
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

Based on https://github.com/triplea-game/triplea/issues/14322. This modifies the error messages shown when either the username or the password is not recognized. The error messages should now be more clear to the user to see 1) what's wrong 2) how to solve the issue.
