### PR TITLE
Allow unitPlacementOnlyAllowedIn to be changed via a trigger in the XML

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -300,6 +300,19 @@ public class UnitAttachment extends DefaultAttachment {
   // also an allowed setter is "setUnitPlacementOnlyAllowedIn",
   // which just creates unitPlacementRestrictions with an inverted list of territories
   @Getter private @Nullable String[] unitPlacementRestrictions = null;
+
+  private String[] getUnitPlacementOnlyAllowedIn() {
+    final Set<String> restrictedTerritories =
+        unitPlacementRestrictions == null
+            ? Set.of()
+            : new HashSet<>(Arrays.asList(unitPlacementRestrictions));
+
+    return getData().getMap().getTerritories().stream()
+        .map(Territory::getName)
+        .filter(name -> !restrictedTerritories.contains(name))
+        .toArray(String[]::new);
+  }
+
   // -1 if infinite (infinite is default)
   @Getter private int maxBuiltPerPlayer = -1;
   private @Nullable Tuple<Integer, String> placementLimit = null;
@@ -979,6 +992,21 @@ public class UnitAttachment extends DefaultAttachment {
     restrictedTerritories.removeAll(allowedTerritories);
     unitPlacementRestrictions =
         restrictedTerritories.stream().map(Territory::getName).toArray(String[]::new);
+  }
+
+  private void setUnitPlacementOnlyAllowedInArray(final String[] value) throws GameParseException {
+    final Collection<Territory> allowedTerritories = getListedTerritories(value);
+    final Collection<Territory> restrictedTerritories =
+        new HashSet<>(getData().getMap().getTerritories());
+
+    restrictedTerritories.removeAll(allowedTerritories);
+
+    unitPlacementRestrictions =
+        restrictedTerritories.stream().map(Territory::getName).toArray(String[]::new);
+  }
+
+  private void resetUnitPlacementOnlyAllowedIn() {
+    unitPlacementRestrictions = null;
   }
 
   private void setRepairsUnits(final String value) throws GameParseException {
@@ -2874,6 +2902,8 @@ public class UnitAttachment extends DefaultAttachment {
         + maxDamage
         + "  unitPlacementRestrictions:"
         + toString(unitPlacementRestrictions)
+        + " unitPlacementOnlyAllowedIn:"
+        + toString(getUnitPlacementOnlyAllowedIn())
         + "  requiresUnits:"
         + toString(requiresUnits)
         + "  consumesUnits:"
@@ -4136,7 +4166,13 @@ public class UnitAttachment extends DefaultAttachment {
       case "destroyedWhenCapturedFrom" ->
           Optional.of(MutableProperty.ofWriteOnlyString(this::setDestroyedWhenCapturedFrom));
       case "unitPlacementOnlyAllowedIn" ->
-          Optional.of(MutableProperty.ofWriteOnlyString(this::setUnitPlacementOnlyAllowedIn));
+          Optional.of(
+              MutableProperty.of(
+                  this::setUnitPlacementOnlyAllowedInArray,
+                  this::setUnitPlacementOnlyAllowedIn,
+                  this::getUnitPlacementOnlyAllowedIn,
+                  this::resetUnitPlacementOnlyAllowedIn));
+
       case "isAAmovement" ->
           Optional.of(
               MutableProperty.<Boolean>ofWriteOnly(this::setIsAaMovement, this::setIsAaMovement));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -992,7 +992,7 @@ public class UnitAttachment extends DefaultAttachment {
         restrictedTerritories.stream().map(Territory::getName).toArray(String[]::new);
   }
 
-  private void setUnitPlacementOnlyAllowedInArray(final String[] value) throws GameParseException {
+  private void setUnitPlacementOnlyAllowedIn(final String[] value) throws GameParseException {
     final Collection<Territory> allowedTerritories = getListedTerritories(value);
     final Collection<Territory> restrictedTerritories =
         new HashSet<>(getData().getMap().getTerritories());
@@ -4027,7 +4027,7 @@ public class UnitAttachment extends DefaultAttachment {
       case "unitPlacementOnlyAllowedIn" ->
           Optional.of(
               MutableProperty.of(
-                  this::setUnitPlacementOnlyAllowedInArray,
+                  this::setUnitPlacementOnlyAllowedIn,
                   this::setUnitPlacementOnlyAllowedIn,
                   this::getUnitPlacementOnlyAllowedIn,
                   this::resetUnitPlacementOnlyAllowedIn));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -297,10 +297,10 @@ public class UnitAttachment extends DefaultAttachment {
   // this unit to move into a territory. (units must be owned by player, not be disabled)
   private @Nullable List<String[]> requiresUnitsToMove = null;
   // a colon delimited list of territories where this unit may not be placed
-  // also an allowed setter is "setUnitPlacementOnlyAllowedIn",
-  // which just creates unitPlacementRestrictions with an inverted list of territories
   @Getter private @Nullable String[] unitPlacementRestrictions = null;
 
+  // a colon delimited list of territories where this unit may only be placed. Essentially the
+  // inverse of unitPlacementRestrictions
   private String[] getUnitPlacementOnlyAllowedIn() {
     final Set<String> restrictedTerritories =
         unitPlacementRestrictions == null
@@ -983,8 +983,6 @@ public class UnitAttachment extends DefaultAttachment {
     unitPlacementRestrictions = null;
   }
 
-  // no field for this, since it is the inverse of unitPlacementRestrictions
-  // we might as well just use unitPlacementRestrictions
   private void setUnitPlacementOnlyAllowedIn(final String value) throws GameParseException {
     final Collection<Territory> allowedTerritories = getListedTerritories(splitOnColon(value));
     final Collection<Territory> restrictedTerritories =
@@ -4026,6 +4024,14 @@ public class UnitAttachment extends DefaultAttachment {
                   this::setUnitPlacementRestrictions,
                   this::getUnitPlacementRestrictions,
                   this::resetUnitPlacementRestrictions));
+      case "unitPlacementOnlyAllowedIn" ->
+          Optional.of(
+              MutableProperty.of(
+                  this::setUnitPlacementOnlyAllowedInArray,
+                  this::setUnitPlacementOnlyAllowedIn,
+                  this::getUnitPlacementOnlyAllowedIn,
+                  this::resetUnitPlacementOnlyAllowedIn));
+
       case "maxBuiltPerPlayer" ->
           Optional.of(
               MutableProperty.of(
@@ -4165,14 +4171,6 @@ public class UnitAttachment extends DefaultAttachment {
           Optional.of(MutableProperty.<Boolean>ofWriteOnly(this::setIsAa, this::setIsAa));
       case "destroyedWhenCapturedFrom" ->
           Optional.of(MutableProperty.ofWriteOnlyString(this::setDestroyedWhenCapturedFrom));
-      case "unitPlacementOnlyAllowedIn" ->
-          Optional.of(
-              MutableProperty.of(
-                  this::setUnitPlacementOnlyAllowedInArray,
-                  this::setUnitPlacementOnlyAllowedIn,
-                  this::getUnitPlacementOnlyAllowedIn,
-                  this::resetUnitPlacementOnlyAllowedIn));
-
       case "isAAmovement" ->
           Optional.of(
               MutableProperty.<Boolean>ofWriteOnly(this::setIsAaMovement, this::setIsAaMovement));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2900,8 +2900,6 @@ public class UnitAttachment extends DefaultAttachment {
         + maxDamage
         + "  unitPlacementRestrictions:"
         + toString(unitPlacementRestrictions)
-        + " unitPlacementOnlyAllowedIn:"
-        + toString(getUnitPlacementOnlyAllowedIn())
         + "  requiresUnits:"
         + toString(requiresUnits)
         + "  consumesUnits:"

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -284,8 +285,8 @@ class UnitAttachmentTest {
 
       unitPlacementOnlyAllowedIn.setValue(new String[] {"A"});
 
-      assertThat(Set.of(unitPlacementOnlyAllowedIn.getValue()), containsInAnyOrder("A"));
-      assertThat(Set.of(unitPlacementRestrictions.getValue()), containsInAnyOrder("B", "C"));
+      assertEquals(Set.of("A"), Set.of(unitPlacementOnlyAllowedIn.getValue()));
+      assertEquals(Set.of("B", "C"), Set.of(unitPlacementRestrictions.getValue()));
     }
 
     @Test
@@ -293,7 +294,7 @@ class UnitAttachmentTest {
         throws MutableProperty.InvalidValueException {
       unitPlacementRestrictions.setValue(new String[] {"B", "C"});
 
-      assertThat(Set.of(unitPlacementOnlyAllowedIn.getValue()), containsInAnyOrder("A"));
+      assertEquals(Set.of("A"), Set.of(unitPlacementOnlyAllowedIn.getValue()));
     }
 
     @Test
@@ -304,8 +305,31 @@ class UnitAttachmentTest {
       unitPlacementOnlyAllowedIn.setValue(new String[] {"A"});
       unitPlacementRestrictions.setValue(new String[] {"B"});
 
-      assertThat(Set.of(unitPlacementOnlyAllowedIn.getValue()), containsInAnyOrder("A", "C"));
-      assertThat(Set.of(unitPlacementRestrictions.getValue()), containsInAnyOrder("B"));
+      assertEquals(Set.of("A", "C"), Set.of(unitPlacementOnlyAllowedIn.getValue()));
+      assertEquals(Set.of("B"), Set.of(unitPlacementRestrictions.getValue()));
+    }
+
+    @Test
+    void resettingUnitPlacementOnlyAllowedInClearsRestrictions()
+        throws MutableProperty.InvalidValueException {
+      when(map.getTerritoryOrNull("A")).thenReturn(territoryA);
+
+      unitPlacementOnlyAllowedIn.setValue(new String[] {"A"});
+      unitPlacementOnlyAllowedIn.resetValue();
+
+      assertEquals(Set.of("A", "B", "C"), Set.of(unitPlacementOnlyAllowedIn.getValue()));
+      assertNull(unitPlacementRestrictions.getValue());
+    }
+
+    @Test
+    void resettingUnitPlacementRestrictionsClearsOnlyAllowedIn()
+        throws MutableProperty.InvalidValueException {
+
+      unitPlacementRestrictions.setValue(new String[] {"A"});
+      unitPlacementRestrictions.resetValue();
+
+      assertEquals(Set.of("A", "B", "C"), Set.of(unitPlacementOnlyAllowedIn.getValue()));
+      assertNull(unitPlacementRestrictions.getValue());
     }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
@@ -20,15 +20,18 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.PlayerList;
+import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.engine.data.properties.BooleanProperty;
 import games.strategy.engine.data.properties.GameProperties;
 import java.security.SecureRandom;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -240,6 +243,69 @@ class UnitAttachmentTest {
 
       // called in getCanNotBeTargetedBy when AIR_ATTACK_SUB_RESTRICTED is true
       verify(unitTypeList, never()).getAllUnitTypes();
+    }
+  }
+
+  @Nested
+  class UnitPlacementOnlyAllowedIn {
+
+    private Territory territoryA;
+    private Territory territoryB;
+    private Territory territoryC;
+    private GameMap map;
+
+    private MutableProperty<String[]> unitPlacementOnlyAllowedIn;
+    private MutableProperty<String[]> unitPlacementRestrictions;
+
+    @BeforeEach
+    void setUp() {
+      territoryA = mock(Territory.class);
+      territoryB = mock(Territory.class);
+      territoryC = mock(Territory.class);
+
+      when(territoryA.getName()).thenReturn("A");
+      when(territoryB.getName()).thenReturn("B");
+      when(territoryC.getName()).thenReturn("C");
+
+      map = mock(GameMap.class);
+      when(gameData.getMap()).thenReturn(map);
+      when(map.getTerritories()).thenReturn(List.of(territoryA, territoryB, territoryC));
+
+      unitPlacementOnlyAllowedIn =
+          (MutableProperty<String[]>) attachment.getPropertyOrThrow("unitPlacementOnlyAllowedIn");
+      unitPlacementRestrictions =
+          (MutableProperty<String[]>) attachment.getPropertyOrThrow("unitPlacementRestrictions");
+    }
+
+    @Test
+    void setUnitPlacementOnlyAllowedInUpdatesRestrictions()
+        throws MutableProperty.InvalidValueException {
+      when(map.getTerritoryOrNull("A")).thenReturn(territoryA);
+
+      unitPlacementOnlyAllowedIn.setValue(new String[] {"A"});
+
+      assertThat(Set.of(unitPlacementOnlyAllowedIn.getValue()), containsInAnyOrder("A"));
+      assertThat(Set.of(unitPlacementRestrictions.getValue()), containsInAnyOrder("B", "C"));
+    }
+
+    @Test
+    void setUnitPlacementRestrictionsUpdatesOnlyAllowedIn()
+        throws MutableProperty.InvalidValueException {
+      unitPlacementRestrictions.setValue(new String[] {"B", "C"});
+
+      assertThat(Set.of(unitPlacementOnlyAllowedIn.getValue()), containsInAnyOrder("A"));
+    }
+
+    @Test
+    void settingBothPlacementPropertiesUsesLastValue()
+        throws MutableProperty.InvalidValueException {
+      when(map.getTerritoryOrNull("A")).thenReturn(territoryA);
+
+      unitPlacementOnlyAllowedIn.setValue(new String[] {"A"});
+      unitPlacementRestrictions.setValue(new String[] {"B"});
+
+      assertThat(Set.of(unitPlacementOnlyAllowedIn.getValue()), containsInAnyOrder("A", "C"));
+      assertThat(Set.of(unitPlacementRestrictions.getValue()), containsInAnyOrder("B"));
     }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
@@ -331,5 +331,27 @@ class UnitAttachmentTest {
       assertEquals(Set.of("A", "B", "C"), Set.of(unitPlacementOnlyAllowedIn.getValue()));
       assertNull(unitPlacementRestrictions.getValue());
     }
+
+    @Test
+    void setUnitPlacementOnlyAllowedInWithColonDelimitedStringUpdatesRestrictions()
+        throws MutableProperty.InvalidValueException {
+      when(map.getTerritoryOrNull("A")).thenReturn(territoryA);
+
+      unitPlacementOnlyAllowedIn.setValue("A");
+
+      assertEquals(Set.of("A"), Set.of(unitPlacementOnlyAllowedIn.getValue()));
+      assertEquals(Set.of("B", "C"), Set.of(unitPlacementRestrictions.getValue()));
+    }
+
+    @Test
+    void setUnitPlacementRestrictionsWithColonDelimitedStringUpdatesOnlyAllowedIn()
+        throws MutableProperty.InvalidValueException {
+      when(map.getTerritoryOrNull("B")).thenReturn(territoryB);
+      when(map.getTerritoryOrNull("C")).thenReturn(territoryC);
+
+      unitPlacementRestrictions.setValue("B:C");
+
+      assertEquals(Set.of("A"), Set.of(unitPlacementOnlyAllowedIn.getValue()));
+    }
   }
 }


### PR DESCRIPTION
## Notes to Reviewer
Initially, only the unit attachment "unitPlacementRestrictions" could be modified via a trigger in the XML. This PR allows you to modify "unitPlacementOnlyAllowedIn" as well. In the original code, it was stated that a getter for unitPlacementOnlyAllowedIn was purposely left out as it was the inverse of unitPlacementRestrictions. However, when working on a TripleA map "North Africa - Rommel's Last Push", I encountered a situation where you want to force a player to only be able to place a unit in a specific territory. If you need to use unitPlacementRestrictions for this, you'd need to list all the territories of the entire game except for that territory. It'd be much easier if you could use unitPlacementOnlyAllowedIn and state the territory you can only place into. This territory needs to be changed via triggers a couple of times to follow the game rules. This PR allows you to do that with unitPlacementOnlyAllowedIn. In short, the following XML code:

```
	<attachment name="triggerAttachmentDestroyerAtlanticOcean" attachTo="British" javaClass="TriggerAttachment" type="player">
		<option name="conditions" value="conditionAttachmentAlwaysTrue"/>
		<option name="unitAttachmentName" value="UnitAttachment" count="unitAttachment"/>
		<option name="unitType" value="UK-destroyer"/>
		<option name="unitProperty" value="unitPlacementOnlyAllowedIn" count="Atlantic Ocean"/>
		<option name="when" value="before:britishAtlanticPlace"/>
	</attachment>
```
would generate an error message, but now it does not anymore and does exactly what it is supposed to do.

Attempts to fix: https://github.com/triplea-game/triplea/issues/14863

There might be better ways to implement this. I used the help of a LLM, and the code it came up with might not be ideal. It does work as intended though. I'd be happy to discuss how to improve this.

## Testing
Added five unit tests:
1) Checks if setting unitPlacementOnlyAllowedIn actually sets said property, and also correctly updates unitPlacementRestrictions
2) Checks if setting unitPlacementRestrictions updates unitPlacementOnlyAllowedIn
3) Checks if setting both at the same time results in the last-set property determining the final value.
4) Checks if resetting unitPlacementOnlyAllowedIn results in clearing unitPlacementRestrictions and filling unitPlacementOnlyAllowedIn with all territories on the map
5) Checks if resetting unitPlacementRestrictions results in clearing it and filling unitPlacementsOnlyAlllowedIn with all territories on the map