### PR TITLE
Fix Easy AI only placing Chinese units in Himalayas

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -1053,8 +1053,12 @@ public class WeakAi extends AbstractAi {
     final boolean placementAnyTerritory = (ra != null && ra.getPlacementAnyTerritory());
     final Optional<Territory> optionalCapitol =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
-    // place in capitol first
-    optionalCapitol.ifPresent(capitol -> placeAllWeCanOn(data, capitol, placeDelegate, player));
+    // place in capitol first, but not if it's impassable
+    optionalCapitol.ifPresent(capitol -> {
+      if (!Matches.territoryIsImpassable().test(capitol)) {
+        placeAllWeCanOn(data, capitol, placeDelegate, player);
+      }
+    });
     final List<Territory> randomTerritories = new ArrayList<>(data.getMap().getTerritories());
     Collections.shuffle(randomTerritories);
     final @Nullable Territory capitol = optionalCapitol.orElse(null);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -1054,11 +1054,9 @@ public class WeakAi extends AbstractAi {
     final Optional<Territory> optionalCapitol =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     // place in capitol first, but not if it's impassable
-    optionalCapitol.ifPresent(capitol -> {
-      if (!Matches.territoryIsImpassable().test(capitol)) {
-        placeAllWeCanOn(data, capitol, placeDelegate, player);
-      }
-    });
+    optionalCapitol
+        .filter(Matches.territoryIsImpassable().negate())
+        .ifPresent(capitol -> placeAllWeCanOn(data, capitol, placeDelegate, player));
     final List<Territory> randomTerritories = new ArrayList<>(data.getMap().getTerritories());
     Collections.shuffle(randomTerritories);
     final @Nullable Territory capitol = optionalCapitol.orElse(null);


### PR DESCRIPTION
In World War II Global 1940 2nd edition, if the Chinese are set to Easy AI, the only territory they will place their units in are the impassable Himalayas. This is because the current code forces the AI to place in their capital, if any. In case of China, these are the Himalayas.

The problem is that this territory is impassable in this game, making this location useless for placing units. This adds a check if the capital is impassable. If it is, don't place the units in the capital, and try to place it a non-capital territory instead.

Fixes: https://github.com/triplea-game/triplea/issues/6683

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer