### PR TITLE
Move battle SoundUtils into delegate.battle for cleaner dependencies

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -83,7 +83,6 @@ import org.triplea.java.RemoveOnNextMajorRelease;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.sound.SoundPath;
-import org.triplea.sound.SoundUtils;
 
 /** Handles logic for battles in which fighting actually occurs. */
 @Slf4j

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/SoundUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/SoundUtils.java
@@ -1,4 +1,4 @@
-package org.triplea.sound;
+package games.strategy.triplea.delegate.battle;
 
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
@@ -8,6 +8,7 @@ import games.strategy.triplea.delegate.battle.MustFightBattle.RetreatType;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import org.triplea.sound.SoundPath;
 
 /** Contains methods to play various sound clips. */
 public final class SoundUtils {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
@@ -9,6 +9,7 @@ import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
+import games.strategy.triplea.delegate.battle.SoundUtils;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.battle.steps.fire.FireRoundStepsFactory;
@@ -23,7 +24,6 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import org.triplea.sound.SoundUtils;
 
 @AllArgsConstructor
 public abstract class AaFireAndCasualtyStep implements BattleStep {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/EvaderRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/EvaderRetreat.java
@@ -12,6 +12,7 @@ import games.strategy.engine.display.IDisplay;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
+import games.strategy.triplea.delegate.battle.SoundUtils;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.settings.ClientSetting;
 import java.util.ArrayList;
@@ -20,7 +21,6 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.experimental.UtilityClass;
-import org.triplea.sound.SoundUtils;
 
 /** Utility class for handling retreating or submerging of `canEvade` units */
 @UtilityClass

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
@@ -17,6 +17,7 @@ import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
+import games.strategy.triplea.delegate.battle.SoundUtils;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.battle.steps.RetreatChecks;
 import games.strategy.triplea.settings.ClientSetting;
@@ -25,7 +26,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.triplea.java.RemoveOnNextMajorRelease;
-import org.triplea.sound.SoundUtils;
 
 @AllArgsConstructor
 public class OffensiveGeneralRetreat implements BattleStep {


### PR DESCRIPTION

SoundsUtils is actually a sound utility for battles. The class has logic for which sounds to play, it's not a pure sounds class. Moving that class to the battles packages is better cohesion. The imports become nicer. 