### PR TITLE
Fix map reloading when a technology is added

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -127,6 +127,8 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new BooleanClientSetting("SHOW_BETA_FEATURES");
   public static final ClientSetting<Boolean> useWebsocketNetwork =
       new BooleanClientSetting("USE_WEBSOCKET_NETWORK");
+  public static final ClientSetting<Boolean> doNotRedrawMap =
+      new BooleanClientSetting("DO_NOT_REDRAW_MAP");
   public static final ClientSetting<Boolean> showSerializeFeatures =
       new BooleanClientSetting("SHOW_SERIALIZE_FEATURES");
   public static final BooleanClientSetting showChatTimeSettings =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -277,6 +277,16 @@ All players in the same game must have it set to the same value. Restart to full
     }
   },
 
+  DO_NOT_REDRAW_MAP(
+      "Do Not Redraw Map",
+      SettingType.TESTING,
+      "Toggles whether to completely redraw the map when a technology is discovered. Default is fully redraw. No redraw makes the \"flash\" you see disappear when a tech is added.") {
+    @Override
+    public SelectionComponent<JComponent> newSelectionComponent() {
+      return booleanRadioButtons(ClientSetting.doNotRedrawMap);
+    }
+  },
+
   LOBBY_URI_OVERRIDE_BINDING("Lobby URI Override", SettingType.TESTING, "Overrides the lobby URI") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -147,11 +147,7 @@ public class MapPanel extends ImageScrollerLargeView {
                   .getUnitIconProperties()
                   .testIfConditionsHaveChanged(gameData)) {
             tileManager.resetTiles(gameData, uiContext.getMapData());
-            SwingUtilities.invokeLater(
-                () -> {
-                  recreateTiles(gameData, uiContext);
-                  repaint();
-                });
+            SwingUtilities.invokeLater(() -> repaint());
           }
         }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -147,7 +147,7 @@ public class MapPanel extends ImageScrollerLargeView {
                   .getUnitIconProperties()
                   .testIfConditionsHaveChanged(gameData)) {
             tileManager.resetTiles(gameData, uiContext.getMapData());
-            SwingUtilities.invokeLater(() -> repaint());
+            SwingUtilities.invokeLater(MapPanel.this::repaint);
           }
         }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -147,7 +147,15 @@ public class MapPanel extends ImageScrollerLargeView {
                   .getUnitIconProperties()
                   .testIfConditionsHaveChanged(gameData)) {
             tileManager.resetTiles(gameData, uiContext.getMapData());
-            SwingUtilities.invokeLater(MapPanel.this::repaint);
+            if (ClientSetting.doNotRedrawMap.getValue().orElse(false)) {
+              SwingUtilities.invokeLater(MapPanel.this::repaint);
+            } else {
+              SwingUtilities.invokeLater(
+                  () -> {
+                    recreateTiles(gameData, uiContext);
+                    repaint();
+                  });
+            }
           }
         }
 


### PR DESCRIPTION
When adding a technology using edit mode, or obtaining a tech normally, or when navigating through the game history and passing a point where a tech has been added with or without edit mode, the map will reload . On fast machines, this takes a fraction of a second. On slow machines, this might take longer. In either case, it's definitely noticeable. This was caused by recreateTiles()

This PR removes that, making sure the map does not get redrawn entirely. Any changes should still be reflected on the map.

Fixes: https://github.com/triplea-game/triplea/issues/4062
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
Please check if this does not cause other bugs. I tested a couple of cases, but I don't know for sure if it's safe to just remove this line. At least it fixes the annoying map reload.