### PR TITLE
Fixed small typo in error message in case of incorrect username

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbTokenGenerator.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbTokenGenerator.java
@@ -97,7 +97,7 @@ public class NodeBbTokenGenerator {
     if (!jsonObject.containsKey("uid")) {
       throw new IllegalStateException(
           String.format(
-              "Couldn't find an account with the username User %s in the selected forum. Please double-check:"
+              "Couldn't find an account with the username %s in the selected forum. Please double-check:"
                   + "\n1) The selected forum"
                   + "\n2) The spelling of your username"
                   + "\n3) If your account is correctly registered at the selected forum",


### PR DESCRIPTION
There was a small typo in the updated error message when the username couldn't be found at the selected forum in the PBF game settings. It would say "username User {username}". This removes "User" so that it says: "username {username}".

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
