### PR TITLE
Allow unitPlacementOnlyAllowedIn to be changed via a trigger in the XML

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -300,6 +300,19 @@ public class UnitAttachment extends DefaultAttachment {
   // also an allowed setter is "setUnitPlacementOnlyAllowedIn",
   // which just creates unitPlacementRestrictions with an inverted list of territories
   @Getter private @Nullable String[] unitPlacementRestrictions = null;
+
+  private String[] getUnitPlacementOnlyAllowedIn() {
+    final Set<String> restrictedTerritories =
+        unitPlacementRestrictions == null
+            ? Set.of()
+            : new HashSet<>(Arrays.asList(unitPlacementRestrictions));
+
+    return getData().getMap().getTerritories().stream()
+        .map(Territory::getName)
+        .filter(name -> !restrictedTerritories.contains(name))
+        .toArray(String[]::new);
+  }
+
   // -1 if infinite (infinite is default)
   @Getter private int maxBuiltPerPlayer = -1;
   private @Nullable Tuple<Integer, String> placementLimit = null;
@@ -979,6 +992,21 @@ public class UnitAttachment extends DefaultAttachment {
     restrictedTerritories.removeAll(allowedTerritories);
     unitPlacementRestrictions =
         restrictedTerritories.stream().map(Territory::getName).toArray(String[]::new);
+  }
+
+  private void setUnitPlacementOnlyAllowedInArray(final String[] value) throws GameParseException {
+    final Collection<Territory> allowedTerritories = getListedTerritories(value);
+    final Collection<Territory> restrictedTerritories =
+        new HashSet<>(getData().getMap().getTerritories());
+
+    restrictedTerritories.removeAll(allowedTerritories);
+
+    unitPlacementRestrictions =
+        restrictedTerritories.stream().map(Territory::getName).toArray(String[]::new);
+  }
+
+  private void resetUnitPlacementOnlyAllowedIn() {
+    unitPlacementRestrictions = null;
   }
 
   private void setRepairsUnits(final String value) throws GameParseException {
@@ -2874,6 +2902,8 @@ public class UnitAttachment extends DefaultAttachment {
         + maxDamage
         + "  unitPlacementRestrictions:"
         + toString(unitPlacementRestrictions)
+        + " unitPlacementOnlyAllowedIn:"
+        + toString(getUnitPlacementOnlyAllowedIn())
         + "  requiresUnits:"
         + toString(requiresUnits)
         + "  consumesUnits:"
@@ -4136,7 +4166,13 @@ public class UnitAttachment extends DefaultAttachment {
       case "destroyedWhenCapturedFrom" ->
           Optional.of(MutableProperty.ofWriteOnlyString(this::setDestroyedWhenCapturedFrom));
       case "unitPlacementOnlyAllowedIn" ->
-          Optional.of(MutableProperty.ofWriteOnlyString(this::setUnitPlacementOnlyAllowedIn));
+          Optional.of(
+              MutableProperty.of(
+                  this::setUnitPlacementOnlyAllowedInArray,
+                  this::setUnitPlacementOnlyAllowedIn,
+                  this::getUnitPlacementOnlyAllowedIn,
+                  this::resetUnitPlacementOnlyAllowedIn));
+
       case "isAAmovement" ->
           Optional.of(
               MutableProperty.<Boolean>ofWriteOnly(this::setIsAaMovement, this::setIsAaMovement));


### PR DESCRIPTION
Initially, only the unit attachment "unitPlacementRestrictions" could be modified via a trigger in the XML. This PR allows you to modify "unitPlacementOnlyAllowedIn" as well. In the original code, it was stated that a getter for unitPlacementOnlyAllowedIn was purposely left out as it was the inverse of unitPlacementRestrictions. However, when working on a TripleA map "North Africa - Rommel's Last Push", I encountered a situation where you want to force a player to only be able to place a unit in a specific territory. If you need to use unitPlacementRestrictions for this, you'd need to list all the territories of the entire game except for that territory. It'd be much easier if you could use unitPlacementOnlyAllowedIn and state the territory you can only place into. This territory needs to be changed via triggers a couple of times to follow the game rules. This PR allows you to do that with unitPlacementOnlyAllowedIn. In short, the following XML code:

```
	<attachment name="triggerAttachmentDestroyerAtlanticOcean" attachTo="British" javaClass="TriggerAttachment" type="player">
		<option name="conditions" value="conditionAttachmentAlwaysTrue"/>
		<option name="unitAttachmentName" value="UnitAttachment" count="unitAttachment"/>
		<option name="unitType" value="UK-destroyer"/>
		<option name="unitProperty" value="unitPlacementOnlyAllowedIn" count="Atlantic Ocean"/>
		<option name="when" value="before:britishAtlanticPlace"/>
	</attachment>
```
would generate an error message, but now it does not anymore and does exactly what it is supposed to do.

Attempts to fix: https://github.com/triplea-game/triplea/issues/14863

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
There might be better ways to implement this. I used the help of a LLM, and the code it came up with might not be ideal. It does work as intended though. I'd be happy to discuss how to do this.