### PR TITLE
Remove error message "Two history synchers?"

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -242,8 +242,10 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       SwingAction.of(
           "Show history",
           e -> {
-            showHistory();
-            dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
+            if (inHistory.compareAndSet(false, true)) {
+              showHistory();
+              dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
+            }
           });
 
   @Getter
@@ -1777,9 +1779,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   }
 
   private void showHistory() {
-    if (historySyncher != null) {
-      return;
-    }
     inHistory.set(true);
     inGame.set(false);
     setWidgetActivation();

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1777,6 +1777,9 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   }
 
   private void showHistory() {
+    if (historySyncher != null) {
+      return;
+    }
     inHistory.set(true);
     inGame.set(false);
     setWidgetActivation();
@@ -1789,9 +1792,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       if (clonedGameData == null) {
         return;
       }
-    }
-    if (historySyncher != null) {
-      return;
     }
     historySyncher = new HistorySynchronizer(clonedGameData, game);
     updatePanelsGameData(clonedGameData);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1791,7 +1791,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       }
     }
     if (historySyncher != null) {
-      throw new IllegalStateException("Two history synchers?");
+      return;
     }
     historySyncher = new HistorySynchronizer(clonedGameData, game);
     updatePanelsGameData(clonedGameData);


### PR DESCRIPTION
This removes the error message "Two history synchers?", which is triggered when toggling the history when it is already showing. It is an unnecessary error message in my opinion, better is to just have nothing happen when the history is toggled again.

Fixes: https://github.com/triplea-game/triplea/issues/14509

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
