### PR TITLE
Fix missing purchase stepper icons by loading pre-made images from assets folder

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/ui/ScrollableTextField.java
+++ b/game-app/game-core/src/main/java/games/strategy/ui/ScrollableTextField.java
@@ -27,9 +27,13 @@ public class ScrollableTextField extends JPanel {
 
   private static boolean imagesLoaded;
   private static Icon up;
+  private static Icon upDisabled;
   private static Icon down;
+  private static Icon downDisabled;
   private static Icon max;
+  private static Icon maxDisabled;
   private static Icon min;
+  private static Icon minDisabled;
 
   private final IntTextField text;
   private final JButton upButton;
@@ -48,6 +52,7 @@ public class ScrollableTextField extends JPanel {
       inset = new Insets(2, 0, 2, 0);
     }
     upButton = new JButton(up);
+    upButton.setDisabledIcon(upDisabled);
     final Action incrementAction =
         new AbstractAction("inc") {
           private static final long serialVersionUID = 2125871167112459475L;
@@ -63,6 +68,7 @@ public class ScrollableTextField extends JPanel {
     upButton.addActionListener(incrementAction);
     upButton.setMargin(inset);
     downButton = new JButton(down);
+    downButton.setDisabledIcon(downDisabled);
     downButton.setMargin(inset);
     final Action decrementAction =
         new AbstractAction("dec") {
@@ -78,6 +84,7 @@ public class ScrollableTextField extends JPanel {
         };
     downButton.addActionListener(decrementAction);
     maxButton = new JButton(max);
+    maxButton.setDisabledIcon(maxDisabled);
     maxButton.setMargin(inset);
     final Action maxAction =
         new AbstractAction("max") {
@@ -93,6 +100,7 @@ public class ScrollableTextField extends JPanel {
         };
     maxButton.addActionListener(maxAction);
     minButton = new JButton(min);
+    minButton.setDisabledIcon(minDisabled);
     minButton.setMargin(inset);
     final Action minAction =
         new AbstractAction("min") {
@@ -126,11 +134,21 @@ public class ScrollableTextField extends JPanel {
     if (imagesLoaded) {
       return;
     }
-    up = new ImageIcon(EngineImageLoader.loadImage("images", "up.gif"));
-    down = new ImageIcon(EngineImageLoader.loadImage("images", "down.gif"));
-    max = new ImageIcon(EngineImageLoader.loadImage("images", "max.gif"));
-    min = new ImageIcon(EngineImageLoader.loadImage("images", "min.gif"));
+
+    up = loadIcon("up.gif");
+    upDisabled = loadIcon("up_disabled.gif");
+    down = loadIcon("down.gif");
+    downDisabled = loadIcon("down_disabled.gif");
+    max = loadIcon("max.gif");
+    maxDisabled = loadIcon("max_disabled.gif");
+    min = loadIcon("min.gif");
+    minDisabled = loadIcon("min_disabled.gif");
+
     imagesLoaded = true;
+  }
+
+  private static Icon loadIcon(final String name) {
+    return new ImageIcon(EngineImageLoader.loadImage("images", name));
   }
 
   public void setMax(final int max) {


### PR DESCRIPTION
## Notes to Reviewer
Instead of programmatically rendering the disabled icons, the icons are now already created as .gif and stored in the folder "assets". The icons are then loaded the same way as the enabled icons.

The PR is not ready to be merged. It should be tested first by someone for whom this error occurs.

Attempts to fix: https://github.com/triplea-game/triplea/issues/14841

@WCSumpton @TheDog-GH Please test this PR and check if the disabled stepper arrows now show. You should put the four disabled icons in your triplea source code folder for it to work. See instruction below.

## Instructions:
[disabled_stepper_icons.zip](https://github.com/user-attachments/files/31329725/disabled_stepper_icons.zip)
- Download and extract the above ZIP file
- Move the four .GIF files to 
`C:\Users\Username\Documents\GitHub\triplea\game-app\game-headed\build\resources\main\assets\images` 
or another path if you have the triplea source code somewhere else.

