### PR TITLE
Add regression tests for carrier landing during placement

### DIFF
--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTestCommon.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTestCommon.java
@@ -272,4 +272,27 @@ public abstract class PlaceDelegateTestCommon extends AbstractDelegateTestCase {
       assertThat(response.getUnits(), is(CollectionUtils.getMatches(units, unitIsOfType(carrier))));
     }
   }
+
+  @Test
+  void testCannotPlaceAirUnitOnFriendlyCarrier() {
+    northSea.getUnitCollection().addAll(create(russians, carrier, 1));
+
+    assertError(delegate.canUnitsBePlaced(northSea, create(british, fighter, 1), british));
+  }
+
+  @Test
+  void testCanPlaceAirUnitOnOwnCarrier() {
+    northSea.getUnitCollection().addAll(create(british, carrier, 1));
+
+    assertValid(delegate.canUnitsBePlaced(northSea, create(british, fighter, 1), british));
+  }
+
+  @Test
+  void testCannotPlaceAirUnitOnOwnAndFriendlyCarrier() {
+    northSea.getUnitCollection().addAll(create(british, carrier, 1));
+    northSea.getUnitCollection().addAll(create(russians, carrier, 1));
+    northSea.getUnitCollection().addAll(create(british, fighter, 2));
+
+    assertError(delegate.canUnitsBePlaced(northSea, create(british, fighter, 1), british));
+  }
 }


### PR DESCRIPTION
## Notes to Reviewer
This is a follow-up for https://github.com/triplea-game/triplea/pull/14505.

Adds three regression tests for carrier landing validation during the placement phase.

The tests cover:

1) An air unit cannot be placed on an allied carrier.
2) An air unit can be placed on its own carrier.
3) An air unit cannot be placed when both an own and allied carrier are present and there are two own fighters on your own carrier (the bug that https://github.com/triplea-game/triplea/pull/14505 fixed). 

These tests are added to `PlaceDelegateTestCommon`, so the same expectations are verified for both `PlaceDelegateTest` and `BidPlaceDelegateTest`.

Verified that with the source code prior to https://github.com/triplea-game/triplea/pull/14505, test 3) fails.