### PR TITLE
Fix Resource Tab showing incorrect data when in history mode

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -15,7 +15,6 @@ import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
-import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.message.IRemote;
 import games.strategy.engine.player.Player;
@@ -40,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Predicate;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.CollectionUtils;
@@ -71,8 +69,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
     // Only add territory resources if endTurn not endTurnNoPU
     for (final GameStep step : data.getSequence()) {
       if (player.equals(step.getPlayerId())) {
-        Optional<IDelegate> optionalDelegate = step.getDelegateOptional();
-        if (optionalDelegate.isPresent() && optionalDelegate.get().getName().equals("endTurn")) {
+        if (step.getDelegateName().equals("endTurn")) {
           final List<Territory> territories = data.getMap().getTerritoriesOwnedBy(player);
           final int pusFromTerritories =
               getProduction(territories, data) * Properties.getPuMultiplier(data.getProperties());


### PR DESCRIPTION
optionalDelegate is apparently always empty when in history mode. This causes vital code to not be executed and results in an incorrect display of estimated collected resources. This removes the use of optionalDelegate in the if-condition and directly uses the step extracted from the parsed GameData. This variable is not empty when in history mode and thus makes sure the calculation is always the same.

Attempts to fix: https://github.com/triplea-game/triplea/issues/5012

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
This one definitely needs to be reviewed carefully, as I am afraid this change might introduce null errors in some cases, but I am not sure when or why. For now, it looks like everything is working correctly.
