### PR TITLE
CI(PR builds): Cache Gradle deps and build outputs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
+      # Gradle setup adds a gradle build cache for PRs to run faster
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Run Build Checks
         # We skip 'spotlessApply' such that only 'spotlessCheck' will run to validate formatting.
         # This is a good setup for a CI server, meanwhile if a developer runs 'verify', they


### PR DESCRIPTION
Adds a gradle cache that persists across PRs, should
reduce PR build time.
