### PR TITLE
Remove redundant link in map maker section of contribution roles

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -92,7 +92,6 @@ role from below and find out what you can do to help.
 
 #### _How to become one_
 
-https://github.com/triplea-game/triplea/tree/master/docs/map-making
 - Check the documentation on [map-making](map-making)
 
 ### :trident: Map Admin


### PR DESCRIPTION
Remove redundant link under "How to become one" in the Map Maker section of "How to contribute to TripleA". Link that leads to the map making guides was posted twice, one embedded and one in full. This removes the full link.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
