### PR TITLE
Fix technology unit images when navigating history

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -577,7 +577,7 @@ public class GameData implements Serializable, GameState {
       change.perform(this);
     }
     dataChangeListeners.forEach(listener -> listener.gameDataChanged(change));
-    GameDataEvent.lookupEvents(change).forEach(this::fireGameDataEvent);
+    GameDataEvent.lookupGameDataChangeEvents(change).forEach(this::fireGameDataEvent);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -577,7 +577,7 @@ public class GameData implements Serializable, GameState {
       change.perform(this);
     }
     dataChangeListeners.forEach(listener -> listener.gameDataChanged(change));
-    GameDataEvent.lookupEvent(change).ifPresent(this::fireGameDataEvent);
+    GameDataEvent.lookupEvents(change).forEach(this::fireGameDataEvent);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameDataEvent.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameDataEvent.java
@@ -12,7 +12,7 @@ public enum GameDataEvent {
   TECH_ATTACHMENT_CHANGED;
 
   /** Returns all game data events represented by a change, including nested composite changes. */
-  static Set<GameDataEvent> lookupEvents(final Change change) {
+  static Set<GameDataEvent> lookupGameDataChangeEvents(final Change change) {
     final Set<GameDataEvent> events = EnumSet.noneOf(GameDataEvent.class);
     if (hasMoveChange(change)) {
       events.add(UNIT_MOVED);
@@ -27,7 +27,7 @@ public enum GameDataEvent {
    * Recursively checks if the change is or contains a 'ALREADY_MOVED' change action. This indicates
    * a unit has moved.
    */
-  static boolean hasMoveChange(final Change change) {
+  private static boolean hasMoveChange(final Change change) {
     if (change instanceof CompositeChange compositeChange) {
       final boolean hasMoveChange =
           compositeChange.getChanges().stream().anyMatch(GameDataEvent::hasMoveChange);

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameDataEvent.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameDataEvent.java
@@ -2,7 +2,8 @@ package games.strategy.engine.data;
 
 import games.strategy.engine.data.changefactory.ObjectPropertyChange;
 import games.strategy.triplea.Constants;
-import java.util.Optional;
+import java.util.EnumSet;
+import java.util.Set;
 
 /** Enum that represents various possible game data change events. */
 public enum GameDataEvent {
@@ -10,20 +11,16 @@ public enum GameDataEvent {
   GAME_STEP_CHANGED,
   TECH_ATTACHMENT_CHANGED;
 
-  /**
-   * Converts a 'Change' object to a 'GameDataEvent' object, returns empty if the change object does
-   * not correspond to any 'GameDataEvent'.
-   */
-  static Optional<GameDataEvent> lookupEvent(final Change change) {
+  /** Returns all game data events represented by a change, including nested composite changes. */
+  static Set<GameDataEvent> lookupEvents(final Change change) {
+    final Set<GameDataEvent> events = EnumSet.noneOf(GameDataEvent.class);
     if (hasMoveChange(change)) {
-      return Optional.of(UNIT_MOVED);
+      events.add(UNIT_MOVED);
     }
-    if (change instanceof ChangeAttachmentChange attachmentChange
-        && attachmentChange.getAttachmentName().equals(Constants.TECH_ATTACHMENT_NAME)) {
-      return Optional.of(TECH_ATTACHMENT_CHANGED);
+    if (hasTechAttachmentChange(change)) {
+      events.add(TECH_ATTACHMENT_CHANGED);
     }
-
-    return Optional.empty();
+    return events;
   }
 
   /**
@@ -40,5 +37,14 @@ public enum GameDataEvent {
     }
     return (change instanceof ObjectPropertyChange objectPropertyChange
         && objectPropertyChange.getProperty().equals(Unit.PropertyName.ALREADY_MOVED.toString()));
+  }
+
+  /** Recursively checks if the change contains an update to a technology attachment. */
+  static boolean hasTechAttachmentChange(final Change change) {
+    if (change instanceof CompositeChange compositeChange) {
+      return compositeChange.getChanges().stream().anyMatch(GameDataEvent::hasTechAttachmentChange);
+    }
+    return change instanceof ChangeAttachmentChange attachmentChange
+        && Constants.TECH_ATTACHMENT_NAME.equals(attachmentChange.getAttachmentName());
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/GameDataEventTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/GameDataEventTest.java
@@ -1,0 +1,45 @@
+package games.strategy.engine.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.changefactory.ObjectPropertyChange;
+import games.strategy.triplea.Constants;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class GameDataEventTest {
+
+  @Test
+  void findsTechnologyAttachmentChangeInsideNestedCompositeChange() {
+    final ChangeAttachmentChange attachmentChange = mock(ChangeAttachmentChange.class);
+    when(attachmentChange.getAttachmentName()).thenReturn(Constants.TECH_ATTACHMENT_NAME);
+    final Change change =
+        new CompositeChange(new CompositeChange(new CompositeChange(attachmentChange)));
+
+    assertThat(
+        GameDataEvent.lookupEvents(change), is(Set.of(GameDataEvent.TECH_ATTACHMENT_CHANGED)));
+  }
+
+  @Test
+  void ignoresOtherAttachmentChangeInsideCompositeChange() {
+    final ChangeAttachmentChange attachmentChange = mock(ChangeAttachmentChange.class);
+    when(attachmentChange.getAttachmentName()).thenReturn("otherAttachment");
+
+    assertThat(GameDataEvent.lookupEvents(new CompositeChange(attachmentChange)), is(Set.of()));
+  }
+
+  @Test
+  void findsAllEventsInsideCompositeChange() {
+    final ChangeAttachmentChange attachmentChange = mock(ChangeAttachmentChange.class);
+    when(attachmentChange.getAttachmentName()).thenReturn(Constants.TECH_ATTACHMENT_NAME);
+    final ObjectPropertyChange moveChange = mock(ObjectPropertyChange.class);
+    when(moveChange.getProperty()).thenReturn(Unit.PropertyName.ALREADY_MOVED.toString());
+
+    assertThat(
+        GameDataEvent.lookupEvents(new CompositeChange(moveChange, attachmentChange)),
+        is(Set.of(GameDataEvent.UNIT_MOVED, GameDataEvent.TECH_ATTACHMENT_CHANGED)));
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/GameDataEventTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/GameDataEventTest.java
@@ -20,7 +20,8 @@ class GameDataEventTest {
         new CompositeChange(new CompositeChange(new CompositeChange(attachmentChange)));
 
     assertThat(
-        GameDataEvent.lookupEvents(change), is(Set.of(GameDataEvent.TECH_ATTACHMENT_CHANGED)));
+        GameDataEvent.lookupGameDataChangeEvents(change),
+        is(Set.of(GameDataEvent.TECH_ATTACHMENT_CHANGED)));
   }
 
   @Test
@@ -28,18 +29,20 @@ class GameDataEventTest {
     final ChangeAttachmentChange attachmentChange = mock(ChangeAttachmentChange.class);
     when(attachmentChange.getAttachmentName()).thenReturn("otherAttachment");
 
-    assertThat(GameDataEvent.lookupEvents(new CompositeChange(attachmentChange)), is(Set.of()));
+    assertThat(
+        GameDataEvent.lookupGameDataChangeEvents(new CompositeChange(attachmentChange)),
+        is(Set.of()));
   }
 
   @Test
-  void findsAllEventsInsideCompositeChange() {
+  void findsAllGameDataChangeEventsInsideCompositeChange() {
     final ChangeAttachmentChange attachmentChange = mock(ChangeAttachmentChange.class);
     when(attachmentChange.getAttachmentName()).thenReturn(Constants.TECH_ATTACHMENT_NAME);
     final ObjectPropertyChange moveChange = mock(ObjectPropertyChange.class);
     when(moveChange.getProperty()).thenReturn(Unit.PropertyName.ALREADY_MOVED.toString());
 
     assertThat(
-        GameDataEvent.lookupEvents(new CompositeChange(moveChange, attachmentChange)),
+        GameDataEvent.lookupGameDataChangeEvents(new CompositeChange(moveChange, attachmentChange)),
         is(Set.of(GameDataEvent.UNIT_MOVED, GameDataEvent.TECH_ATTACHMENT_CHANGED)));
   }
 }


### PR DESCRIPTION
## Notes to Reviewer

I updated game-data event detection so composite history changes emit every matching event, including nested technology attachment changes. This lets the existing unit-image cache listener refresh images when I navigate across a technology discovery in history, while preserving unit-movement notifications from the same composite change.

I added regression coverage for nested technology changes, unrelated attachment changes, and composites containing both movement and technology updates.

## Validation

- `./gradlew :game-core:test --tests games.strategy.engine.data.GameDataEventTest`
- `./verify --exclude-task spotlessApply`
- `git diff --check origin/main...HEAD`

I could not replay the attached save game through the desktop UI in this headless environment.

Fixes #14624
