### PR TITLE
Remove redundant set of 'inHistory' in TripleAFrame

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -244,7 +244,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       SwingAction.of(
           "Show history",
           e -> {
-            if (inHistory.compareAndSet(false, true)) {
+            if (!inHistory.get()) {
               showHistory();
               dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
             }
@@ -1694,7 +1694,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
           showGame();
         }
       } else {
-        if (inHistory.compareAndSet(false, true)) {
+        if (!inHistory.get()) {
           showHistory();
         }
       }


### PR DESCRIPTION
Replaces the 'compareAndSet' operation on AtomicBoolean inHistory with a 'get'.

Setting is unnecessary as the method called in the if-block already sets inHistory.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
