### PR TITLE
Ensure no error message is thrown when no first enemy found

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AttackerAndDefenderSelector.java
@@ -95,9 +95,7 @@ public class AttackerAndDefenderSelector {
       final Collection<Unit> units = territory.getUnits();
       if (!units.isEmpty()
           && units.stream().map(Unit::getOwner).allMatch(Matches.isAllied(currentPlayer))) {
-        return ProUtils.getEnemyPlayersInTurnOrder(currentPlayer).stream()
-            .findFirst()
-            .orElseThrow();
+        return ProUtils.getEnemyPlayersInTurnOrder(currentPlayer).stream().findFirst().orElse(null);
       }
     }
     return currentPlayer;


### PR DESCRIPTION
When pressing ctrl+B in a territory with only friendly units, the game will assign the first enemy player in turn order it finds as the attacker. If no such player is found, the game throws an error message. Instead, it is better to return null, as null is also a viable return statement. This makes the game continue and not crash.

Fixes: https://github.com/triplea-game/triplea/issues/14609

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
