### PR TITLE
Download maps window: remove abort if maps list is empty

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -603,11 +603,7 @@ public class DownloadMapsWindow extends JFrame {
           .result
           .ifPresent(
               downloadMapsWindowModel -> {
-                if (downloadMapsWindowModel.getMapStore().isEmpty()) {
-                  return; // no maps to show, so we can leave
-                }
                 state = State.INITIALIZING;
-
                 createAndShow(mapNamesToDownload, downloadMapsWindowModel);
               });
     }


### PR DESCRIPTION
Updates behavior to still show the download maps window
even if the maps list is empty. Previously the maps
window was aborted and it made it look like the game
encountered some sort of error as clicking the 'download
maps' button opened a progress dialog to download maps
and then closed and did nothing else. Showing a download
maps window with no maps to download is better, as it makes
it more obvious the issue is the empty map list rather than
there appearing to be some sort of UI glitch.
