### PR TITLE
Smooth map scrolling when using the arrow keys

### DIFF
--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -86,8 +86,10 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.Frame;
 import java.awt.Graphics;
+import java.awt.GraphicsEnvironment;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.HeadlessException;
 import java.awt.Image;
 import java.awt.Insets;
 import java.awt.Toolkit;
@@ -1809,8 +1811,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
    * #computeScrollSpeed()} still applies and takes effect live while held.
    */
   private final class ArrowKeyScroller implements KeyListener {
-    // ~66 fps; small enough that each frame's pan step is a few pixels rather than a visible jump.
-    private static final int FRAME_INTERVAL_MS = 15;
     // computeScrollSpeed() is calibrated as pixels per 50ms tick by MapPanel's button-drag scroll
     // loop; reusing that cadence here keeps the arrowKeyScrollSpeed setting feeling the same.
     private static final double LEGACY_TICKS_PER_SECOND = 20.0;
@@ -1820,7 +1820,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     // release/press pair, and the paired press clears this before the deferred check deactivates
     // it.
     private final Set<Integer> pendingRelease = new HashSet<>();
-    private final Timer timer = new Timer(FRAME_INTERVAL_MS, e -> tick());
+    private final Timer timer = new Timer(computeFrameIntervalMs(), e -> tick());
     private long lastTickNanos;
     // Sub-pixel pan carried between frames so fractional velocity is not lost to integer rounding.
     private double residualX;
@@ -1900,6 +1900,29 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
           || keyCode == KeyEvent.VK_DOWN
           || keyCode == KeyEvent.VK_LEFT
           || keyCode == KeyEvent.VK_RIGHT;
+    }
+
+    /**
+     * Frame interval matched to the display's refresh rate, so a panned frame is never held on
+     * screen longer than the monitor shows it — that hold is what smears map motion on a
+     * sample-and-hold display, and running slower than the refresh only adds judder on top of it.
+     * Clamped to 60-120 fps, and falls back to ~100 fps when the driver reports an unknown rate.
+     */
+    private int computeFrameIntervalMs() {
+      int refreshHz = 0;
+      try {
+        refreshHz =
+            GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getDefaultScreenDevice()
+                .getDisplayMode()
+                .getRefreshRate();
+      } catch (final HeadlessException ignored) {
+        // no display available; the fallback below applies
+      }
+      if (refreshHz <= 0) {
+        refreshHz = 100;
+      }
+      return Math.max(8, Math.min(16, Math.round(1000f / refreshHz)));
     }
   }
 

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -106,6 +106,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -140,6 +141,7 @@ import javax.swing.ListCellRenderer;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 import javax.swing.WindowConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -1789,42 +1791,116 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   }
 
   private KeyListener getArrowKeyListener() {
-    return new KeyListener() {
-      @Override
-      public void keyPressed(final KeyEvent e) {
-        isCtrlPressed = e.isControlDown();
-        // scroll map according to wasd/arrow keys
-        final int diffPixel = computeScrollSpeed();
-        final int x = mapPanel.getXOffset();
-        final int y = mapPanel.getYOffset();
-        final int keyCode = e.getKeyCode();
-
-        if (keyCode == KeyEvent.VK_RIGHT) {
-          getMapPanel().setTopLeft(x + diffPixel, y);
-        } else if (keyCode == KeyEvent.VK_LEFT) {
-          getMapPanel().setTopLeft(x - diffPixel, y);
-        } else if (keyCode == KeyEvent.VK_DOWN) {
-          getMapPanel().setTopLeft(x, y + diffPixel);
-        } else if (keyCode == KeyEvent.VK_UP) {
-          getMapPanel().setTopLeft(x, y - diffPixel);
-        }
-      }
-
-      @Override
-      public void keyTyped(final KeyEvent e) {
-        // not needed interface method
-      }
-
-      @Override
-      public void keyReleased(final KeyEvent e) {
-        isCtrlPressed = e.isControlDown();
-      }
-    };
+    return new ArrowKeyScroller();
   }
 
   private int computeScrollSpeed() {
     return ClientSetting.arrowKeyScrollSpeed.getValueOrThrow()
         * (isCtrlPressed ? ClientSetting.fasterArrowKeyScrollMultiplier.getValueOrThrow() : 1);
+  }
+
+  /**
+   * Pans the map while an arrow key is held using a fixed-rate animation timer, so motion is smooth
+   * regardless of the operating system's key-repeat rate. Driving the pan off {@code keyPressed}
+   * events directly (as before) produced jagged jumps, because those events arrive on the OS repeat
+   * cadence — a long initial delay followed by chunky, uneven repeats.
+   *
+   * <p>Holding two arrow keys pans diagonally. The Ctrl multiplier from {@link
+   * #computeScrollSpeed()} still applies and takes effect live while held.
+   */
+  private final class ArrowKeyScroller implements KeyListener {
+    // ~66 fps; small enough that each frame's pan step is a few pixels rather than a visible jump.
+    private static final int FRAME_INTERVAL_MS = 15;
+    // computeScrollSpeed() is calibrated as pixels per 50ms tick by MapPanel's button-drag scroll
+    // loop; reusing that cadence here keeps the arrowKeyScrollSpeed setting feeling the same.
+    private static final double LEGACY_TICKS_PER_SECOND = 20.0;
+
+    private final Set<Integer> heldKeys = new HashSet<>();
+    // Keys whose keyReleased is awaiting confirmation; an X11 auto-repeat fires a phantom
+    // release/press pair, and the paired press clears this before the deferred check deactivates
+    // it.
+    private final Set<Integer> pendingRelease = new HashSet<>();
+    private final Timer timer = new Timer(FRAME_INTERVAL_MS, e -> tick());
+    private long lastTickNanos;
+    // Sub-pixel pan carried between frames so fractional velocity is not lost to integer rounding.
+    private double residualX;
+    private double residualY;
+
+    @Override
+    public void keyPressed(final KeyEvent e) {
+      isCtrlPressed = e.isControlDown();
+      final int keyCode = e.getKeyCode();
+      if (!isArrowKey(keyCode)) {
+        return;
+      }
+      pendingRelease.remove(keyCode);
+      if (heldKeys.add(keyCode) && !timer.isRunning()) {
+        residualX = 0;
+        residualY = 0;
+        lastTickNanos = System.nanoTime();
+        timer.start();
+      }
+    }
+
+    @Override
+    public void keyReleased(final KeyEvent e) {
+      isCtrlPressed = e.isControlDown();
+      final int keyCode = e.getKeyCode();
+      if (!isArrowKey(keyCode)) {
+        return;
+      }
+      // Defer deactivation one event-loop cycle: on X11 the auto-repeat press is already queued
+      // ahead of this runnable and will clear pendingRelease, so a held key never stops mid-scroll.
+      pendingRelease.add(keyCode);
+      SwingUtilities.invokeLater(
+          () -> {
+            if (pendingRelease.remove(keyCode)) {
+              heldKeys.remove(keyCode);
+            }
+          });
+    }
+
+    @Override
+    public void keyTyped(final KeyEvent e) {
+      // not needed interface method
+    }
+
+    private void tick() {
+      if (heldKeys.isEmpty()) {
+        timer.stop();
+        return;
+      }
+      final long now = System.nanoTime();
+      final double dtSeconds = (now - lastTickNanos) / 1_000_000_000.0;
+      lastTickNanos = now;
+      final double distance = computeScrollSpeed() * LEGACY_TICKS_PER_SECOND * dtSeconds;
+      if (heldKeys.contains(KeyEvent.VK_RIGHT)) {
+        residualX += distance;
+      }
+      if (heldKeys.contains(KeyEvent.VK_LEFT)) {
+        residualX -= distance;
+      }
+      if (heldKeys.contains(KeyEvent.VK_DOWN)) {
+        residualY += distance;
+      }
+      if (heldKeys.contains(KeyEvent.VK_UP)) {
+        residualY -= distance;
+      }
+      final int stepX = (int) residualX;
+      final int stepY = (int) residualY;
+      residualX -= stepX;
+      residualY -= stepY;
+      if (stepX != 0 || stepY != 0) {
+        getMapPanel().setTopLeft(mapPanel.getXOffset() + stepX, mapPanel.getYOffset() + stepY);
+      }
+    }
+
+    private boolean isArrowKey(final int keyCode) {
+      return keyCode == KeyEvent.VK_UP
+          || keyCode == KeyEvent.VK_DOWN
+          || keyCode == KeyEvent.VK_LEFT
+          || keyCode == KeyEvent.VK_RIGHT;
+    }
   }
 
   private void showEditMode() {

--- a/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-headed/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -96,6 +96,7 @@ import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.io.IOException;
@@ -392,7 +393,9 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
             .build(),
         BorderLayout.SOUTH);
 
-    mapPanel.addKeyListener(getArrowKeyListener());
+    final ArrowKeyScroller arrowKeyScroller = new ArrowKeyScroller();
+    mapPanel.addKeyListener(arrowKeyScroller);
+    mapPanel.addFocusListener(arrowKeyScroller);
 
     actionButtonsPanel.setBorder(null);
     statsPanel = new StatPanel(data, uiContext);
@@ -1792,28 +1795,65 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     return "";
   }
 
-  private KeyListener getArrowKeyListener() {
-    return new ArrowKeyScroller();
-  }
-
   private int computeScrollSpeed() {
     return ClientSetting.arrowKeyScrollSpeed.getValueOrThrow()
         * (isCtrlPressed ? ClientSetting.fasterArrowKeyScrollMultiplier.getValueOrThrow() : 1);
   }
 
+  /** One animation tick's integer pan and the sub-pixel remainder carried to the next tick. */
+  record ScrollStep(int stepX, int stepY, double residualX, double residualY) {}
+
+  /**
+   * Adds this frame's pan distance for each held arrow key onto the carried sub-pixel residual,
+   * then splits the total into an integer step and the leftover fraction, so fractional velocity
+   * survives integer rounding instead of being dropped each frame.
+   */
+  static ScrollStep computeScrollStep(
+      final double residualX,
+      final double residualY,
+      final double distance,
+      final Set<Integer> heldKeys) {
+    double x = residualX;
+    double y = residualY;
+    if (heldKeys.contains(KeyEvent.VK_RIGHT)) {
+      x += distance;
+    }
+    if (heldKeys.contains(KeyEvent.VK_LEFT)) {
+      x -= distance;
+    }
+    if (heldKeys.contains(KeyEvent.VK_DOWN)) {
+      y += distance;
+    }
+    if (heldKeys.contains(KeyEvent.VK_UP)) {
+      y -= distance;
+    }
+    final int stepX = (int) x;
+    final int stepY = (int) y;
+    return new ScrollStep(stepX, stepY, x - stepX, y - stepY);
+  }
+
+  /**
+   * Clamps a display refresh rate to the 8-16 ms timer-interval band (~60-125 fps), treating a
+   * non-positive (unknown) rate as ~100 fps.
+   */
+  static int clampFrameIntervalMs(final int refreshHz) {
+    final int hz = refreshHz <= 0 ? 100 : refreshHz;
+    return Math.max(8, Math.min(16, Math.round(1000f / hz)));
+  }
+
   /**
    * Pans the map while an arrow key is held using a fixed-rate animation timer, so motion is smooth
-   * regardless of the operating system's key-repeat rate. Driving the pan off {@code keyPressed}
-   * events directly (as before) produced jagged jumps, because those events arrive on the OS repeat
-   * cadence — a long initial delay followed by chunky, uneven repeats.
+   * regardless of the operating system's key-repeat rate. A {@code keyPressed}-driven pan instead
+   * follows the OS key-repeat cadence — a long initial delay then chunky, uneven repeats — which
+   * reads as jagged jumps; the fixed-rate timer decouples motion from that cadence.
    *
    * <p>Holding two arrow keys pans diagonally. The Ctrl multiplier from {@link
    * #computeScrollSpeed()} still applies and takes effect live while held.
    */
-  private final class ArrowKeyScroller implements KeyListener {
+  private final class ArrowKeyScroller implements KeyListener, FocusListener {
     // computeScrollSpeed() is calibrated as pixels per 50ms tick by MapPanel's button-drag scroll
     // loop; reusing that cadence here keeps the arrowKeyScrollSpeed setting feeling the same.
-    private static final double LEGACY_TICKS_PER_SECOND = 20.0;
+    private static final double DRAG_SCROLL_TICKS_PER_SECOND = 20.0;
 
     private final Set<Integer> heldKeys = new HashSet<>();
     // Keys whose keyReleased is awaiting confirmation; an X11 auto-repeat fires a phantom
@@ -1861,8 +1901,18 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     }
 
     @Override
-    public void keyTyped(final KeyEvent e) {
-      // not needed interface method
+    public void keyTyped(final KeyEvent e) {}
+
+    @Override
+    public void focusGained(final FocusEvent e) {}
+
+    @Override
+    public void focusLost(final FocusEvent e) {
+      // A key released while mapPanel lacks focus never reaches keyReleased, so held state would
+      // leak and pan the map forever; dropping it on focus loss ends the scroll instead.
+      heldKeys.clear();
+      pendingRelease.clear();
+      timer.stop();
     }
 
     private void tick() {
@@ -1873,25 +1923,13 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       final long now = System.nanoTime();
       final double dtSeconds = (now - lastTickNanos) / 1_000_000_000.0;
       lastTickNanos = now;
-      final double distance = computeScrollSpeed() * LEGACY_TICKS_PER_SECOND * dtSeconds;
-      if (heldKeys.contains(KeyEvent.VK_RIGHT)) {
-        residualX += distance;
-      }
-      if (heldKeys.contains(KeyEvent.VK_LEFT)) {
-        residualX -= distance;
-      }
-      if (heldKeys.contains(KeyEvent.VK_DOWN)) {
-        residualY += distance;
-      }
-      if (heldKeys.contains(KeyEvent.VK_UP)) {
-        residualY -= distance;
-      }
-      final int stepX = (int) residualX;
-      final int stepY = (int) residualY;
-      residualX -= stepX;
-      residualY -= stepY;
-      if (stepX != 0 || stepY != 0) {
-        getMapPanel().setTopLeft(mapPanel.getXOffset() + stepX, mapPanel.getYOffset() + stepY);
+      final double distance = computeScrollSpeed() * DRAG_SCROLL_TICKS_PER_SECOND * dtSeconds;
+      final ScrollStep step = computeScrollStep(residualX, residualY, distance, heldKeys);
+      residualX = step.residualX();
+      residualY = step.residualY();
+      if (step.stepX() != 0 || step.stepY() != 0) {
+        getMapPanel()
+            .setTopLeft(mapPanel.getXOffset() + step.stepX(), mapPanel.getYOffset() + step.stepY());
       }
     }
 
@@ -1906,7 +1944,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
      * Frame interval matched to the display's refresh rate, so a panned frame is never held on
      * screen longer than the monitor shows it — that hold is what smears map motion on a
      * sample-and-hold display, and running slower than the refresh only adds judder on top of it.
-     * Clamped to 60-120 fps, and falls back to ~100 fps when the driver reports an unknown rate.
+     * Clamped to an 8-16 ms interval (~60-125 fps), and falls back to ~100 fps when the driver
+     * reports an unknown rate.
      */
     private int computeFrameIntervalMs() {
       int refreshHz = 0;
@@ -1916,13 +1955,10 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                 .getDefaultScreenDevice()
                 .getDisplayMode()
                 .getRefreshRate();
-      } catch (final HeadlessException ignored) {
-        // no display available; the fallback below applies
+      } catch (final HeadlessException | NullPointerException ignored) {
+        // no display available, or the driver reports no display mode; the fallback applies
       }
-      if (refreshHz <= 0) {
-        refreshHz = 100;
-      }
-      return Math.max(8, Math.min(16, Math.round(1000f / refreshHz)));
+      return clampFrameIntervalMs(refreshHz);
     }
   }
 

--- a/game-app/game-headed/src/test/java/games/strategy/triplea/ui/TripleAFrameTest.java
+++ b/game-app/game-headed/src/test/java/games/strategy/triplea/ui/TripleAFrameTest.java
@@ -88,6 +88,20 @@ final class TripleAFrameTest {
     }
 
     @Test
+    void upPanTruncatesTowardNegativeYWithSameMagnitudeAsLeftPan() {
+      // Guards the VK_UP -> negative-y mapping so vertical panning mirrors the horizontal sign
+      // convention; without it only three of the four arrow directions have a direct sign check.
+      final Set<Integer> up = Set.of(KeyEvent.VK_UP);
+
+      ScrollStep step = TripleAFrame.computeScrollStep(0, 0, SUB_PIXEL_PER_TICK, up);
+      step = TripleAFrame.computeScrollStep(0, step.residualY(), SUB_PIXEL_PER_TICK, up);
+      step = TripleAFrame.computeScrollStep(0, step.residualY(), SUB_PIXEL_PER_TICK, up);
+
+      assertEquals(-1, step.stepY());
+      assertEquals(-0.2, step.residualY(), RESIDUAL_TOLERANCE);
+    }
+
+    @Test
     void diagonalAccumulatesEachAxisIndependently() {
       final ScrollStep step =
           TripleAFrame.computeScrollStep(0, 0, 1.5, Set.of(KeyEvent.VK_RIGHT, KeyEvent.VK_DOWN));

--- a/game-app/game-headed/src/test/java/games/strategy/triplea/ui/TripleAFrameTest.java
+++ b/game-app/game-headed/src/test/java/games/strategy/triplea/ui/TripleAFrameTest.java
@@ -1,0 +1,110 @@
+package games.strategy.triplea.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import games.strategy.triplea.ui.TripleAFrame.ScrollStep;
+import java.awt.event.KeyEvent;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the pure scroll math extracted from {@code ArrowKeyScroller}: the frame-interval clamp
+ * and the sub-pixel residual accumulation that carries fractional pan velocity across frames. The
+ * timer, key-event wiring, and refresh-rate lookup stay display-bound and are not covered here.
+ */
+final class TripleAFrameTest {
+
+  // Tolerance for accumulated sub-pixel residuals, which are exact in binary only by luck.
+  private static final double RESIDUAL_TOLERANCE = 1.0e-9;
+
+  @Nested
+  final class ClampFrameIntervalMs {
+    @Test
+    void sixtyHertzRoundsAndClampsToSixteenMs() {
+      // 1000/60 = 16.67 rounds to 17, clamped down to the 16 ms ceiling.
+      assertEquals(16, TripleAFrame.clampFrameIntervalMs(60));
+    }
+
+    @Test
+    void oneHundredTwentyHertzMapsToEightMs() {
+      assertEquals(8, TripleAFrame.clampFrameIntervalMs(120));
+    }
+
+    @Test
+    void oneHundredFortyFourHertzClampsToEightMsFloor() {
+      // 1000/144 = 6.94 rounds to 7, raised to the 8 ms floor.
+      assertEquals(8, TripleAFrame.clampFrameIntervalMs(144));
+    }
+
+    @Test
+    void thirtyHertzClampsToSixteenMsCeiling() {
+      assertEquals(16, TripleAFrame.clampFrameIntervalMs(30));
+    }
+
+    @Test
+    void unknownRateFallsBackToOneHundredHertz() {
+      // A non-positive rate stands in for an unknown/headless display; 1000/100 = 10 ms.
+      assertEquals(10, TripleAFrame.clampFrameIntervalMs(0));
+      assertEquals(10, TripleAFrame.clampFrameIntervalMs(-1));
+    }
+  }
+
+  @Nested
+  final class ComputeScrollStep {
+    private static final double SUB_PIXEL_PER_TICK = 0.4;
+
+    @Test
+    void subPixelDistanceAccumulatesUntilItYieldsAWholeStep() {
+      final Set<Integer> right = Set.of(KeyEvent.VK_RIGHT);
+
+      final ScrollStep first = TripleAFrame.computeScrollStep(0, 0, SUB_PIXEL_PER_TICK, right);
+      assertEquals(0, first.stepX());
+      assertEquals(0.4, first.residualX(), RESIDUAL_TOLERANCE);
+
+      final ScrollStep second =
+          TripleAFrame.computeScrollStep(first.residualX(), 0, SUB_PIXEL_PER_TICK, right);
+      assertEquals(0, second.stepX());
+      assertEquals(0.8, second.residualX(), RESIDUAL_TOLERANCE);
+
+      final ScrollStep third =
+          TripleAFrame.computeScrollStep(second.residualX(), 0, SUB_PIXEL_PER_TICK, right);
+      assertEquals(1, third.stepX());
+      assertEquals(0.2, third.residualX(), RESIDUAL_TOLERANCE);
+    }
+
+    @Test
+    void leftPanTruncatesWithSameMagnitudeAsRightPan() {
+      // Guards the truncate-toward-zero direction: left and right must travel equal distance for
+      // equal held time, or panning would be asymmetric.
+      final Set<Integer> left = Set.of(KeyEvent.VK_LEFT);
+
+      ScrollStep step = TripleAFrame.computeScrollStep(0, 0, SUB_PIXEL_PER_TICK, left);
+      step = TripleAFrame.computeScrollStep(step.residualX(), 0, SUB_PIXEL_PER_TICK, left);
+      step = TripleAFrame.computeScrollStep(step.residualX(), 0, SUB_PIXEL_PER_TICK, left);
+
+      assertEquals(-1, step.stepX());
+      assertEquals(-0.2, step.residualX(), RESIDUAL_TOLERANCE);
+    }
+
+    @Test
+    void diagonalAccumulatesEachAxisIndependently() {
+      final ScrollStep step =
+          TripleAFrame.computeScrollStep(0, 0, 1.5, Set.of(KeyEvent.VK_RIGHT, KeyEvent.VK_DOWN));
+
+      assertEquals(1, step.stepX());
+      assertEquals(1, step.stepY());
+      assertEquals(0.5, step.residualX(), RESIDUAL_TOLERANCE);
+      assertEquals(0.5, step.residualY(), RESIDUAL_TOLERANCE);
+    }
+
+    @Test
+    void opposingKeysCancelToNoMotion() {
+      final ScrollStep step =
+          TripleAFrame.computeScrollStep(0, 0, 5.0, Set.of(KeyEvent.VK_LEFT, KeyEvent.VK_RIGHT));
+
+      assertEquals(0, step.stepX());
+      assertEquals(0, step.residualX(), RESIDUAL_TOLERANCE);
+    }
+  }
+}


### PR DESCRIPTION
Scrolling the map with the arrow keys was very jagged. This was due to the
map redraw happening on discrete key events happening in a fixed
interval.

To fix this, we instead use a swing timer to do a fixed rate scroll that runs while
an arrow key is held, moving a small per-frame step at constant velocity.

Holding two arrow keys now pans diagonally. Sub-pixel
remainder is carried between frames so fractional velocity isn't lost.

Linux/X11 note: holding a key emits phantom keyReleased/keyPressed pairs;
release is deferred one event-loop cycle so the paired repeat press cancels
it and scrolling doesn't stutter.

## Changes
- Smooth arrow-key map scrolling via animation timer
- Match arrow-scroll frame rate to display refresh