### PR TITLE
Refactor MapDownload PR02 (Initial tab titles)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -58,6 +58,13 @@ import org.triplea.swing.jpanel.JPanelBuilder;
 /** Window that allows for map downloads and removal. */
 @Slf4j
 public class DownloadMapsWindow extends JFrame {
+
+  private final JTabbedPane tabbedPane;
+  private ManagedMapStore mapStore;
+  private JPanel availablePanel;
+  private JPanel outOfDatePanel = null;
+  private JPanel installedPanel = null;
+
   private enum MapAction {
     INSTALL,
     UPDATE,
@@ -111,11 +118,12 @@ public class DownloadMapsWindow extends JFrame {
 
     SwingComponents.addWindowClosingListener(this, progressPanel::cancel);
 
-    final Component outerTabs = newAvailableInstalledTabbedPanel(allDownloads, pendingDownloads);
+    tabbedPane = newAvailableInstalledTabbedPanel(allDownloads, pendingDownloads);
+    updateTabTitles();
 
     final JSplitPane splitPane =
         new JSplitPane(
-            JSplitPane.VERTICAL_SPLIT, outerTabs, SwingComponents.newJScrollPane(progressPanel));
+            JSplitPane.VERTICAL_SPLIT, tabbedPane, SwingComponents.newJScrollPane(progressPanel));
     splitPane.setDividerLocation(DIVIDER_POSITION);
     add(splitPane);
   }
@@ -265,6 +273,7 @@ public class DownloadMapsWindow extends JFrame {
   private JTabbedPane newAvailableInstalledTabbedPanel(
       final List<MapDownloadItem> downloads, final Set<MapDownloadItem> pendingDownloads) {
     final DownloadMapsWindowMapsListing mapList = new DownloadMapsWindowMapsListing(downloads);
+    this.mapStore = mapList.getMapStore();
 
     final JTabbedPane tabbedPane = new JTabbedPane();
 
@@ -273,26 +282,46 @@ public class DownloadMapsWindow extends JFrame {
     final List<MapDownloadItem> outOfDateDownloads =
         mapList.getOutOfDateExcluding(pendingDownloads);
     // For the UX, always show an available maps tab, even if it is empty
-    final JPanel available = newMapSelectionPanel(availableDownloads, MapAction.INSTALL, true);
-    tabbedPane.addTab(String.format("New Maps (%d)", availableDownloads.size()), available);
+    availablePanel = newMapSelectionPanel(availableDownloads, MapAction.INSTALL, true);
+    tabbedPane.addTab("", availablePanel);
 
     if (!outOfDateDownloads.isEmpty()) {
-      final JPanel outOfDate = newMapSelectionPanel(outOfDateDownloads, MapAction.UPDATE, false);
-      tabbedPane.addTab(
-          String.format("Updates Available (%d)", outOfDateDownloads.size()), outOfDate);
+      outOfDatePanel = newMapSelectionPanel(outOfDateDownloads, MapAction.UPDATE, false);
+      tabbedPane.addTab("", outOfDatePanel);
     }
 
     if (!mapList.getInstalled().isEmpty()) {
-      final JPanel installed =
+      installedPanel =
           newMapSelectionPanel(
               mapList.getInstalled().keySet().stream()
                   .sorted(Comparator.comparing(m -> m.getMapName().toUpperCase(Locale.ENGLISH)))
                   .toList(),
               MapAction.REMOVE,
               false);
-      tabbedPane.addTab(String.format("Installed (%d)", mapList.getInstalled().size()), installed);
+      tabbedPane.addTab("", installedPanel);
     }
     return tabbedPane;
+  }
+
+  private void updateTabTitles() {
+    setTabTitle(
+        availablePanel,
+        String.format("New Maps (%d)", mapStore.getCountByStatus(ManagedMapStatus.AVAILABLE)));
+    setTabTitle(
+        outOfDatePanel,
+        String.format(
+            "Updates Available (%d)",
+            mapStore.getCountByStatus(ManagedMapStatus.UPDATE_AVAILABLE)));
+    setTabTitle(
+        installedPanel,
+        String.format("Installed (%d)", mapStore.getCountByStatus(ManagedMapStatus.INSTALLED)));
+  }
+
+  private void setTabTitle(Component tab, String title) {
+    int index = tabbedPane.indexOfComponent(tab);
+    if (index != -1) {
+      tabbedPane.setTitleAt(index, title);
+    }
   }
 
   private JPanel newMapSelectionPanel(

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ManagedMapStore.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ManagedMapStore.java
@@ -6,10 +6,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.Getter;
 import org.triplea.http.client.lobby.maps.listing.MapDownloadItem;
 
@@ -22,6 +25,8 @@ enum StoreState {
 final class ManagedMapStore {
 
   private final Map<String, ManagedMap> mapsByName = new HashMap<>();
+  private final Map<ManagedMapStatus, Set<ManagedMap>> groupsByStatus =
+      new EnumMap<>(ManagedMapStatus.class);
   @Getter private StoreState storeState;
 
   ManagedMapStore() {
@@ -31,6 +36,9 @@ final class ManagedMapStore {
   public void initialize(
       Collection<MapDownloadItem> downloads, InstalledMapsListing installedMapsListing) {
     storeState = StoreState.INITIALIZING;
+    for (ManagedMapStatus mapStatus : ManagedMapStatus.values()) {
+      groupsByStatus.put(mapStatus, new HashSet<>());
+    }
     downloads.forEach(
         downloadItem -> {
           Optional<InstalledMap> installedMapByName =
@@ -63,6 +71,7 @@ final class ManagedMapStore {
 
   void put(final ManagedMap map) {
     mapsByName.put(map.getMapName(), map);
+    groupsByStatus.get(map.getMapStatus()).add(map);
   }
 
   void remove(final String mapName) {
@@ -85,6 +94,10 @@ final class ManagedMapStore {
         .filter(m -> m.getMapStatus() == status)
         .sorted(Comparator.comparing(ManagedMap::getMapName))
         .toList();
+  }
+
+  int getCountByStatus(final ManagedMapStatus status) {
+    return groupsByStatus.get(status).size();
   }
 
   int size() {


### PR DESCRIPTION
- Adds to downloadMapsWindwos tabbedPane, panels (availablePanel, outOfDatePanel, installedPanel) and the mapStore
- Sets tab titles through new method updateTabTitles

Before and after comparison shows no difference. (maybe loading time got better)
<img width="1182" height="638" alt="image" src="https://github.com/user-attachments/assets/e909aef2-3d04-429c-a6ee-1a5bacf13b6e" />
<img width="1081" height="554" alt="image" src="https://github.com/user-attachments/assets/311c1095-d347-44d0-ae97-8936a9c18ce6" />

