### PR TITLE
Offset warning icon to prevent it from obscuring number of units in stack

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapRouteDrawer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapRouteDrawer.java
@@ -45,6 +45,9 @@ public class MapRouteDrawer {
   private static final int MESSAGE_TEXT_Y = 18;
   private static final int MESSAGE_TEXT_SPACING = 6;
   private static final Font MESSAGE_FONT = new Font("Dialog", Font.BOLD, 16);
+  // Offset the cursor to prevent it from obscuring UI elements
+  private static final double CURSOR_OFFSET_X = 25;
+  private static final double CURSOR_OFFSET_Y = 10;
 
   private final RouteCalculator routeCalculator;
   private final MapData mapData;
@@ -140,9 +143,11 @@ public class MapRouteDrawer {
     if (cursorImage != null) {
       for (final Point2D[] endPoint : routeCalculator.getAllPoints(lastRoutePoint)) {
         final AffineTransform imageTransform = getDrawingTransform();
-        imageTransform.translate(endPoint[0].getX(), endPoint[0].getY());
+        imageTransform.translate(
+            endPoint[0].getX() + CURSOR_OFFSET_X, endPoint[0].getY() + CURSOR_OFFSET_Y);
         imageTransform.translate(cursorImage.getWidth() / 2.0, cursorImage.getHeight() / 2.0);
         imageTransform.scale(1 / mapPanel.getScale(), 1 / mapPanel.getScale());
+        imageTransform.translate(-cursorImage.getWidth() / 2.0, -cursorImage.getHeight() / 2.0);
         graphics.drawImage(cursorImage, imageTransform, null);
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapRouteDrawer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapRouteDrawer.java
@@ -46,7 +46,8 @@ public class MapRouteDrawer {
   private static final int MESSAGE_TEXT_SPACING = 6;
   private static final Font MESSAGE_FONT = new Font("Dialog", Font.BOLD, 16);
   // Offset the cursor to prevent it from obscuring UI elements
-  private static final double CURSOR_OFFSET_X = 25;
+  // TODO: Derive these values dynamically rather than using hardcoded values.
+  private static final double CURSOR_OFFSET_X = 20;
   private static final double CURSOR_OFFSET_Y = 10;
 
   private final RouteCalculator routeCalculator;


### PR DESCRIPTION


<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
This offsets the warning icon when some units cannot move to the territory but others can, so that it doesn't overlap with the number of units in the stack. It also draws the icon from its center rather than the top, so that when you zoom in or out the center stays at the same position, which looks visually better.

Fixes: https://github.com/triplea-game/triplea/issues/5696

Before:
<img width="149" height="126" alt="Screenshot 08-18-2026 10 53 15" src="https://github.com/user-attachments/assets/c00078d5-c576-4b21-beda-e3e86715c545" /><img width="149" height="126" alt="Screenshot 08-18-2026 10 53 25" src="https://github.com/user-attachments/assets/0eb2b596-50bf-4233-80f7-086dfee7a577" />



After:
<img width="149" height="126" alt="Screenshot 08-18-2026 10 55 23" src="https://github.com/user-attachments/assets/37958193-2418-4305-9c61-e2e88e856737" /><img width="149" height="126" alt="Screenshot 08-18-2026 10 55 35" src="https://github.com/user-attachments/assets/5e7d8543-b502-4fe1-b541-7767e75fe22d" />

