### PR TITLE
CICD: remove release version label from headless docker image

### DIFF
--- a/.github/workflows/build-headless-docker.yml
+++ b/.github/workflows/build-headless-docker.yml
@@ -29,10 +29,8 @@ jobs:
         if: ${{ env.IS_MAIN_BUILD }}
         run: |
           ./gradlew :game-headless:shadowJar
-          BUILD_VERSION=$(game-app/run/.build/get-build-version)
 
           docker build game-app/game-headless \
             --tag ghcr.io/triplea-game/bot:latest \
             --label gitSha="$(git rev-parse --short HEAD)" \
-            --label buildVersion="$BUILD_VERSION"
           docker push ghcr.io/triplea-game/bot:latest


### PR DESCRIPTION
Simplifies by removing a dependency on build versioning.
Meanwhile, we still have the Git SHA as a label, which
is the important part to have.
