### PR TITLE
Convert jdk http client to okhttp

### DIFF
--- a/lib/websocket-client/AGENTS.md
+++ b/lib/websocket-client/AGENTS.md
@@ -1,9 +1,8 @@
 # lib/websocket-client
 
-WebSocket client library built on Java 11+ `java.net.http.WebSocket` (stdlib, not
-`org.java_websocket`). Provides `GenericWebSocketClient` for connecting to
-WebSocket servers with JSON message serialization via Gson and type-safe
-listener dispatch.
+WebSocket client library built on OkHttp (`okhttp3.WebSocket`). Provides
+`GenericWebSocketClient` for connecting to WebSocket servers with JSON message
+serialization via Gson and type-safe listener dispatch.
 
 ## Source Files
 
@@ -11,7 +10,7 @@ listener dispatch.
 |------|---------|
 | `GenericWebSocketClient` | Public facade implementing `WebSocket` and `WebSocketConnectionListener`. Routes messages to typed listeners, manages error propagation |
 | `WebSocket` | Public interface defining the client contract: connect, close, send, add listeners |
-| `WebSocketConnection` | Internal connection manager. Handles `java.net.http.HttpClient` WebSocket lifecycle, message queuing, keep-alive pings |
+| `WebSocketConnection` | Internal connection manager. Handles the OkHttp `WebSocket` lifecycle, message queuing, reconnect; relies on OkHttp's native ping interval for keep-alive |
 | `WebSocketConnectionListener` | Internal callback interface between `WebSocketConnection` and `GenericWebSocketClient` |
 | `MessageEnvelope` | Generic JSON envelope wrapping payload with a type ID for routing |
 | `WebSocketMessage` | Marker interface for transmissible message types. Single method: `toEnvelope()` |
@@ -35,15 +34,15 @@ client versions.
 ## Connection Lifecycle
 
 1. **Connect** — `GenericWebSocketClient.connect()` delegates to
-   `WebSocketConnection`, which creates an `HttpClient` WebSocket with 5-second
+   `WebSocketConnection`, which opens an OkHttp `WebSocket` with a 5-second
    connect timeout. On failure, retries once after 1-second sleep.
 
 2. **Message queuing** — Messages sent before `onOpen()` are queued in a
    synchronized list and flushed in order when the connection opens.
 
-3. **Keep-alive** — Ping sender starts on connection open. Sends pings every
-   10 seconds using a `ScheduledTimer`. Each ping retries up to 5 times with
-   3-second backoff via `Retriable`.
+3. **Keep-alive** — Handled natively by OkHttp via `pingInterval` (30s). If a
+   pong is not received the connection fails, which triggers a reconnect
+   loop.
 
 4. **Close (client-initiated)** — `close()` sends `NORMAL_CLOSURE` with reason
    `"Client disconnect."`. Triggers `connectionClosedListeners`.
@@ -61,36 +60,33 @@ client versions.
   thread-safe listener dispatch and registration.
 - `sendMessage()` and `onOpen()` synchronize on the `queuedMessages` list to
   prevent race conditions during connection setup.
-- Message callbacks arrive on the HTTP client's internal thread.
-- Ping sender runs on a separate scheduled timer thread.
+- Message callbacks arrive on OkHttp's internal reader thread.
+- Reconnect runs on a dedicated virtual thread (`websocket-reconnect-thread`).
 
 ## Conventions
 
 - **Lombok throughout** — `@Builder` on `GenericWebSocketClient` constructor,
   `@Synchronized` for concurrency, `@Slf4j` for logging, `@Value` on
   `MessageType`.
-- **Message fragments accumulated** — `onText()` collects `CharSequence`
-  fragments in a `StringBuilder` until `last=true`, then dispatches the
-  complete message.
+- **Whole-message delivery** — OkHttp reassembles frames and delivers each
+  complete text message once via `onMessage(String)`.
 - **Client vs. terminated distinction** — `connectionClosed` (client asked to
   disconnect) and `connectionTerminated` (server dropped connection) are
   separate listener lists with different signatures.
 
 ## Gotchas
 
-- Only one automatic retry on initial connection failure — no exponential
-  backoff or configurable retry policy.
-- Ping failure after 5 retries only logs a warning; disconnection is left to
-  the server's idle timeout.
-- `sendMessage()` silently catches and logs exceptions on `sendText()` — callers
-  won't see send failures.
-- The `errorHandler` receives both transport errors (WebSocket `onError`) and
-  application-level errors (`ServerErrorMessage`). There is no way to
-  distinguish them.
+- Only one automatic retry on *initial* connection failure (then `errorHandler`
+  fires). After an established connection drops, the reconnect loop retries
+  indefinitely with a fixed 5s back-off.
+- `sendMessage()` logs (does not throw) if OkHttp refuses to enqueue a message —
+  callers won't see send failures.
+- An unexpected transport failure (`onFailure`) drives the reconnect loop rather
+  than calling `handleError`; the `errorHandler` is reserved for initial-connect
+  failure and application-level errors (`ServerErrorMessage`).
 
 ## Build
 
 Published as a Maven artifact via `maven-publish`. Version from `JAR_VERSION`
-env var. Only local dependency: `:lib:java-extras` (provides `Interruptibles`,
-`Retriable`, `Timers`). Uses Java stdlib `java.net.http` for WebSocket — no
-external WebSocket library.
+env var. Local dependency: `:lib:java-extras` (provides `Interruptibles`).
+External dependency: OkHttp (`libs.okhttp`) for the WebSocket transport.

--- a/lib/websocket-client/build.gradle.kts
+++ b/lib/websocket-client/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation(rootProject.libs.okhttp)
     implementation(project(":java-extras"))
     implementation(project(":lobby-client-data"))
 }

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -3,18 +3,11 @@ package org.triplea.http.client.web.socket;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.WebSocket;
-import java.net.http.WebSocket.Listener;
-import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -22,10 +15,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
 import org.triplea.java.Interruptibles;
-import org.triplea.java.Retriable;
-import org.triplea.java.timer.ScheduledTimer;
-import org.triplea.java.timer.Timers;
 
 /**
  * Component to manage a websocket connection. Responsible for:
@@ -50,9 +45,18 @@ class WebSocketConnection {
    */
   @VisibleForTesting static final String SERVER_BAN_DISCONNECT_MESSAGE = "You have been banned";
 
+  /** Normal closure status code per RFC 6455. */
+  @VisibleForTesting static final int NORMAL_CLOSURE = 1000;
+
+  /** How often OkHttp sends keep-alive pings; the connection fails if no pong is received. */
+  private static final Duration PING_INTERVAL = Duration.ofSeconds(30);
+
   private static final long RECONNECT_BACKOFF_MILLIS = 5000;
 
   private WebSocketConnectionListener listener;
+
+  /** Invoked if the initial connection (including the single retry) fails. */
+  private Consumer<String> errorHandler;
 
   /**
    * If sending messages before a connection is opened, they will be queued. When the connection is
@@ -74,7 +78,7 @@ class WebSocketConnection {
   @Setter(
       value = AccessLevel.PACKAGE,
       onMethod_ = {@VisibleForTesting})
-  private HttpClient httpClient = HttpClient.newHttpClient();
+  private OkHttpClient httpClient = defaultHttpClient();
 
   private final URI serverUri;
 
@@ -82,63 +86,33 @@ class WebSocketConnection {
 
   @Nullable private Thread reconnectThread;
 
-  private WebSocket client;
+  private volatile WebSocket client;
+
+  /**
+   * Completed when the in-progress connect attempt opens, or completed exceptionally when it fails.
+   * Bridges OkHttp's async callbacks to the imperative connect/reconnect flow.
+   */
+  private volatile CompletableFuture<WebSocket> connectFuture;
 
   @Getter(
       value = AccessLevel.PACKAGE,
       onMethod_ = {@VisibleForTesting})
-  private final Listener internalListener = new InternalWebSocketListener();
-
-  @Getter(
-      value = AccessLevel.PACKAGE,
-      onMethod_ = {@VisibleForTesting})
-  private final ScheduledTimer pingSender;
+  private final WebSocketListener internalListener = new InternalWebSocketListener();
 
   WebSocketConnection(URI serverUri, Map<String, String> headers) {
     this.serverUri = serverUri;
-    pingSender =
-        Timers.fixedRateTimer("websocket-ping-sender")
-            .period(10, TimeUnit.SECONDS)
-            .delay(10, TimeUnit.SECONDS)
-            .task(this::sendPingTask);
     this.headers = headers;
   }
 
-  public boolean isOpen() {
-    return !(client.isInputClosed() && client.isOutputClosed());
+  private static OkHttpClient defaultHttpClient() {
+    return new OkHttpClient.Builder()
+        .connectTimeout(Duration.ofMillis(DEFAULT_CONNECT_TIMEOUT_MILLIS))
+        .pingInterval(PING_INTERVAL)
+        .build();
   }
 
-  /**
-   * Sends pings with retries. Retry threshold is set up to account for disconnect at 60 seconds. We
-   * send a ping every 45s, if that fails we'll try again at the 48s mark, again at 51s, again at
-   * 54s, and one last time at 57s.
-   */
-  private void sendPingTask() {
-    if (!client.isOutputClosed()) {
-
-      final Optional<Boolean> pingSuccess =
-          Retriable.<Boolean>builder()
-              .withMaxAttempts(5)
-              .withFixedBackOff(Duration.ofSeconds(3))
-              .withTask(
-                  () -> {
-                    try {
-                      client.sendPing(ByteBuffer.allocate(0)).get();
-                      return Optional.of(true);
-                    } catch (final ExecutionException | InterruptedException e) {
-                      return Optional.of(false);
-                    }
-                  })
-              .buildAndExecute();
-
-      if (pingSuccess.isEmpty()) {
-        log.warn(
-            "Failed to send pings to server, retries exhausted. "
-                + "If the server does not receive pings then the connection to "
-                + "the server will be disconnected. Expecting to be disconnected "
-                + "from the server soon");
-      }
-    }
+  public boolean isOpen() {
+    return client != null && connectionIsOpen;
   }
 
   /** Does an async close of the current websocket connection. */
@@ -149,14 +123,9 @@ class WebSocketConnection {
     }
     // Client can be null if the connection hasn't completely opened yet.
     // This null check prevents a potential NPE, which should rarely ever occur.
-    if (client != null && !client.isOutputClosed()) {
-      client
-          .sendClose(WebSocket.NORMAL_CLOSURE, CLIENT_DISCONNECT_MESSAGE)
-          .exceptionally(
-              e -> {
-                log.info("Failed to close websocket", e);
-                return null;
-              });
+    final WebSocket currentClient = client;
+    if (currentClient != null) {
+      currentClient.close(NORMAL_CLOSURE, CLIENT_DISCONNECT_MESSAGE);
     }
   }
 
@@ -169,42 +138,50 @@ class WebSocketConnection {
    */
   void connect(final WebSocketConnectionListener listener, final Consumer<String> errorHandler) {
     this.listener = Preconditions.checkNotNull(listener);
+    this.errorHandler = errorHandler;
     Preconditions.checkState(client == null);
     Preconditions.checkState(!closed);
 
-    connectAsyncAndStartPingSender()
+    attemptConnect()
         .exceptionally(
             throwable -> {
               // Do a single retry with fixed back-off
               log.info("Failed to connect, will retry", throwable);
               Interruptibles.sleep(1000);
-              retryConnection(errorHandler);
+              retryConnection();
               return null;
             });
   }
 
-  private CompletableFuture<WebSocket> connectAsync() {
-    var clientBuilder = httpClient.newWebSocketBuilder();
-    headers.forEach(clientBuilder::header);
-    return clientBuilder
-        .connectTimeout(Duration.ofMillis(DEFAULT_CONNECT_TIMEOUT_MILLIS))
-        .buildAsync(this.serverUri, internalListener);
-  }
-
-  private CompletableFuture<Void> connectAsyncAndStartPingSender() {
-    return connectAsync().thenRun(pingSender::start);
-  }
-
-  private void retryConnection(final Consumer<String> errorHandler) {
+  private void retryConnection() {
     connectionIsOpen = false;
-    httpClient = HttpClient.newHttpClient();
-    connectAsyncAndStartPingSender()
+    attemptConnect()
         .exceptionally(
             throwable -> {
               log.info("Failed to connect", throwable);
               errorHandler.accept("Failed to connect: " + throwable.getMessage());
               return null;
             });
+  }
+
+  /**
+   * Opens a new websocket. OkHttp's {@code newWebSocket} returns immediately; success or failure is
+   * delivered via {@link InternalWebSocketListener}, which completes the returned future.
+   */
+  private CompletableFuture<WebSocket> attemptConnect() {
+    final CompletableFuture<WebSocket> future = new CompletableFuture<>();
+    connectFuture = future;
+    httpClient.newWebSocket(buildConnectRequest(), internalListener);
+    return future;
+  }
+
+  private Request buildConnectRequest() {
+    // OkHttp connects over an http/https URL; serverUri uses ws/wss (set by
+    // WebSocketProtocolSwapper), so swap the scheme back: ws -> http, wss -> https.
+    final String httpUrl = serverUri.toString().replaceFirst("^ws", "http");
+    final Request.Builder requestBuilder = new Request.Builder().url(httpUrl);
+    headers.forEach(requestBuilder::addHeader);
+    return requestBuilder.build();
   }
 
   /**
@@ -229,9 +206,8 @@ class WebSocketConnection {
                   while (!Thread.currentThread().isInterrupted()) {
                     listener.onReconnecting(attempt++);
                     connectionIsOpen = false;
-                    httpClient = HttpClient.newHttpClient();
                     try {
-                      connectAsync()
+                      attemptConnect()
                           .get(DEFAULT_CONNECT_TIMEOUT_MILLIS * 2L, TimeUnit.MILLISECONDS);
                       log.info("Successfully reconnected on attempt {}", attempt - 1);
                       listener.reconnected();
@@ -268,83 +244,76 @@ class WebSocketConnection {
     synchronized (queuedMessages) {
       if (!connectionIsOpen) {
         queuedMessages.add(message);
-      } else {
-        client
-            .sendText(message, true)
-            .exceptionally(
-                e -> {
-                  log.error("Failed to send text", e);
-                  return null;
-                });
+      } else if (!client.send(message)) {
+        log.error("Failed to send text, message dropped (connection closing or send buffer full)");
       }
     }
   }
 
   @VisibleForTesting
-  class InternalWebSocketListener implements Listener {
-    private final StringBuilder textAccumulator = new StringBuilder();
+  class InternalWebSocketListener extends WebSocketListener {
 
     @Override
-    public void onOpen(final WebSocket webSocket) {
+    public void onOpen(final WebSocket webSocket, final Response response) {
       synchronized (queuedMessages) {
         client = webSocket;
         connectionIsOpen = true;
-        queuedMessages.forEach(
-            message ->
-                client
-                    .sendText(message, true)
-                    .exceptionally(
-                        e -> {
-                          log.error("Failed to send queued text.", e);
-                          return null;
-                        }));
+        queuedMessages.forEach(webSocket::send);
         queuedMessages.clear();
       }
-      // Allow onText to be called at least once, WebSocketConnection is initialized
-      webSocket.request(1);
-    }
-
-    @Override
-    public @Nullable CompletionStage<?> onText(
-        final WebSocket webSocket, final CharSequence data, final boolean last) {
-      // No need to synchronize access, this listener is never called concurrently
-      // and always called in-order by the API
-      textAccumulator.append(data);
-      if (last) {
-        listener.messageReceived(textAccumulator.toString());
-        textAccumulator.setLength(0);
+      final CompletableFuture<WebSocket> future = connectFuture;
+      if (future != null) {
+        future.complete(webSocket);
       }
-      // We're done processing, allow listener to be called again at least once
-      webSocket.request(1);
-      return null;
     }
 
     @Override
-    public @Nullable CompletionStage<?> onClose(
-        final WebSocket webSocket, final int statusCode, final String reason) {
+    public void onMessage(final WebSocket webSocket, final String text) {
+      // OkHttp reassembles fragments and delivers each complete message once, in order, on a
+      // single reader thread, so no accumulation or synchronization is needed here.
+      listener.messageReceived(text);
+    }
+
+    @Override
+    public void onClosing(final WebSocket webSocket, final int code, final String reason) {
+      // The server initiated the close handshake; complete it so the socket shuts down cleanly.
+      // The reason-based handling happens in onClosed.
+      webSocket.close(NORMAL_CLOSURE, null);
+    }
+
+    @Override
+    public void onClosed(final WebSocket webSocket, final int code, final String reason) {
+      connectionIsOpen = false;
       log.info("Connection closed, reason: '{}'", reason);
 
-      if (closed || reason.equals(WebSocketConnection.CLIENT_DISCONNECT_MESSAGE)) {
-        pingSender.cancel();
+      if (closed || reason.equals(CLIENT_DISCONNECT_MESSAGE)) {
         listener.connectionClosed();
-        return null;
+        return;
       }
 
       if (reason.equals(SERVER_BAN_DISCONNECT_MESSAGE)) {
         log.info("Connection terminated by server (ban): {}", reason);
-        pingSender.cancel();
         listener.connectionTerminated(reason);
-        return null;
+        return;
       }
 
       log.info("Unexpected disconnect, attempting to reconnect...");
       reconnectAsync();
-      return null;
     }
 
     @Override
-    public void onError(final WebSocket webSocket, final Throwable error) {
-      listener.handleError(error);
+    public void onFailure(
+        final WebSocket webSocket, final Throwable t, @Nullable final Response response) {
+      connectionIsOpen = false;
+      final CompletableFuture<WebSocket> future = connectFuture;
+      if (future != null && !future.isDone()) {
+        // A connect/reconnect attempt failed; whoever awaits this future decides whether to retry.
+        future.completeExceptionally(t);
+      } else if (!closed) {
+        // An established connection dropped unexpectedly.
+        log.info("Websocket connection failed, attempting to reconnect...", t);
+        reconnectAsync();
+      }
     }
   }
 }

--- a/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -1,9 +1,6 @@
 package org.triplea.http.client.web.socket;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,12 +11,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.WebSocket;
-import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
 import org.jetbrains.annotations.NonNls;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,81 +34,68 @@ class WebSocketConnectionTest {
   private static final String MESSAGE = "message";
   private static final String REASON = "reason";
 
-  private static final Exception exception = new Exception();
+  private static final Throwable failure = new Exception();
 
   @ExtendWith(MockitoExtension.class)
   @Nested
   class WebSocketClientCallbacks {
     @Mock private WebSocketConnectionListener webSocketConnectionListener;
     private WebSocketConnection webSocketConnection;
-    private WebSocket.Listener listener;
+    private WebSocketListener listener;
 
     @BeforeEach
     void setUp() {
       webSocketConnection = new WebSocketConnection(INVALID_URI, Map.of());
+      // Inject a mock client so connect() does no real network I/O; the connect attempt's future
+      // stays pending and the tests drive the listener callbacks deterministically.
+      webSocketConnection.setHttpClient(mock(OkHttpClient.class));
       webSocketConnection.connect(webSocketConnectionListener, err -> {});
       listener = webSocketConnection.getInternalListener();
     }
 
     @AfterEach
     void tearDown() {
-      webSocketConnection.getPingSender().cancel();
+      // Interrupts any reconnect thread that a test may have started.
+      webSocketConnection.close();
     }
 
     @Test
     void onMessage() {
-      listener.onText(mock(WebSocket.class), MESSAGE, true);
+      listener.onMessage(mock(WebSocket.class), MESSAGE);
       verify(webSocketConnectionListener).messageReceived(MESSAGE);
     }
 
     @Test
-    void verifyListenerAccumulatesMessagesUntilLast() {
-      listener.onText(mock(WebSocket.class), "1", false);
-      listener.onText(mock(WebSocket.class), "2", false);
-      listener.onText(mock(WebSocket.class), "3", true);
-
-      verify(webSocketConnectionListener).messageReceived("123");
-    }
-
-    @Test
-    void verifyListenerClearsMessageCorrectly() {
-      listener.onText(mock(WebSocket.class), "1", false);
-      listener.onText(mock(WebSocket.class), "2", false);
-      listener.onText(mock(WebSocket.class), "3", true);
-      listener.onText(mock(WebSocket.class), "4", false);
-      listener.onText(mock(WebSocket.class), "5", true);
-
-      verify(webSocketConnectionListener).messageReceived("123");
-      verify(webSocketConnectionListener).messageReceived("45");
-    }
-
-    @Test
     void onCloseDueToClientDisconnect() {
-      listener.onClose(mock(WebSocket.class), 0, WebSocketConnection.CLIENT_DISCONNECT_MESSAGE);
+      listener.onClosed(mock(WebSocket.class), 0, WebSocketConnection.CLIENT_DISCONNECT_MESSAGE);
       verify(webSocketConnectionListener).connectionClosed();
     }
 
     @Test
     void onCloseDueToUnexpectedDisconnect() {
-      listener.onClose(mock(WebSocket.class), 0, REASON);
+      listener.onClosed(mock(WebSocket.class), 0, REASON);
       // Reconnect is attempted asynchronously on a virtual thread; onReconnecting fires first
       verify(webSocketConnectionListener, timeout(2000)).onReconnecting(1);
       verify(webSocketConnectionListener, never()).connectionTerminated(any());
     }
 
     @Test
-    @DisplayName("Server ban causes connectionTerminated, not a reconnect attempt")
-    void onCloseDueToServerBan() {
-      listener.onClose(mock(WebSocket.class), 0, WebSocketConnection.SERVER_BAN_DISCONNECT_MESSAGE);
-      verify(webSocketConnectionListener)
-          .connectionTerminated(WebSocketConnection.SERVER_BAN_DISCONNECT_MESSAGE);
-      verify(webSocketConnectionListener, never()).onReconnecting(anyInt());
+    @DisplayName("Transport failure on an open connection triggers a reconnect")
+    void onFailureDueToUnexpectedDisconnect() {
+      // Mark the in-progress connect attempt as opened so the failure is treated as a drop.
+      listener.onOpen(mock(WebSocket.class), null);
+      listener.onFailure(mock(WebSocket.class), failure, null);
+      verify(webSocketConnectionListener, timeout(2000)).onReconnecting(1);
     }
 
     @Test
-    void onError() {
-      listener.onError(mock(WebSocket.class), exception);
-      verify(webSocketConnectionListener).handleError(exception);
+    @DisplayName("Server ban causes connectionTerminated, not a reconnect attempt")
+    void onCloseDueToServerBan() {
+      listener.onClosed(
+          mock(WebSocket.class), 0, WebSocketConnection.SERVER_BAN_DISCONNECT_MESSAGE);
+      verify(webSocketConnectionListener)
+          .connectionTerminated(WebSocketConnection.SERVER_BAN_DISCONNECT_MESSAGE);
+      verify(webSocketConnectionListener, never()).onReconnecting(anyInt());
     }
 
     @Test
@@ -120,18 +104,17 @@ class WebSocketConnectionTest {
       final WebSocket mockedWebSocket = mockWebSocket();
       // not connected, this message should be queued
       webSocketConnection.sendMessage(MESSAGE);
-      verify(mockedWebSocket, never()).sendText(any(), anyBoolean());
+      verify(mockedWebSocket, never()).send(anyString());
 
       // onOpen should trigger message send
-      listener.onOpen(mockedWebSocket);
+      listener.onOpen(mockedWebSocket, null);
 
-      verify(mockedWebSocket).sendText(any(), anyBoolean());
+      verify(mockedWebSocket).send(MESSAGE);
     }
 
     private WebSocket mockWebSocket() {
       final WebSocket mockedWebSocket = mock(WebSocket.class);
-      when(mockedWebSocket.sendText(any(), anyBoolean()))
-          .thenReturn(CompletableFuture.completedFuture(null));
+      when(mockedWebSocket.send(anyString())).thenReturn(true);
       return mockedWebSocket;
     }
   }
@@ -150,73 +133,47 @@ class WebSocketConnectionTest {
       webSocketConnection = new WebSocketConnection(INVALID_URI, Map.of());
     }
 
-    private void requiresSendTextAction() {
-      when(webSocket.sendText(any(), anyBoolean()))
-          .thenReturn(CompletableFuture.completedFuture(null));
-    }
-
     @AfterEach
     void tearDown() {
-      webSocketConnection.getPingSender().cancel();
+      webSocketConnection.close();
     }
 
     @Nested
     class WithMockedHttpClient {
 
-      @Mock private HttpClient httpClient;
-
-      @BeforeEach
-      void setUp() {
-        final WebSocket.Builder builder = mock(WebSocket.Builder.class);
-        when(builder.connectTimeout(any())).thenReturn(builder);
-
-        when(builder.buildAsync(any(), any()))
-            .thenReturn(CompletableFuture.completedFuture(webSocket));
-
-        when(httpClient.newWebSocketBuilder()).thenReturn(builder);
-      }
+      @Mock private OkHttpClient httpClient;
 
       @Test
-      @DisplayName("Verify connect initiates connection and starts the pinger")
+      @DisplayName("Verify connect initiates a websocket connection")
       void connectWillInitiateConnection() {
         webSocketConnection.setHttpClient(httpClient);
         webSocketConnection.connect(webSocketConnectionListener, errorHandler);
 
-        verify(httpClient.newWebSocketBuilder())
-            .connectTimeout(Duration.ofMillis(WebSocketConnection.DEFAULT_CONNECT_TIMEOUT_MILLIS));
-        verifyPingerIsStarted();
+        verify(httpClient)
+            .newWebSocket(any(Request.class), eq(webSocketConnection.getInternalListener()));
       }
     }
 
-    private void verifyPingerIsStarted() {
-      assertThat(
-          "Pinger should be started on successful connection",
-          webSocketConnection.getPingSender().isRunning(),
-          is(true));
-    }
-
     @Test
-    @DisplayName("Close will close the underlying socket and stops the pinger")
+    @DisplayName("Close will close the underlying socket")
     void close() {
-      webSocketConnection.getInternalListener().onOpen(webSocket);
-      when(webSocket.sendClose(anyInt(), any()))
-          .thenReturn(CompletableFuture.completedFuture(null));
+      webSocketConnection.getInternalListener().onOpen(webSocket, null);
+      when(webSocket.close(anyInt(), any())).thenReturn(true);
       webSocketConnection.close();
 
-      verify(webSocket).sendClose(eq(WebSocket.NORMAL_CLOSURE), any());
-      assertThat(webSocketConnection.getPingSender().isRunning(), is(false));
+      verify(webSocket).close(eq(WebSocketConnection.NORMAL_CLOSURE), any());
     }
 
     @Test
     @DisplayName("Send will send messages if connection is open")
     void sendMessage() {
-      requiresSendTextAction();
-      webSocketConnection.getInternalListener().onOpen(webSocket);
+      when(webSocket.send(anyString())).thenReturn(true);
+      webSocketConnection.getInternalListener().onOpen(webSocket, null);
       webSocketConnection.setConnectionIsOpen(true);
 
       webSocketConnection.sendMessage(MESSAGE);
 
-      verify(webSocket).sendText(MESSAGE, true);
+      verify(webSocket).send(MESSAGE);
     }
 
     @Test
@@ -224,7 +181,7 @@ class WebSocketConnectionTest {
     void sendMessageWillQueueMessagesIfConnectionIsNotOpen() {
       webSocketConnection.sendMessage(MESSAGE);
 
-      verify(webSocket, never()).sendText(anyString(), anyBoolean());
+      verify(webSocket, never()).send(anyString());
     }
   }
 }


### PR DESCRIPTION
JDKs http client is broken if it can't find a local IP
address, which can happen on windows machines behind
specific network configs (like a VPN or something like that...)

This update replaces the JDKs http client in our websocket
connection client to instead use OkHttp instead
