### PR TITLE
Build config: re-order expand wildcard to be below java format

### DIFF
--- a/gradle/build-logic/triplea-java-library/src/main/kotlin/triplea-java-library.gradle.kts
+++ b/gradle/build-logic/triplea-java-library/src/main/kotlin/triplea-java-library.gradle.kts
@@ -26,8 +26,8 @@ spotless {
     }
 
     java {
-        expandWildcardImports()
         googleJavaFormat()
+        expandWildcardImports()
         removeUnusedImports()
         cleanthat()
             .sourceCompatibility("21")


### PR DESCRIPTION
Seems to resolve error:
> LINE_UNDEFINED expandwildcardimports(java.lang.IllegalStateException) There was a problem interacting with Java-Parser; maybe you set an incompatible version? (...)
