### PR TITLE
Hide configured players from technology table

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TechnologyPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TechnologyPanel.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
@@ -206,7 +207,13 @@ class TechnologyPanel extends JPanel implements GameDataChangeListener {
     }
 
     private void initColList() {
-      final List<GamePlayer> players = gameData.getPlayerList().getPlayers();
+      final Set<String> hiddenPlayers = uiContext.getMapData().getHiddenPlayersInTechTable();
+
+      final List<GamePlayer> players =
+          gameData.getPlayerList().getPlayers().stream()
+              .filter(player -> !hiddenPlayers.contains(player.getName()))
+              .toList();
+
       colList = players.stream().map(GamePlayer::getName).toArray(String[]::new);
       Arrays.sort(colList);
     }
@@ -216,7 +223,12 @@ class TechnologyPanel extends JPanel implements GameDataChangeListener {
       // copy so that the object doesn't change underneath us
       final GameData gameDataSync = TechnologyPanel.this.gameData;
       try (GameData.Unlocker ignored = gameDataSync.acquireReadLock()) {
+        final Set<String> hiddenPlayers = uiContext.getMapData().getHiddenPlayersInTechTable();
         for (final GamePlayer playerID : gameDataSync.getPlayerList().getPlayers()) {
+          if (hiddenPlayers.contains(playerID.getName())) {
+            continue;
+          }
+
           if (colMap.get(playerID.getName()) == null) {
             throw new IllegalStateException(
                 String.format(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -83,7 +84,8 @@ public class MapData {
   @NonNls public static final String PROPERTY_MAP_MAPBLENDS = "map.mapBlends";
   @NonNls public static final String PROPERTY_MAP_MAPBLENDMODE = "map.mapBlendMode";
   @NonNls public static final String PROPERTY_MAP_MAPBLENDALPHA = "map.mapBlendAlpha";
-
+  private static final String PROPERTY_PLAYERS_NOT_SHOWN_IN_TECH_TABLE =
+      "players_not_shown_in_tech_table";
   @NonNls public static final String POLYGON_FILE = "polygons.txt";
 
   @NonNls private static final String PROPERTY_DONT_DRAW_UNITS = "dont_draw_units";
@@ -788,5 +790,22 @@ public class MapData {
                   .or(() -> loader.loadImage(standardImageName))
                   .orElse(null);
             }));
+  }
+
+  public Set<String> getHiddenPlayersInTechTable() {
+    return parseHiddenPlayers(
+        mapProperties.getProperty(PROPERTY_PLAYERS_NOT_SHOWN_IN_TECH_TABLE, ""));
+  }
+
+  @VisibleForTesting
+  static Set<String> parseHiddenPlayers(final String players) {
+    if (players.isBlank()) {
+      return Collections.emptySet();
+    }
+
+    return Arrays.stream(players.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toSet());
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ui/mapdata/MapDataTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ui/mapdata/MapDataTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Properties;
+import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +39,32 @@ final class MapDataTest {
       properties.setProperty(NAME, "malformed");
 
       assertThat(getProperty(), is(DEFAULT_VALUE));
+    }
+
+    @Nested
+    final class ParseHiddenPlayersTest {
+
+      @Test
+      void shouldReturnEmptySetWhenPropertyIsBlank() {
+        assertThat(MapData.parseHiddenPlayers(""), is(Set.of()));
+      }
+
+      @Test
+      void shouldReturnSinglePlayer() {
+        assertThat(MapData.parseHiddenPlayers("Germans"), is(Set.of("Germans")));
+      }
+
+      @Test
+      void shouldTrimWhitespace() {
+        assertThat(
+            MapData.parseHiddenPlayers(" Germans , Russians "), is(Set.of("Germans", "Russians")));
+      }
+
+      @Test
+      void shouldIgnoreEmptyEntries() {
+        assertThat(
+            MapData.parseHiddenPlayers("Germans,,Russians,"), is(Set.of("Germans", "Russians")));
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR adds support for hiding specific players from the Technology Table using the map property:

```properties
players_not_shown_in_tech_table=Player1,Player2
```

Players listed in this property are:
- Excluded when the Technology Table is initialized.
- Ignored during table updates to keep the UI consistent.

## Testing

- Added unit tests for parsing the property.
- Verified parsing for:
  - Empty property
  - Single player
  - Multiple players with whitespace
  - Empty entries
- Ran:

```bash
./gradlew spotlessApply
./gradlew check
```

Both completed successfully.

## Notes to Reviewer

This change is backward compatible. Maps that do not define
`players_not_shown_in_tech_table` will behave exactly as before.