### PR TITLE
Improve carrier landing validation for air units in the placement phase

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1655,17 +1655,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     return CollectionUtils.getAny(factoryUnits).getOriginalOwner();
   }
 
-  /*
-  TODO: TripleA currently does not track which air units are assigned to which carrier. As a result, carrier capacity
-   can be calculated incorrectly when both friendly and owned carriers are present in the same sea zone.
-   Example:
-   A sea zone contains one owned carrier and one allied carrier.
-   The allied player has air units in the sea zone.
-   If the allied air units occupy the allied carrier, placement on the owned carrier should be allowed.
-   If the allied air units occupy the owned carrier, placement should not be allowed because newly produced aircraft
-   cannot be placed on an allied carrier.
-   TripleA currently allows placement in both situations.
-  */
   private static Optional<@Nls String> validateNewAirCanLandOnCarriers(
       final Territory to, final Collection<Unit> units, final GamePlayer player) {
     int cost = AirMovementValidator.carrierCost(units);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -858,7 +858,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       return Optional.of("Cannot place these units outside of the capital");
     }
     if (to.isWater()) {
-      final Optional<String> canLand = validateNewAirCanLandOnCarriers(to, units);
+      final Optional<String> canLand = validateNewAirCanLandOnCarriers(to, units, player);
       if (canLand.isPresent()) {
         return canLand;
       }
@@ -1659,12 +1659,37 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
    * The rule is that new fighters can be produced on new carriers. This does not allow for fighters
    * to be produced on old carriers. THIS ISN'T CORRECT.
    */
+  /*
+  TODO: In the code below, the game incorrectly allows you to place fighters on friendly carriers when there is in a
+   sea zone:
+   1) A carrier owned by you
+   2) A friendly carrier
+   3) Air units from the friendly power
+   This is because at the time of writing, TripleA does not know which fighters are on which carriers
+   If the friendly air units are on the friendly carrier, you should be able to place air units on your empty carrier.
+   If the friendly air units are on your OWN carrier, then you should NOT be able to place air units in the sea zone,
+   because you cannot place air units on the friendly carrier
+   Currently in this last situation, the game incorrectly allows you to place aircraft in the sea zone.
+   */
   private static Optional<@Nls String> validateNewAirCanLandOnCarriers(
-      final Territory to, final Collection<Unit> units) {
-    final int cost = AirMovementValidator.carrierCost(units);
-    int capacity = AirMovementValidator.carrierCapacity(units, to);
-    capacity += AirMovementValidator.carrierCapacity(to.getUnits(), to);
-    // TODO: This method considers existing carriers but not existing air units
+      final Territory to, final Collection<Unit> units, final GamePlayer player) {
+    // Find the units in the territory controlled by the current player
+    final Collection<Unit> ownedUnitsInTerritory = new ArrayList<>();
+    for (final Unit unit : to.getUnits()) {
+      if (unit.getOwner().equals(player)) {
+        ownedUnitsInTerritory.add(unit);
+      }
+    }
+    // Finds the total carrierCost of the units
+    int cost = AirMovementValidator.carrierCost(units); // Considers the placeable units
+    cost +=
+        AirMovementValidator.carrierCost(
+            ownedUnitsInTerritory); // Considers the units in the territory
+    // Finds the total carrierCapacity of the units
+    int capacity = AirMovementValidator.carrierCapacity(units, to); // Considers the placeable units
+    capacity +=
+        AirMovementValidator.carrierCapacity(
+            ownedUnitsInTerritory, to); // Considers the units in the territory
     if (cost > capacity) {
       return Optional.of("Not enough new carriers to land all the fighters");
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1655,41 +1655,24 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     return CollectionUtils.getAny(factoryUnits).getOriginalOwner();
   }
 
-  /**
-   * The rule is that new fighters can be produced on new carriers. This does not allow for fighters
-   * to be produced on old carriers. THIS ISN'T CORRECT.
-   */
   /*
-  TODO: In the code below, the game incorrectly allows you to place fighters on friendly carriers when there is in a
-   sea zone:
-   1) A carrier owned by you
-   2) A friendly carrier
-   3) Air units from the friendly power
-   This is because at the time of writing, TripleA does not know which fighters are on which carriers
-   If the friendly air units are on the friendly carrier, you should be able to place air units on your empty carrier.
-   If the friendly air units are on your OWN carrier, then you should NOT be able to place air units in the sea zone,
-   because you cannot place air units on the friendly carrier
-   Currently in this last situation, the game incorrectly allows you to place aircraft in the sea zone.
-   */
+  TODO: TripleA currently does not track which air units are assigned to which carrier. As a result, carrier capacity
+   can be calculated incorrectly when both friendly and owned carriers are present in the same sea zone.
+   Example:
+   A sea zone contains one owned carrier and one allied carrier.
+   The allied player has air units in the sea zone.
+   If the allied air units occupy the allied carrier, placement on the owned carrier should be allowed.
+   If the allied air units occupy the owned carrier, placement should not be allowed because newly produced aircraft
+   cannot be placed on an allied carrier.
+   TripleA currently allows placement in both situations.
+  */
   private static Optional<@Nls String> validateNewAirCanLandOnCarriers(
       final Territory to, final Collection<Unit> units, final GamePlayer player) {
-    // Find the units in the territory controlled by the current player
-    final Collection<Unit> ownedUnitsInTerritory = new ArrayList<>();
-    for (final Unit unit : to.getUnits()) {
-      if (unit.getOwner().equals(player)) {
-        ownedUnitsInTerritory.add(unit);
-      }
-    }
-    // Finds the total carrierCost of the units
-    int cost = AirMovementValidator.carrierCost(units); // Considers the placeable units
-    cost +=
-        AirMovementValidator.carrierCost(
-            ownedUnitsInTerritory); // Considers the units in the territory
-    // Finds the total carrierCapacity of the units
-    int capacity = AirMovementValidator.carrierCapacity(units, to); // Considers the placeable units
+    int cost = AirMovementValidator.carrierCost(units);
+    cost += AirMovementValidator.carrierCost(to.getMatches(Matches.unitIsOwnedBy(player)));
+    int capacity = AirMovementValidator.carrierCapacity(units, to);
     capacity +=
-        AirMovementValidator.carrierCapacity(
-            ownedUnitsInTerritory, to); // Considers the units in the territory
+        AirMovementValidator.carrierCapacity(to.getMatches(Matches.unitIsOwnedBy(player)), to);
     if (cost > capacity) {
       return Optional.of("Not enough new carriers to land all the fighters");
     }


### PR DESCRIPTION
When there is a friendly carrier in a sea zone, normally the engine correctly prevents you from placing your aircraft directly in this sea zone, EXCEPT when there is a carrier controlled by you in that sea zone (either from a previous turn or placed there this turn). In that case, the game does allow you to place aircraft on the friendly carrier, in addition to on the carrier you own.

This PR fixes that issue, as well as the issue where fighters you OWN already in the sea zone that you want to place fighters on carriers weren't taken into account. What previously happened was that the game allowed you to place let's say two fighters in a sea zone containing an aircraft carrier and two fighters. The game only recognized the carrier and therefore allowed the placement of two more fighters, but ignored the two fighters already present. Then, if you clicked "done", the engine would warn you of fighters not being able to land. Now, the engine will immediately tell you that you cannot place those fighters in that territory because there are not enough carriers. Based on the removed TODO comment that I happened to notice.

Attempts to fix: https://github.com/triplea-game/triplea/issues/6238

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer

TODO: Currently there is still one scenario where the game incorrectly allows you to place fighters on friendly carriers. That is when a sea zone contains:
1) A carrier owned by you
2) A friendly carrier
3) Air units from a friendly power

This is because at the time of writing, TripleA does not know which fighters are on which carriers.
If the friendly air units are on the friendly carrier, you should be able to place air units on your empty carrier.
If the friendly air units are on your OWN carrier, then you should NOT be able to place air units in the sea zone because you are not allowed to place air units on the friendly carrier. 
Currently in this last situation, the game incorrectly allows you to place aircraft in the sea zone.

Because aircraft assigned to carriers is not implemented yet, there is no way to distinguish if the first situation is occurring or the second situation. Therefore, I think it's best to leave that problem as it is until this has been implemented and simply allow it for both instances. It is better to allow it in an incorrect case than disallow it in a correct case.
