### PR TITLE
Support hiding players in Unit Help table via map.properties

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -87,6 +88,9 @@ public class MapData {
   @NonNls public static final String POLYGON_FILE = "polygons.txt";
 
   @NonNls private static final String PROPERTY_DONT_DRAW_UNITS = "dont_draw_units";
+
+  private static final String PROPERTY_PLAYERS_NOT_SHOWN_IN_UNIT_HELP_TABLE =
+      "players_not_shown_in_unit_help_table";
 
   @NonNls
   private static final String PROPERTY_MAP_SMALLMAPTERRITORYSATURATION =
@@ -788,5 +792,22 @@ public class MapData {
                   .or(() -> loader.loadImage(standardImageName))
                   .orElse(null);
             }));
+  }
+
+  public Set<String> getHiddenPlayersInUnitHelpTable() {
+    return parseHiddenPlayers(
+        mapProperties.getProperty(PROPERTY_PLAYERS_NOT_SHOWN_IN_UNIT_HELP_TABLE, ""));
+  }
+
+  @VisibleForTesting
+  static Set<String> parseHiddenPlayers(String players) {
+    if (players == null || players.isBlank()) {
+      return Set.of();
+    }
+
+    return Arrays.stream(players.split(","))
+        .map(String::trim)
+        .filter(player -> !player.isEmpty())
+        .collect(Collectors.toSet());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitStatsTable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitStatsTable.java
@@ -101,23 +101,38 @@ public class UnitStatsTable {
   private static Map<GamePlayer, List<UnitType>> getAllPlayerUnitsWithImages(
       final GameState data, final UiContext uiContext) {
     final Map<GamePlayer, List<UnitType>> unitTypes = new LinkedHashMap<>();
+    final Set<String> hiddenPlayers = uiContext.getMapData().getHiddenPlayersInUnitHelpTable();
+
     for (final GamePlayer p : data.getPlayerList().getPlayers()) {
+      if (hiddenPlayers.contains(p.getName())) {
+        continue;
+      }
+
       unitTypes.put(p, getPlayerUnitsWithImages(p, data, uiContext));
     }
+
     final Set<UnitType> unitsSoFar = new HashSet<>();
     for (final List<UnitType> l : unitTypes.values()) {
       unitsSoFar.addAll(l);
     }
+
     final Set<UnitType> all = data.getUnitTypeList().getAllUnitTypes();
     all.removeAll(unitsSoFar);
-    unitTypes.put(
-        data.getPlayerList().getNullPlayer(),
-        getPlayerUnitsWithImages(data.getPlayerList().getNullPlayer(), data, uiContext));
-    unitsSoFar.addAll(unitTypes.get(data.getPlayerList().getNullPlayer()));
+
+    final GamePlayer nullPlayer = data.getPlayerList().getNullPlayer();
+
+    if (!hiddenPlayers.contains(nullPlayer.getName())) {
+      unitTypes.put(nullPlayer, getPlayerUnitsWithImages(nullPlayer, data, uiContext));
+
+      unitsSoFar.addAll(unitTypes.get(nullPlayer));
+    }
+
     all.removeAll(unitsSoFar);
+
     if (!all.isEmpty()) {
       unitTypes.put(null, new ArrayList<>(all));
     }
+
     return unitTypes;
   }
 


### PR DESCRIPTION
## Summary

Adds support for the `players_not_shown_in_unit_help_table` map property.

### Changes
- Added parsing for `players_not_shown_in_unit_help_table` in `MapData`.
- Filtered players listed in the Unit Help table based on the configured property.
- Supports hiding both regular players and the `NullPlayer`.

### Testing
- Verified that configured players are omitted from the Unit Help table.
- Ran `./gradlew spotlessApply`.
- Ran `./gradlew check`.