### PR TITLE
Update dice roller fallback URI

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/DiceServerEditor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/DiceServerEditor.java
@@ -26,7 +26,7 @@ import org.triplea.swing.SwingComponents;
 
 /** A class to configure a Dice Server for the game. */
 public class DiceServerEditor extends JPanel {
-  public static final URI PRODUCTION_URI = URI.create("https://dice.marti.triplea-game.org");
+  public static final URI PRODUCTION_URI = URI.create("https://dice.triplea-game.org");
 
   private static final long serialVersionUID = -451810815037661114L;
   public static final int ADDRESS_FIELD_MAX_LENGTH = 1019;


### PR DESCRIPTION
If no custom dice roller URI is set, then we use a fallback.
This updates the fallback to use the new 'dice.triplea-game.org'
server instead of 'dice.marti.triplea-game.org'
