### PR TITLE
Fix buttons being clipped in the right-hand side panel

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -173,7 +173,7 @@ class TechPanel extends ActionPanel {
 
   private final Action justRollTech =
       SwingAction.of(
-          "Done/Roll Current Tokens",
+          "Done",
           e -> {
             currTokens = getCurrentPlayer().getResources().getQuantity(Constants.TECH_TOKENS);
             // If this player has tokens, roll them.

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -424,15 +424,17 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
           }
         });
 
-    // The calculated minimum width (240px) is insufficient to display all buttons ('Cancel',
-    // 'Done', 'Undo All')
-    final int minimumRightHandSidePanelWidth = 248;
     rightHandSidePanel.setPreferredSize(
         new Dimension(
             (int) smallView.getPreferredSize().getWidth(),
             (int) mapPanel.getPreferredSize().getHeight()));
+    // The calculated minimum width (240px) is insufficient to display all buttons ('Cancel',
+    // 'Done', 'Undo All')
+    final int minimumRightHandSidePanelWidth = 248;
     rightHandSidePanel.setMinimumSize(
-        new Dimension(minimumRightHandSidePanelWidth, rightHandSidePanel.getMinimumSize().height));
+        new Dimension(
+            Math.max(minimumRightHandSidePanelWidth, rightHandSidePanel.getMinimumSize().width),
+            rightHandSidePanel.getMinimumSize().height));
 
     gameCenterPanel =
         new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mapAndChatPanel, rightHandSidePanel);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -423,10 +423,17 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
             editPanel.setActive(false);
           }
         });
+
+    // The calculated minimum width (240px) is insufficient to display all buttons ('Cancel',
+    // 'Done', 'Undo All')
+    final int minimumRightHandSidePanelWidth = 248;
     rightHandSidePanel.setPreferredSize(
         new Dimension(
             (int) smallView.getPreferredSize().getWidth(),
             (int) mapPanel.getPreferredSize().getHeight()));
+    rightHandSidePanel.setMinimumSize(
+        new Dimension(minimumRightHandSidePanelWidth, rightHandSidePanel.getMinimumSize().height));
+
     gameCenterPanel =
         new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mapAndChatPanel, rightHandSidePanel);
     gameCenterPanel.setOneTouchExpandable(true);

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -428,8 +428,9 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
         new Dimension(
             (int) smallView.getPreferredSize().getWidth(),
             (int) mapPanel.getPreferredSize().getHeight()));
-    // The calculated minimum width (240px) is insufficient to display all buttons ('Cancel',
-    // 'Done', 'Undo All')
+    // The right-hand side panel's minimum width needs to be at least as wide as the smallMap, but
+    // not smaller than 248 px or there is not enough room for the Cancel/Done/Undo All buttons
+    // (issue #14880).
     final int minimumRightHandSidePanelWidth = 248;
     rightHandSidePanel.setMinimumSize(
         new Dimension(


### PR DESCRIPTION
<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
The buttons Cancel, Done and Undo All didn't always fit in the right-hand side panel. When the width of the smallMap image in the top right was too small, the Undo All button would clip with the edge and not be drawn. 

This sets the right-hand side panel to a minimum size that is just enough to fit all three buttons (248px vs the original 240px).

Also, when playing a game with tech tokens, in the tech screen you would have two buttons: "Buy Tech Tokens..." and "Done/Roll Current Tokens". The latter's name is so long that even with the slightly increased width, this button would still stick out of the screen. That's why in this PR, I also changed the name of this button to simply "Done". That's because now, both buttons fit without clipping the edge without the need for making the minimum size of the panel a lot bigger (305px).

It's also obvious from the context that pressing Done will result in rolling current tech tokens. In games without tech tokens, it would say "Roll Tech...", and you wouldn't have techToken resource in the lower left corner. In games with techTokens, you would have "Buy Tech Tokens..." and the resource showing in the lower left corner.

Fixes: https://github.com/triplea-game/triplea/issues/14880

## Verification
Tested with the UI, see screenshots below:

Before:
<img width="259" height="276" alt="undo all before" src="https://github.com/user-attachments/assets/30554bcf-9b4e-45ad-901b-273da0de08af" /><img width="259" height="276" alt="tech token before" src="https://github.com/user-attachments/assets/51bc2c31-8e0f-4a92-a81b-d2df34de531a" />

After:
<img width="259" height="276" alt="undo all after" src="https://github.com/user-attachments/assets/f056d2b6-2b90-4a65-bdb0-dca0aa142133" /><img width="259" height="276" alt="tech tokens after" src="https://github.com/user-attachments/assets/6843ca64-c2c7-4d34-b530-43e91b8b93bf" />
