### PR TITLE
Fix units display incorrect in game history (#4717) - HistoryPanel.gotoNode calls HistoryDetailsPanel.render after Hstory.gotoNode is done

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -259,14 +259,15 @@ public class HistoryPanel extends JPanel {
 
   private void gotoNode(final HistoryNode node) {
     Util.ensureOnEventDispatchThread();
-    if (details != null) {
-      details.render(node);
-    }
     // If this is not a leaf node, set the game state to the last leaf node before it. This way,
     // selecting something like "Round 3" shows the state at the start of the round, which ensures
     // chronological order when moving up/down the nodes using arrow keys even if some are expanded.
     Optional<HistoryNode> target = data.getHistory().getNearestLeafAtOrBefore(node);
     data.getHistory().gotoNode(target.orElse((HistoryNode) node.getRoot()));
+
+    if (details != null) {
+      details.render(node);
+    }
   }
 
   public HistoryNode getCurrentNode() {


### PR DESCRIPTION
Should fix #4717.