### PR TITLE
CICD: update set-game-headed-build-number shell flags

### DIFF
--- a/game-app/run/.build/set-game-headed-build-number
+++ b/game-app/run/.build/set-game-headed-build-number
@@ -2,10 +2,9 @@
 
 # Overwrites the game-headed 'product.properties' file to have an updated build version
 
+set -e
 scriptDir=$(dirname "$0")
 buildVersion=$("$scriptDir"/get-build-version)
 productPropertiesFile=$(find "$scriptDir/../../" -path "*src/main/resources/META-INF/*" -name "product.properties" -type f)
 
-set -x
-
-echo "version = $buildVersion" > "$productPropertiesFile"
+echo "version = $buildVersion" | tee "$productPropertiesFile"


### PR DESCRIPTION
- Replace 'set -x' and output rediction with 'tee'
- Add a 'set -e' flag to halt on any errors
