### PR TITLE
fix 14812 (TransportUtils IndexOutOfBoundsException) - Adds test method findMinTransportsToUnloadFailsForUnitWithoutTransportOption (exposing the bug) - Fix in findTransportsThatUnitsCouldUnloadFrom to avoid adding empty transportOptions

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -280,7 +280,9 @@ public final class TransportUtils {
           transportOptions.add(transport);
         }
       }
-      result.put(unit, transportOptions);
+      if (!transportOptions.isEmpty()) {
+        result.put(unit, transportOptions);
+      }
     }
     return result;
   }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/util/TransportUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/util/TransportUtilsTest.java
@@ -8,9 +8,11 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
 import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
+import static games.strategy.triplea.util.TransportUtils.findMinTransportsToUnload;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameStep;
@@ -19,6 +21,8 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.xml.TestMapGameData;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -64,6 +68,16 @@ public class TransportUtilsTest {
     transport.setUnloaded(List.of(dummyUnit));
     dummyUnit.getProperty(Unit.PropertyName.UNLOADED_TO).orElseThrow().setValue(t);
     assertThat(dummyUnit.getUnloadedTo(), equalTo(t));
+  }
+
+  @Test
+  void findMinTransportsToUnloadFailsForUnitWithoutTransportOption() {
+    final Collection<Unit> units = Arrays.asList(infantry1, tank2);
+    final Collection<Unit> transports = List.of(transport1);
+
+    addTransportedUnits(sz5, transport1, List.of(infantry1));
+
+    assertDoesNotThrow(() -> findMinTransportsToUnload(units, transports));
   }
 
   @Nested


### PR DESCRIPTION
Should fix #14812 