### PR TITLE
Prevent ArrayList from being modified while being iterated over

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -531,7 +531,6 @@ public class MapPanel extends ImageScrollerLargeView {
     unitSelectionListeners.remove(listener);
   }
 
-  // We iterate over a copy of the listener list to allow listeners to modify it
   private void notifyUnitSelected(
       final List<Unit> units, @Nullable final Territory territory, final MouseDetails me) {
     for (final UnitSelectionListener listener :

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -505,19 +506,19 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   private void notifyTerritorySelected(final Territory t, final MouseDetails me) {
-    for (final MapSelectionListener msl : mapSelectionListeners) {
+    for (final MapSelectionListener msl : new CopyOnWriteArrayList<>(mapSelectionListeners)) {
       msl.territorySelected(t, me);
     }
   }
 
   private void notifyMouseMoved(final Territory t, final MouseDetails me) {
-    for (final MapSelectionListener msl : mapSelectionListeners) {
+    for (final MapSelectionListener msl : new CopyOnWriteArrayList<>(mapSelectionListeners)) {
       msl.mouseMoved(t, me);
     }
   }
 
   private void notifyMouseEntered(final Territory t) {
-    for (final MapSelectionListener msl : mapSelectionListeners) {
+    for (final MapSelectionListener msl : new CopyOnWriteArrayList<>(mapSelectionListeners)) {
       msl.mouseEntered(t);
     }
   }
@@ -530,15 +531,18 @@ public class MapPanel extends ImageScrollerLargeView {
     unitSelectionListeners.remove(listener);
   }
 
+  // We iterate over a copy of the listener list to allow listeners to modify it
   private void notifyUnitSelected(
       final List<Unit> units, @Nullable final Territory territory, final MouseDetails me) {
-    for (final UnitSelectionListener listener : new ArrayList<>(unitSelectionListeners)) {
+    for (final UnitSelectionListener listener :
+        new CopyOnWriteArrayList<>(unitSelectionListeners)) {
       listener.unitsSelected(units, territory, me);
     }
   }
 
   private void notifyMouseEnterUnit(final List<Unit> units, final Territory t) {
-    for (final MouseOverUnitListener listener : mouseOverUnitsListeners) {
+    for (final MouseOverUnitListener listener :
+        new CopyOnWriteArrayList<>(mouseOverUnitsListeners)) {
       listener.mouseEnter(units, t);
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -506,19 +505,19 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   private void notifyTerritorySelected(final Territory t, final MouseDetails me) {
-    for (final MapSelectionListener msl : new CopyOnWriteArrayList<>(mapSelectionListeners)) {
+    for (final MapSelectionListener msl : new ArrayList<>(mapSelectionListeners)) {
       msl.territorySelected(t, me);
     }
   }
 
   private void notifyMouseMoved(final Territory t, final MouseDetails me) {
-    for (final MapSelectionListener msl : new CopyOnWriteArrayList<>(mapSelectionListeners)) {
+    for (final MapSelectionListener msl : new ArrayList<>(mapSelectionListeners)) {
       msl.mouseMoved(t, me);
     }
   }
 
   private void notifyMouseEntered(final Territory t) {
-    for (final MapSelectionListener msl : new CopyOnWriteArrayList<>(mapSelectionListeners)) {
+    for (final MapSelectionListener msl : new ArrayList<>(mapSelectionListeners)) {
       msl.mouseEntered(t);
     }
   }
@@ -533,15 +532,13 @@ public class MapPanel extends ImageScrollerLargeView {
 
   private void notifyUnitSelected(
       final List<Unit> units, @Nullable final Territory territory, final MouseDetails me) {
-    for (final UnitSelectionListener listener :
-        new CopyOnWriteArrayList<>(unitSelectionListeners)) {
+    for (final UnitSelectionListener listener : new ArrayList<>(unitSelectionListeners)) {
       listener.unitsSelected(units, territory, me);
     }
   }
 
   private void notifyMouseEnterUnit(final List<Unit> units, final Territory t) {
-    for (final MouseOverUnitListener listener :
-        new CopyOnWriteArrayList<>(mouseOverUnitsListeners)) {
+    for (final MouseOverUnitListener listener : new ArrayList<>(mouseOverUnitsListeners)) {
       listener.mouseEnter(units, t);
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -532,7 +532,7 @@ public class MapPanel extends ImageScrollerLargeView {
 
   private void notifyUnitSelected(
       final List<Unit> units, @Nullable final Territory territory, final MouseDetails me) {
-    for (final UnitSelectionListener listener : unitSelectionListeners) {
+    for (final UnitSelectionListener listener : new ArrayList<>(unitSelectionListeners)) {
       listener.unitsSelected(units, territory, me);
     }
   }


### PR DESCRIPTION
An ArrayList was able to be modified while being iterated over. This PR makes sure that the method iterates over a copy of that list and prevents errors from occurring. It also fixed this for several other methods that could potentially cause the same ConcurrentModificationException.

Fixes: https://github.com/triplea-game/triplea/issues/14830

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
