### PR TITLE
Fix Easy AI not placing Chinese units in World War II v3

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -18,6 +18,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.UnitUtils;
 import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.ai.AiUtils;
+import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
@@ -1048,6 +1049,8 @@ public class WeakAi extends AbstractAi {
     if (player.getUnitCollection().isEmpty()) {
       return;
     }
+    final RulesAttachment ra = player.getRulesAttachment();
+    final boolean placementAnyTerritory = (ra != null && ra.getPlacementAnyTerritory());
     final Optional<Territory> optionalCapitol =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     // place in capitol first
@@ -1058,7 +1061,7 @@ public class WeakAi extends AbstractAi {
     for (final Territory t : randomTerritories) {
       if (!t.equals(capitol)
           && t.isOwnedBy(player)
-          && t.anyUnitsMatch(Matches.unitCanProduceUnits())) {
+          && (placementAnyTerritory || t.anyUnitsMatch(Matches.unitCanProduceUnits()))) {
         placeAllWeCanOn(data, t, placeDelegate, player);
       }
     }


### PR DESCRIPTION
Easy AI only looked at territories containing factories when placing units. However, players that have the rulesAttachment "placementAnyTerritory" (like China in World War II v3) can place in any territory, also ones without factories. This adds a check if "placementAnyTerritory" is true. If it is, then all owned territories qualify for placement. If not, then only territories with factories do so. Attempts to fix: https://github.com/triplea-game/triplea/issues/3350
 
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
