### PR TITLE
Fix PBEM setup issue

### DIFF
--- a/lib/swing-lib/src/main/java/org/triplea/swing/JTextFieldBuilder.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/JTextFieldBuilder.java
@@ -47,13 +47,13 @@ public class JTextFieldBuilder {
     Optional.ofNullable(actionListener)
         .ifPresent(action -> textField.addActionListener(e -> action.accept(textField)));
 
+    Optional.ofNullable(maxLength).map(JTextFieldLimit::new).ifPresent(textField::setDocument);
+
     Optional.ofNullable(textListener)
         .ifPresent(
             listener ->
                 new DocumentListenerBuilder(() -> textListener.accept(textField.getText()))
                     .attachTo(textField));
-
-    Optional.ofNullable(maxLength).map(JTextFieldLimit::new).ifPresent(textField::setDocument);
 
     Optional.ofNullable(text).ifPresent(textField::setText);
 

--- a/lib/swing-lib/src/test/java/org/triplea/swing/JTextFieldBuilderTest.java
+++ b/lib/swing-lib/src/test/java/org/triplea/swing/JTextFieldBuilderTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.core.Is.is;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JTextField;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,17 @@ class JTextFieldBuilderTest {
     Awaitility.await()
         .atMost(Duration.ofMillis(DocumentListenerBuilder.CALLBACK_DELAY_MS * 2))
         .until(() -> value.get() == 1);
+  }
+
+  @Test
+  void textListenerWithMaxLength() {
+    final AtomicReference<String> value = new AtomicReference<>();
+
+    JTextFieldBuilder.builder().maxLength(20).textListener(value::set).build().setText("test");
+
+    Awaitility.await()
+        .atMost(Duration.ofMillis(DocumentListenerBuilder.CALLBACK_DELAY_MS * 2))
+        .until(() -> "test".equals(value.get()));
   }
 
   @Test


### PR DESCRIPTION

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
Changes the order of code in JTextFieldBuilder.java to fix the PBEM setup issue. When choosing an Email Provider under Automatically Send Emails, the fields would remain red as if they were unfilled, even after being filled in. This was caused by the text listener being attached to the wrong document due to the order of the code. With the correct order, the fields are correctly recognized as filled in and turn normal.

Fixes: https://github.com/triplea-game/triplea/issues/14845
## Testing
Added a regression test for the interaction between textListener and maxLength.
